### PR TITLE
fix(helm): remove operator pod resource request/limit defaults (FB-1653)

### DIFF
--- a/helm/firebolt-operator/README.md
+++ b/helm/firebolt-operator/README.md
@@ -73,7 +73,7 @@ kubectl delete crd fireboltengines.compute.firebolt.io fireboltinstances.compute
 | rbac.apiserverProxyGrant | bool | `false` | Render an additional ClusterRole (or per-namespace Role when `watchNamespaces` is set) granting only `pods/proxy: get`. Required when any FireboltInstance opts into `spec.metricScrapeMode=ApiserverProxy`; the default `metricScrapeMode=PodIP` reaches engine metrics directly on the pod IP and does not need this permission. Leaving this false while an instance is set to `ApiserverProxy` makes the metric scrape surface as a 403 from the apiserver. |
 | rbac.create | bool | `true` | Whether to create ClusterRole, ClusterRoleBinding, and leader-election RBAC resources. |
 | replicaCount | int | `1` | Number of operator replicas. |
-| resources | object | requests: 10m/64Mi, limits: 500m/128Mi | CPU/memory resource requests and limits for the operator pod. |
+| resources | object | `{}` | CPU/memory resource requests and limits for the operator pod. Empty by default so the chart imposes no requests or limits; set them to match your cluster's scheduling and quota policy. |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the ServiceAccount (e.g. for IRSA / Workload Identity). |
 | serviceAccount.create | bool | `true` | Whether to create a ServiceAccount. |
 | serviceAccount.name | string | `""` | The name of the ServiceAccount to use. If empty, a name is generated from the fullname template. |

--- a/helm/firebolt-operator/values.yaml
+++ b/helm/firebolt-operator/values.yaml
@@ -215,15 +215,10 @@ additionalArgs: []
 # -- Additional environment variables for the operator container.
 additionalEnv: []
 
-# -- CPU/memory resource requests and limits for the operator pod.
-# @default -- requests: 10m/64Mi, limits: 500m/128Mi
-resources:
-  limits:
-    cpu: 500m
-    memory: 128Mi
-  requests:
-    cpu: 10m
-    memory: 64Mi
+# -- CPU/memory resource requests and limits for the operator pod. Empty by
+# default so the chart imposes no requests or limits; set them to match your
+# cluster's scheduling and quota policy.
+resources: {}
 
 # -- Extra volumes attached to the operator Pod. Rendered as-is into
 # `pod.spec.volumes`. Useful for mounting externally-provisioned certs,


### PR DESCRIPTION
**Background**

ISSUE-REF: FB-1653

Follow-up from the staging compute rollout. The operator Helm chart's `values.yaml` shipped hard-coded resource requests (`10m`/`64Mi`) and limits (`500m`/`128Mi`) on the operator pod.

**Summary**
- `helm/firebolt-operator/values.yaml`: `resources` now defaults to `{}` instead of the hard-coded requests/limits.
- The deployment template already wraps the block in `{{- with .Values.resources }}` (`deployment.yaml:137`), so an empty value renders the `manager` container with no `resources` stanza — no template change needed.
- `helm/firebolt-operator/README.md` regenerated via `make helm-docs`.

Going forward, the chart imposes no requests or limits on the operator pod by default; operators set them via values to match their cluster's scheduling and quota policy. The downstream `do-compute-charts` workaround can be dropped.

**Test Plan**
- `make helm-lint` — passes for both charts.
- `helm template t helm/firebolt-operator --show-only templates/deployment.yaml` — confirms the `manager` container renders with no `resources:` block.
- Chart-only change; no Go code or unit/e2e tests affected.