### PR TITLE
chore(deps): bump packdb engine/metadata to 5.0.1-0.20260619171610.8e3abb43e96b

### DIFF
--- a/config/images/defaults.latest.env
+++ b/config/images/defaults.latest.env
@@ -23,9 +23,9 @@
 #     test/e2e/e2e_suite_test.go's SynchronizedBeforeSuite.
 
 ENGINE_IMAGE=ghcr.io/firebolt-db/engine
-ENGINE_TAG=release-4.32.0-pre.0.20260612115847.e36d5e7953e5
+ENGINE_TAG=release-5.0.1-0.20260619171610.8e3abb43e96b
 METADATA_IMAGE=ghcr.io/firebolt-db/metadata
-METADATA_TAG=release-4.32.0-pre.0.20260612115847.e36d5e7953e5
+METADATA_TAG=release-5.0.1-0.20260619171610.8e3abb43e96b
 POSTGRES_IMAGE=postgres:16-alpine
 ENVOY_IMAGE=envoyproxy/envoy
 ENVOY_TAG=v1.37.2


### PR DESCRIPTION
## Summary

Bump default engine/metadata images to packdb `5.0.1-0.20260619171610.8e3abb43e96b`
— the build the engine `:dev` tag currently points to.

> [!NOTE]
> **Temporary automation.** Opened weekly (Mondays) by packdb's
> `Temporary - Weekly downstream image bump` workflow as a stand-in for a real
> engine release: it bumps to whatever the engine `:dev` tag points to, as if the
> engine `:latest` tag had been refreshed. It exists only until the new Firebolt
> engine images have a proper release cadence that moves `:latest` and drives
> `API-release-flow`'s bump jobs. An unmerged PR is overwritten by next Monday's run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only tag bump with no application logic changes; CI runs unit and E2E for both `dev` and `latest` variants on this file.
> 
> **Overview**
> Updates the **`latest`** image variant pins in `config/images/defaults.latest.env` so **`ENGINE_TAG`** and **`METADATA_TAG`** both move from `release-4.32.0-pre.0.20260612115847.e36d5e7953e5` to **`release-5.0.1-0.20260619171610.8e3abb43e96b`**, keeping engine and metadata on the same release flavor.
> 
> When builds or tests run with `IMAGE_VARIANT=latest`, the operator and E2E suite will pull and exercise this packdb build instead of the previous pre-4.32 pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d263fd64ec4b16826d82319de8dc90e260a6537c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->