### PR TITLE
ci: remove obsolete app-token usage (FB-1790)

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -140,22 +140,9 @@ jobs:
           echo "=== container memlock (daemon-level default-ulimits) ==="
           docker run --rm alpine sh -c 'ulimit -l'
 
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: app-token
-        with:
-          client-id: ${{ secrets.GH_APP_FB_DB_CI_WRITER_CLIENT_ID }}
-          private-key: ${{ secrets.GH_APP_FB_DB_CI_WRITER_APP_KEY_PEM }}
-          permission-contents: read
-
-      - name: Configure Git for private modules
-        env:
-          GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
-
       - name: Clone the code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
-          token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
 
       - name: Setup Go

--- a/.github/workflows/test-helm.yaml
+++ b/.github/workflows/test-helm.yaml
@@ -110,21 +110,8 @@ jobs:
           sudo systemctl daemon-reload
           sudo systemctl restart docker
 
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: app-token
-        with:
-          client-id: ${{ secrets.GH_APP_FB_DB_CI_WRITER_CLIENT_ID }}
-          private-key: ${{ secrets.GH_APP_FB_DB_CI_WRITER_APP_KEY_PEM }}
-          permission-contents: read
-
-      - name: Configure Git for private modules
-        env:
-          GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
-
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0


### PR DESCRIPTION
**Background**

FB-1790: remove obsolete app-token usage

**Summary**
The repository was made public so these steps are not required any longer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only cleanup with no application or security logic changes; main risk is CI failing if any step still required private module auth (unlikely after going public).
> 
> **Overview**
> Removes **private-repo CI plumbing** from `test-e2e.yaml` and `test-helm.yaml` now that the repository is public.
> 
> Both workflows no longer mint a GitHub App token, configure `git` URL rewrites for `x-access-token` access to `github.com`, or pass that token into `actions/checkout`. Checkout continues with `persist-credentials: false` and the default `GITHUB_TOKEN`-based flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12147dcc0de958cec517e962e4d38eadca8d6c69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->