### PR TITLE
ci: enforce conventional commits in PR title (FB-1790)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,40 +12,6 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Validate PR title
-        if: ${{ !startsWith(github.head_ref, 'dependabot') && !startsWith(github.head_ref, 'release-please') }}
-        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50  # v6.1.1
-        with:
-
-          # List of allowed commit types
-          types: |
-            build
-            chore
-            ci
-            docs
-            feat
-            fix
-            perf
-            refactor
-            revert
-            style
-            test
-
-          subjectPattern: ^[a-z0-9_].*\((#[0-9]+|[A-Z]+-[0-9]+)\)$
-          requireScope: false
-          validateSingleCommit: false
-          subjectPatternError: |
-            The subject "{subject}" found in the pull request title "{title}" didn't match the configured pattern.
-
-            We follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
-            Our CI is configured to forbidden PRs with titles that don't follow this standard.
-            That's it, all commits landing in the `main` branch must be formatted in this way.
-            Please make sure you read and understand this convention.
-
-            The subject must not start with a capital letter, and must end with an issue
-            reference in parentheses: either a GitHub issue like "(#123)" or a tracker
-            ticket like "(FB-1234)".
-
       - name: Clone the code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,27 +7,48 @@ permissions: {}
 
 jobs:
   lint:
-    name: Run on Ubuntu
+    name: Lint
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: app-token
+      - name: Validate PR title
+        if: ${{ !startsWith(github.head_ref, 'dependabot') && !startsWith(github.head_ref, 'release-please') }}
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50  # v6.1.1
         with:
-          client-id: ${{ secrets.GH_APP_FB_DB_CI_WRITER_CLIENT_ID }}
-          private-key: ${{ secrets.GH_APP_FB_DB_CI_WRITER_APP_KEY_PEM }}
-          permission-contents: read
 
-      - name: Configure Git for private modules
-        env:
-          GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
+          # List of allowed commit types
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+
+          subjectPattern: ^[a-z0-9_].*\((#[0-9]+|[A-Z]+-[0-9]+)\)$
+          requireScope: false
+          validateSingleCommit: false
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}" didn't match the configured pattern.
+
+            We follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
+            Our CI is configured to forbidden PRs with titles that don't follow this standard.
+            That's it, all commits landing in the `main` branch must be formatted in this way.
+            Please make sure you read and understand this convention.
+
+            The subject must not start with a capital letter, and must end with an issue
+            reference in parentheses: either a GitHub issue like "(#123)" or a tracker
+            ticket like "(FB-1234)".
 
       - name: Clone the code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
 
       - name: Setup Go

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,57 @@
+name: PR Title
+
+on:
+  pull_request:
+    # 'edited' is required so that fixing a failed title (which changes only the
+    # title, not the commits) re-triggers validation. The default activity types
+    # (opened, synchronize, reopened) do not cover title edits.
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+
+permissions: {}
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    if: ${{ !startsWith(github.head_ref, 'dependabot') && !startsWith(github.head_ref, 'release-please') }}
+    steps:
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50  # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+
+          # List of allowed commit types
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+
+          subjectPattern: ^[a-z0-9_].*\((#[0-9]+|[A-Z]+-[0-9]+)\)$
+          requireScope: false
+          validateSingleCommit: false
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}" didn't match the configured pattern.
+
+            We follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
+            Our CI is configured to forbidden PRs with titles that don't follow this standard.
+            That's it, all commits landing in the `main` branch must be formatted in this way.
+            Please make sure you read and understand this convention.
+
+            The subject must not start with a capital letter, and must end with an issue
+            reference in parentheses: either a GitHub issue like "(#123)" or a tracker
+            ticket like "(FB-1234)".

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,7 +248,7 @@ Do not delete Docker images or kind clusters; assume the kind cluster is already
 Ask before creating or amending commits.
 
 ```
-<type>(<scope>): <description> (FB-<ticket>)
+<type>(<scope>): <description> (<issue-ref>)
 ```
 
 Types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`.
@@ -259,9 +259,9 @@ Rules:
 
 - Subject: imperative mood, lowercase, no trailing period; keep it under 100 characters.
 - Body: explain what changed and *why*.
-- The `FB-<ticket>` reference is required; take it from the branch name or last commit.
+- An issue reference is required: either a GitHub issue (`#123`) or a Linear ticket (`FB-<ticket>`); take it from the branch name or last commit.
 
-Example: `fix(controller): report ready-vs-total pods in PodsNotReady message (FB-<ticket>)`
+Example: `fix(controller): report ready-vs-total pods in PodsNotReady message (#123)`
 
 **Staging**: always add files by explicit path (`git add file1 file2`). Never use `git add -A`, `git add .`, or `git add --all` -- untracked files that are not meant to be versioned will be committed.
 
@@ -277,5 +277,5 @@ When breaking work into a plan, divide it into self-contained commits. Each comm
 ### Code quality
 
 - Ignoring errors is forbidden except with a documented rationale in a comment.
-- No ticket references (`FB-<ticket>`, `FIR-<ticket>`, or any tracker ID) in code or docs: not in comments, identifiers, strings, or doc prose. Tickets go in the commit message only (see Commit conventions).
+- No issue references (`FB-<ticket>`, `FIR-<ticket>`, any tracker ID, or a GitHub issue number like `#123`) in code or docs: not in comments, identifiers, strings, or doc prose. They go in the commit message only (see Commit conventions).
 - Comments and docs state how the code behaves now, not what just changed. Do not narrate edits ("previously", "changed to", "fixed the bug where", "new:").


### PR DESCRIPTION
**Background**

FB-1790: enforce conventional commits in PR title

**Summary**
We still require a issue tracker reference, which can alternatively be a GitHub issue

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow and documentation only; the lint job no longer configures private Go module auth, which could matter only if golangci-lint still needs to fetch private `github.com/firebolt-db/*` modules without vendoring.
> 
> **Overview**
> **CI now validates PR titles** on open, sync, reopen, and **title edit** (excluding dependabot/release-please branches). Titles must follow allowed conventional types and a subject pattern: lowercase start, ending with `(#123)` or `(FB-1234)`.
> 
> The **lint workflow** drops the GitHub App token, private-module git URL rewrite, and custom checkout token—checkout uses default credentials with `persist-credentials: false` only. The job is renamed to **Lint**.
> 
> **AGENTS.md** documents the generalized `<issue-ref>` format (GitHub `#` or Linear `FB-`) for commits and extends the “no tracker IDs in code/docs” rule to GitHub issue numbers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1365ee120508f62782709ad901cc9eb57277126a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->