### PR TITLE
ci: remove obsolete app-token usage from unit tests (FB-1790)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,22 +21,9 @@ jobs:
       matrix:
         variant: [dev, latest]
     steps:
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: app-token
-        with:
-          client-id: ${{ secrets.GH_APP_FB_DB_CI_WRITER_CLIENT_ID }}
-          private-key: ${{ secrets.GH_APP_FB_DB_CI_WRITER_APP_KEY_PEM }}
-          permission-contents: read
-
-      - name: Configure Git for private modules
-        env:
-          GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
-
       - name: Clone the code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
 
       - name: Setup Go


### PR DESCRIPTION
**Background**

FB-1790: remove obsolete app-token usage

**Summary**
The unit test suite also doesn't require the token any longer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only cleanup with no application or test logic changes; risk is limited to PR CI failing if private module fetch still required a token (intentionally removed per ticket).
> 
> **Overview**
> Aligns the **Tests** workflow with FB-1790 by dropping CI steps that minted a `GH_APP_FB_DB_CI_WRITER` token for checkout and `git` access to private modules.
> 
> **Removed:** `actions/create-github-app-token`, the global `git config` URL rewrite for `https://github.com/`, and passing the app token into `actions/checkout`. Checkout now uses default credentials with `persist-credentials: false` only; `make test` / `make test-property` still set `GOPRIVATE: github.com/firebolt-db/*`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cde86ad114fbb6d5bba667132fbdecbe7be9ebe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->