### PR TITLE
chore(deps): bump packdb engine/metadata to 4.32.0-pre.0.20260612115847.e36d5e7953e5

### DIFF
--- a/config/images/defaults.latest.env
+++ b/config/images/defaults.latest.env
@@ -23,9 +23,9 @@
 #     test/e2e/e2e_suite_test.go's SynchronizedBeforeSuite.
 
 ENGINE_IMAGE=ghcr.io/firebolt-db/engine
-ENGINE_TAG=release-4.32.0-pre.0.20260609145613.22a1ea4abadb
+ENGINE_TAG=release-4.32.0-pre.0.20260612115847.e36d5e7953e5
 METADATA_IMAGE=ghcr.io/firebolt-db/metadata
-METADATA_TAG=release-4.32.0-pre.0.20260609145613.22a1ea4abadb
+METADATA_TAG=release-4.32.0-pre.0.20260612115847.e36d5e7953e5
 POSTGRES_IMAGE=postgres:16-alpine
 ENVOY_IMAGE=envoyproxy/envoy
 ENVOY_TAG=v1.37.2


### PR DESCRIPTION
## Summary

Bump default engine/metadata images to packdb `4.32.0-pre.0.20260612115847.e36d5e7953e5`
— the build the engine `:dev` tag currently points to.

> [!NOTE]
> **Temporary automation.** Opened weekly (Mondays) by packdb's
> `Temporary - Weekly downstream image bump` workflow as a stand-in for a real
> engine release: it bumps to whatever the engine `:dev` tag points to, as if the
> engine `:latest` tag had been refreshed. It exists only until the new Firebolt
> engine images have a proper release cadence that moves `:latest` and drives
> `API-release-flow`'s bump jobs. An unmerged PR is overwritten by next Monday's run.