### PR TITLE
feat!(controller): align with engine FHS image layout (FB-1733)

### DIFF
--- a/api/v1alpha1/operatorauthority.go
+++ b/api/v1alpha1/operatorauthority.go
@@ -47,9 +47,9 @@ const ReservedFireboltKeyPrefix = "firebolt.io/"
 // inside each generation's StatefulSet pod template. The drain check, the
 // stsMatchesSpec drift detection, and the FireboltEngineClass validating webhook
 // all rely on it being stable and operator-owned. The name matches the
-// public CRD ("engine"); the binary entrypoint inside the image is still
-// `firebolt-core`, but that's an image-internal path and doesn't surface
-// on the pod template.
+// public CRD ("engine"); the engine binary inside the image lives at
+// /opt/firebolt/firebolt, but that's an image-internal path and doesn't
+// surface on the pod template.
 const EngineContainerName = "engine"
 
 // EngineWebContainerName is the fixed name of the operator-injected Engine Web UI
@@ -120,14 +120,14 @@ const (
 	// EngineConfigVolumeName is the projected-volume name carrying the
 	// engine config.yaml (operator-rendered ConfigMap). It is mounted
 	// at ConfigMountPath on the engine container.
-	EngineConfigVolumeName = "nodes-config"
+	EngineConfigVolumeName = "engine-config"
 	// EngineDataVolumeName is the data volume backing the engine's
 	// per-pod state — either a PVC synthesized from the StatefulSet's
 	// VolumeClaimTemplate, an emptyDir, or a hostPath, depending on
 	// FireboltEngineSpec.Storage. Mounted at DataMountPath.
 	EngineDataVolumeName = "data"
 	// EngineRuntimeVolumeName is the emptyDir volume mounted at
-	// /var/run/firebolt for the engine's unix domain socket.
+	// /run/firebolt for the engine's unix domain socket.
 	EngineRuntimeVolumeName = "runtime"
 	// GatewayConfigVolumeName carries the operator-rendered Envoy
 	// config (envoy.yaml). Mounted at /etc/envoy on the Envoy

--- a/config/images/defaults.dev.env
+++ b/config/images/defaults.dev.env
@@ -21,7 +21,7 @@
 #     test/e2e/e2e_suite_test.go's SynchronizedBeforeSuite.
 
 ENGINE_IMAGE=ghcr.io/firebolt-db/engine
-ENGINE_TAG=dev
+ENGINE_TAG=release-5.0.1-0.20260622084213.3ef06de4e9aa-amd64
 METADATA_IMAGE=ghcr.io/firebolt-db/metadata
 METADATA_TAG=dev
 POSTGRES_IMAGE=postgres:16-alpine

--- a/config/images/defaults.dev.env
+++ b/config/images/defaults.dev.env
@@ -21,7 +21,7 @@
 #     test/e2e/e2e_suite_test.go's SynchronizedBeforeSuite.
 
 ENGINE_IMAGE=ghcr.io/firebolt-db/engine
-ENGINE_TAG=release-5.0.1-0.20260622084213.3ef06de4e9aa-amd64
+ENGINE_TAG=dev
 METADATA_IMAGE=ghcr.io/firebolt-db/metadata
 METADATA_TAG=dev
 POSTGRES_IMAGE=postgres:16-alpine

--- a/config/images/defaults.latest.env
+++ b/config/images/defaults.latest.env
@@ -23,9 +23,9 @@
 #     test/e2e/e2e_suite_test.go's SynchronizedBeforeSuite.
 
 ENGINE_IMAGE=ghcr.io/firebolt-db/engine
-ENGINE_TAG=release-4.32.0-pre.0.20260612115847.e36d5e7953e5
+ENGINE_TAG=release-5.0.1-0.20260622084213.3ef06de4e9aa
 METADATA_IMAGE=ghcr.io/firebolt-db/metadata
-METADATA_TAG=release-4.32.0-pre.0.20260612115847.e36d5e7953e5
+METADATA_TAG=release-5.0.1-0.20260622084213.3ef06de4e9aa
 POSTGRES_IMAGE=postgres:16-alpine
 ENVOY_IMAGE=envoyproxy/envoy
 ENVOY_TAG=v1.37.2

--- a/docs/engineclass/fireboltengineclass-design.mdx
+++ b/docs/engineclass/fireboltengineclass-design.mdx
@@ -17,7 +17,7 @@ struct fields:
    (`name`, `command`, `args`, `ports`, probes, reserved env keys),
    the StatefulSet-bound pod fields (`terminationGracePeriodSeconds=60`,
    `subdomain`, `hostname`, `restartPolicy`, `activeDeadlineSeconds`),
-   and the operator-owned volumes / mounts (`nodes-config`, data). Always win.
+   and the operator-owned volumes / mounts (`engine-config`, data). Always win.
 2. **`FireboltEngineClass.spec.template`** (when `spec.engineClassRef`
    is set): Fills in user-owned fields the engine template doesn't set.
 3. **`FireboltEngine.spec.template`**: Wins over the class on conflict.
@@ -40,7 +40,7 @@ on the resolved value):
 | pod-template labels | Reserved keys (`firebolt.io/engine`, `firebolt.io/generation`) non-overridable. Engine template labels > class labels |
 | pod-template annotations | engine template annotations > class annotations |
 | pod-level `securityContext` | engine template > class > Firebolt Operator default (FSGroup, FSGroupChangePolicy always stamped) |
-| pod-level `volumes` | Firebolt Operator-owned volumes (`nodes-config`, data) come first. Class volumes then engine volumes are appended in that order. Names colliding with operator volumes are dropped |
+| pod-level `volumes` | Firebolt Operator-owned volumes (`engine-config`, data) come first. Class volumes then engine volumes are appended in that order. Names colliding with operator volumes are dropped |
 | pod-level `imagePullSecrets` | class slice + engine slice, concatenated |
 | init containers | class slice + engine slice, concatenated (mirrors `tolerations`) |
 | sidecar containers (anything not named `engine`) | class sidecars + engine sidecars, appended after the operator-built engine container |

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -33,7 +33,7 @@ applies these defaults on the `engine` container:
 | `runAsNonRoot` | `true` |
 | Capabilities | drop `ALL` |
 | `allowPrivilegeEscalation` | `false` |
-| Read-only root filesystem | `true` (unix domain socket via emptyDir at `/var/run/firebolt`; status file and engine data on the PVC at `/var/lib/firebolt`) |
+| Read-only root filesystem | `true` (unix domain socket via emptyDir at `/run/firebolt`; status file and engine data on the PVC at `/var/lib/firebolt`) |
 | Seccomp | not set |
 
 You can replace that entire container `securityContext` wholesale through

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -49,6 +49,30 @@ Firebolt Operator only stamps `fsGroup` (3473) and
 Sidecar containers and init containers pass through from your template
 without operator hardening.
 
+#### Writable directories and arbitrary UIDs
+
+The engine image owns two writable directories: the data dir
+(`/var/lib/firebolt`, the PVC mount) and the unix socket dir
+(`/run/firebolt`, an `emptyDir`). Both are group-owned by root (GID 0)
+with mode `2770` (`g=u` plus the setgid bit), not the broad `777` the
+image used previously. The read-only application payload at
+`/opt/firebolt` stays `firebolt:firebolt 0755`.
+
+This follows the OpenShift "arbitrary UID" convention: a platform that
+assigns a random non-namespace UID still places the process in group 0,
+so the GID-0 group ownership keeps both directories readable and
+writable, while `other` gets nothing. The setgid bit makes files the
+engine creates at runtime inherit group 0. The engine runs with
+`umask 0007` so it does not strip those group bits off new files. Under
+the default UID/GID `3473/3473` the user owns the directories outright,
+so the same layout works without OpenShift.
+
+Mounted volumes override the image's directory permissions. When a
+platform assigns an arbitrary UID, give the engine a writable data dir
+either through the stamped `fsGroup` (which `chown`s the PVC to the
+group) or by mounting volumes already group-0-writable, and avoid
+pinning a `runAsUser` that is not a member of group 0.
+
 Validating webhooks on `FireboltEngine` and `FireboltEngineClass` (and
 the engine reconciler when webhooks are off) reject operator-owned paths
 on engine templates: command, args, ports, probes, reserved env keys, and

--- a/examples/engine-full.yaml
+++ b/examples/engine-full.yaml
@@ -13,7 +13,7 @@ spec:
   instanceRef: firebolt
   replicas: 2
 
-  # Per-replica engine data volume at /firebolt-core/volume. Changing storage
+  # Per-replica engine data volume at /var/lib/firebolt. Changing storage
   # triggers a blue-green rollout. Omit storage entirely (or set it to {}) to
   # accept the operator default of an emptyDir; opt into a PersistentVolumeClaim
   # by setting persistentVolumeClaim (with or without explicit fields). The

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -160,13 +160,14 @@ const (
 	MetricSuspendedQueries = "firebolt_suspended_queries"
 
 	// ConfigMountPath is where the engine config.yaml is mounted in the container.
-	// FireboltCoreServer reads <root>/config.yaml from its --data-dir when present,
-	// so the file must land at this path inside the container.
-	ConfigMountPath = "/firebolt-core/volume/config.yaml"
+	// With --server-config unset the engine falls back to <data-dir>/config.yaml,
+	// so the file must land at DataMountPath/config.yaml inside the container.
+	ConfigMountPath = "/var/lib/firebolt/config.yaml"
 
-	// DataMountPath is where the engine's per-pod PVC is mounted. Matches the
-	// path the engine binary uses for its working data.
-	DataMountPath = "/firebolt-core/volume"
+	// DataMountPath is where the engine's per-pod data volume is mounted. Matches
+	// the --data-dir passed to the engine binary: the writable state root that
+	// holds persistent_data, diagnostic_data, and scratch.
+	DataMountPath = "/var/lib/firebolt"
 	// DataVolumeName is the name of the data volume inside the StatefulSet's
 	// VolumeClaimTemplates and the corresponding container VolumeMount.
 	DataVolumeName = "data"
@@ -301,7 +302,9 @@ func resolveContainerImagePullPolicy(image string, policy corev1.PullPolicy) cor
 // the label is absent and POD_INDEX will be empty; in that case we fall
 // back to extracting the ordinal from HOSTNAME (<sts-name>-<ordinal>).
 //
-// `firebolt server` is the engine image's unified entrypoint;
+// `firebolt server` is the engine image's unified entrypoint; the binary lives
+// at /opt/firebolt/firebolt (read-only payload) and the writable state root is
+// passed as --data-dir /var/lib/firebolt.
 // FIREBOLT_CORE_MODE=1 (set as a container env var) selects the firebolt-core
 // code path so the operator-rendered config (config.yaml at the data-dir root)
 // is treated as authoritative and not rewritten at startup.
@@ -310,7 +313,7 @@ set -euo pipefail
 if [ -z "${POD_INDEX:-}" ]; then
   POD_INDEX="${HOSTNAME##*-}"
 fi
-exec /firebolt-core/firebolt server --node "$POD_INDEX" --data-dir /firebolt-core/volume
+exec /opt/firebolt/firebolt server --node "$POD_INDEX" --data-dir /var/lib/firebolt
 `
 
 // GetServicePorts returns the externally-meaningful service ports for a

--- a/internal/controller/engine_class_merge_test.go
+++ b/internal/controller/engine_class_merge_test.go
@@ -444,12 +444,12 @@ func TestBuildStatefulSet_MergesClassEngineContainerFields(t *testing.T) {
 		t.Error("engine Lifecycle missing class-supplied PreStop hook")
 	}
 
-	// Operator mounts (data + nodes-config) must remain at the head;
+	// Operator mounts (data + engine-config) must remain at the head;
 	// shared-cache appended after.
 	if len(engine.VolumeMounts) < 3 {
 		t.Fatalf("engine VolumeMounts = %+v, want operator mounts + class mount", engine.VolumeMounts)
 	}
-	if engine.VolumeMounts[0].Name != DataVolumeName || engine.VolumeMounts[1].Name != "nodes-config" {
+	if engine.VolumeMounts[0].Name != DataVolumeName || engine.VolumeMounts[1].Name != "engine-config" {
 		t.Errorf("operator volumeMounts displaced from leading position: %+v", engine.VolumeMounts[:2])
 	}
 	if engine.VolumeMounts[len(engine.VolumeMounts)-1].Name != "shared-cache" {
@@ -457,7 +457,7 @@ func TestBuildStatefulSet_MergesClassEngineContainerFields(t *testing.T) {
 	}
 
 	// The pod must carry the matching pod-level volume so the kubelet
-	// can resolve the sidecar mount; the operator's data + nodes-config
+	// can resolve the sidecar mount; the operator's data + engine-config
 	// volumes stay at the head.
 	volNames := make([]string, len(sts.Spec.Template.Spec.Volumes))
 	for i := range sts.Spec.Template.Spec.Volumes {
@@ -503,19 +503,19 @@ func TestBuildStatefulSet_AppendsClassImagePullSecrets(t *testing.T) {
 
 // TestAppendUserPodVolumes_OperatorReservedNamesWin covers the
 // defense against a class or engine template redefining the operator-owned
-// volume names (DataVolumeName, "nodes-config"): the operator entry must
+// volume names (DataVolumeName, "engine-config"): the operator entry must
 // remain. Otherwise a FireboltEngineClass author (or an engine template
 // author) could silently break engine startup or data persistence by
 // collision.
 func TestAppendUserPodVolumes_OperatorReservedNamesWin(t *testing.T) {
 	operator := []corev1.Volume{
-		{Name: "nodes-config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "op-cfg"}}}},
+		{Name: "engine-config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "op-cfg"}}}},
 		{Name: DataVolumeName, VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 	}
 	classInfo := newFireboltEngineClassInfo(classWith(nil, &corev1.PodSpec{
 		Volumes: []corev1.Volume{
 			// Names colliding with operator-owned volumes are dropped.
-			{Name: "nodes-config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "class-cfg"}}}},
+			{Name: "engine-config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "class-cfg"}}}},
 			{Name: DataVolumeName, VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/mnt"}}},
 			{Name: "extra", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 		},
@@ -526,7 +526,7 @@ func TestAppendUserPodVolumes_OperatorReservedNamesWin(t *testing.T) {
 		t.Fatalf("got %d volumes, want 3 (2 operator + 1 non-colliding class)", len(got))
 	}
 	if got[0].ConfigMap == nil || got[0].ConfigMap.Name != "op-cfg" {
-		t.Errorf("operator nodes-config replaced by class entry: %+v", got[0])
+		t.Errorf("operator engine-config replaced by class entry: %+v", got[0])
 	}
 	if got[1].EmptyDir == nil {
 		t.Errorf("operator data volume replaced by class hostPath entry: %+v", got[1])
@@ -548,11 +548,11 @@ func TestAppendUserPodVolumes_OperatorReservedNamesWin(t *testing.T) {
 // The static reservation in operatorOwnedPodVolumeNames must catch
 // this even when the operator-built slice happens not to carry "data".
 func TestAppendUserPodVolumes_PVCBackendDropsCollidingData(t *testing.T) {
-	// PVC backend: only "nodes-config" is in the operator slice — the
+	// PVC backend: only "engine-config" is in the operator slice — the
 	// data volume is provisioned by VolumeClaimTemplates and never
 	// appears in pod-level Volumes.
 	operator := []corev1.Volume{
-		{Name: "nodes-config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "op-cfg"}}}},
+		{Name: "engine-config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "op-cfg"}}}},
 	}
 	classInfo := newFireboltEngineClassInfo(classWith(nil, &corev1.PodSpec{
 		Volumes: []corev1.Volume{
@@ -569,7 +569,7 @@ func TestAppendUserPodVolumes_PVCBackendDropsCollidingData(t *testing.T) {
 		}
 	}
 	if len(got) != 2 {
-		t.Fatalf("got %d volumes, want 2 (operator nodes-config + non-colliding class extra)", len(got))
+		t.Fatalf("got %d volumes, want 2 (operator engine-config + non-colliding class extra)", len(got))
 	}
 }
 
@@ -580,7 +580,7 @@ func TestAppendUserPodVolumes_PVCBackendDropsCollidingData(t *testing.T) {
 // either.
 func TestAppendUserPodVolumes_PVCBackendDropsCollidingEngineData(t *testing.T) {
 	operator := []corev1.Volume{
-		{Name: "nodes-config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "op-cfg"}}}},
+		{Name: "engine-config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "op-cfg"}}}},
 	}
 	spec := testSpec()
 	setSpecTemplatePod(spec, func(p *corev1.PodSpec) {

--- a/internal/controller/engine_reconcile.go
+++ b/internal/controller/engine_reconcile.go
@@ -622,7 +622,7 @@ func buildStatefulSet(spec *computev1alpha1.FireboltEngineSpec, engineName, name
 
 	volumeMounts := buildEngineContainerVolumeMounts(spec, classInfo)
 	engineEnv := buildEngineContainerEnv(spec, classInfo)
-	// The "data" volume backing /firebolt-core/volume is either a per-pod
+	// The "data" volume backing /var/lib/firebolt is either a per-pod
 	// PVC (the default; the StatefulSet controller synthesizes the pod
 	// Volume from the VolumeClaimTemplate) or a node-local emptyDir /
 	// hostPath that we add to pod.spec.volumes explicitly.
@@ -685,7 +685,7 @@ func buildStatefulSet(spec *computev1alpha1.FireboltEngineSpec, engineName, name
 	}
 	podVolumes := []corev1.Volume{
 		{
-			Name: "nodes-config",
+			Name: "engine-config",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
@@ -1651,7 +1651,7 @@ func effectiveEngineEnvFrom(spec *computev1alpha1.FireboltEngineSpec, classInfo 
 // effectiveEngineVolumeMounts concatenates additional volumeMounts on
 // the engine container from both class and engine templates, class
 // first. Entries whose name collides with an operator-reserved volume
-// ("nodes-config", DataVolumeName) are skipped on both sides: the
+// ("engine-config", DataVolumeName) are skipped on both sides: the
 // operator owns those mount paths and a user override would silently
 // break startup (config volume) or data persistence (data volume).
 func effectiveEngineVolumeMounts(spec *computev1alpha1.FireboltEngineSpec, classInfo *FireboltEngineClassInfo) []corev1.VolumeMount {
@@ -1673,7 +1673,7 @@ func effectiveEngineVolumeMounts(spec *computev1alpha1.FireboltEngineSpec, class
 func appendUserVolumeMounts(dst, src []corev1.VolumeMount) []corev1.VolumeMount {
 	for i := range src {
 		name := src[i].Name
-		if name == "nodes-config" || name == DataVolumeName {
+		if name == "engine-config" || name == DataVolumeName {
 			continue
 		}
 		dst = append(dst, *src[i].DeepCopy())
@@ -1721,14 +1721,14 @@ func buildEngineContainerVolumeMounts(spec *computev1alpha1.FireboltEngineSpec, 
 			MountPath: DataMountPath,
 		},
 		{
-			Name:      "nodes-config",
+			Name:      "engine-config",
 			MountPath: ConfigMountPath,
 			SubPath:   ConfigFileName,
 			ReadOnly:  true,
 		},
 		{
 			Name:      computev1alpha1.EngineRuntimeVolumeName,
-			MountPath: "/var/run/firebolt",
+			MountPath: "/run/firebolt",
 		},
 	}
 	return append(out, effectiveEngineVolumeMounts(spec, classInfo)...)
@@ -1923,7 +1923,7 @@ func appendUserPodVolumes(operator []corev1.Volume, spec *computev1alpha1.Firebo
 // making the runtime-derived reservation insufficient.
 func operatorOwnedPodVolumeNames() map[string]struct{} {
 	return map[string]struct{}{
-		"nodes-config":              {},
+		"engine-config":             {},
 		DataVolumeName:              {},
 		EngineWebWritableVolumeName: {},
 	}
@@ -2140,8 +2140,8 @@ func getEngineContainerSecurityContext(spec *computev1alpha1.FireboltEngineSpec)
 // no user value is supplied. Mirrors the firebolt-instance-helm chart's
 // engine StatefulSet (UID/GID 3473): non-root, no extra capabilities,
 // no privilege escalation, read-only root filesystem; engine runtime
-// writes go to the data PVC at /firebolt-core/volume and an emptyDir at
-// /var/run/firebolt.
+// writes go to the data volume at /var/lib/firebolt and an emptyDir at
+// /run/firebolt.
 func defaultEngineContainerSecurityContext() *corev1.SecurityContext {
 	runAsUser := DefaultEngineWebD
 	runAsGroup := DefaultEngineGID
@@ -2644,7 +2644,7 @@ const (
 
 // resolveStorageBackend returns the effective backend for an
 // EngineStorageSpec. If no sibling pointer is set we default to
-// BackendEmptyDir: engine data at /firebolt-core/volume is regenerable
+// BackendEmptyDir: engine data at /var/lib/firebolt is regenerable
 // cache (authoritative state lives in the metadata service and the
 // managed-table S3 bucket), so an ephemeral pod-local volume is the
 // safe default and avoids a hard dependency on a dynamic-provisioner

--- a/internal/controller/engine_reconcile_test.go
+++ b/internal/controller/engine_reconcile_test.go
@@ -2660,7 +2660,7 @@ func TestBuildStatefulSet_InitContainers(t *testing.T) {
 			Name:    "prep-disk",
 			Image:   "busybox:1.36",
 			Command: []string{"sh", "-c"},
-			Args:    []string{"chown -R 3473:3473 /firebolt-core/volume"},
+			Args:    []string{"chown -R 3473:3473 /var/lib/firebolt"},
 			SecurityContext: &corev1.SecurityContext{
 				RunAsUser: boolPtrInt64(0),
 			},

--- a/internal/controller/engine_storage_test.go
+++ b/internal/controller/engine_storage_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 // TestBuildStatefulSet_DataVolumeBackends guards the data-volume backend
-// matrix: the engine pod's /firebolt-core/volume mount can be backed by
+// matrix: the engine pod's /var/lib/firebolt mount can be backed by
 // the default emptyDir, an
 // opt-in per-pod PVC, an explicit emptyDir with knobs, or a hostPath. The
 // PVC backend emits a single VolumeClaimTemplate (and no pod-level data


### PR DESCRIPTION
**Background**

FB-1733: The engine image moved to an FHS-compliant layout, so the operator's hardcoded paths no longer match the image.

**Summary**

- Point the engine mounts and startup script at the new FHS paths: binary at `/opt/firebolt/firebolt`, data root at `/var/lib/firebolt`, runtime socket at `/run/firebolt`.
- Rename the engine config volume `nodes-config` → `engine-config` so the volume name matches the public CRD vocabulary.
- Update comments, docs, and the example/test fixtures that referenced the old paths and volume name.

Going forward, these are pod-template changes, so existing engines roll one new generation on upgrade via `stsMatchesSpec` drift detection.

**Test Plan**

- `make build && make lint && make test` all pass.
- Verified live on a local Kind cluster: instance + engine reach Ready with the new engine image once paths were aligned.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core engine pod startup paths and a reserved volume name, which forces rollouts and can break clusters still on pre-FHS engine images until upgraded together.
> 
> **Overview**
> **Breaking pod-template alignment** for the engine image’s FHS layout: startup now runs `/opt/firebolt/firebolt` with `--data-dir /var/lib/firebolt`, config mounts at `/var/lib/firebolt/config.yaml`, and the unix socket uses `/run/firebolt` instead of `/var/run/firebolt`.
> 
> The operator-owned config volume is renamed **`nodes-config` → `engine-config`** everywhere (API constants, reconciler, reserved-volume logic, and docs). Existing engines should pick this up as **pod-template drift** and roll a new generation via `stsMatchesSpec`.
> 
> Default **engine/metadata image tags** in `config/images/defaults.latest.env` bump to the matching **5.0.1** release build. Docs and examples are updated for the new paths, and security docs add guidance on writable dirs and OpenShift-style arbitrary UIDs with the new image permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9a14e059f60585558b6786fd97b5148f74d9c6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->