### PR TITLE
ci: add rollup gate jobs for conditional required checks (FB-1816)

### DIFF
--- a/.github/workflows/formal-verification.yaml
+++ b/.github/workflows/formal-verification.yaml
@@ -9,8 +9,45 @@ on:
 permissions: {}
 
 jobs:
+  detect:
+    name: Detect formal-relevant change
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      relevant: ${{ steps.detect.outputs.relevant }}
+    steps:
+      - name: Determine whether formal specs/fixture changed
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # On non-pull_request events (push to main) always run.
+          # On a PR, TLC's result depends only on the TLA+ specs, the
+          # fixture generator, and the generated fixture — not docs and
+          # not most Go changes. Fail-safe: any uncertainty -> true.
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          files="$(gh api --paginate \
+            "repos/${REPO}/compare/${BASE_SHA}...${HEAD_SHA}" \
+            --jq '.files[].filename' 2>/dev/null || true)"
+          printf '%s\n' "${files:-<none>}"
+          if [ -z "${files}" ]; then echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0; fi
+          if printf '%s\n' "${files}" \
+            | grep -qE '^formal/|^scripts/gen-tla-state-tests\.py$|_tla_states_data_test\.go$'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+
   tlc:
-    name: TLC model checker
+    name: TLC
+    needs: detect
+    if: needs.detect.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -70,3 +107,28 @@ jobs:
             git --no-pager diff -- internal/controller/engine_tla_states_data_test.go
             exit 1
           fi
+
+  # Single stable required-check name for branch protection. Keeping the
+  # required name "TLC model checker" on this gate (the worker job is now
+  # "TLC") means branch protection does not change for TLC. The gate runs
+  # `if: always()`, passes when the path-scoped worker was `success` or
+  # (intentionally) `skipped`, and fails closed if `detect` failed.
+  tlc-required:
+    name: TLC model checker
+    needs: [detect, tlc]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Verify gated jobs
+        env:
+          DETECT: ${{ needs.detect.result }}
+          TLC: ${{ needs.tlc.result }}
+        run: |
+          if [ "$DETECT" != "success" ]; then
+            echo "::error::detect did not succeed (result=$DETECT)"; exit 1
+          fi
+          case "$TLC" in
+            success|skipped) echo "gate satisfied (tlc=$TLC)";;
+            *) echo "::error::tlc result=$TLC"; exit 1;;
+          esac

--- a/.github/workflows/lint-and-scan-actions.yaml
+++ b/.github/workflows/lint-and-scan-actions.yaml
@@ -9,14 +9,54 @@ on:
   push:
     branches: ["main"]
     paths: [".github/**"]
+  # No `paths` filter on pull_request: the workflow must run on every PR so
+  # the `Actions Lint & Scan` rollup gate always reports a status. The
+  # `detect` job decides whether actionlint/zizmor actually execute (only
+  # when files under .github/ changed). A trigger-level `paths` filter would
+  # leave the required gate Pending on non-.github PRs and block the merge.
   pull_request:
     branches: ["**"]
-    paths: [".github/**"]
 
 permissions: {}
 
 jobs:
+  detect:
+    name: Detect .github change
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      relevant: ${{ steps.detect.outputs.relevant }}
+    steps:
+      - name: Determine whether workflow/action files changed
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # On non-pull_request events (push to main) always run; the push
+          # trigger is already path-filtered to .github/**. On a PR, run the
+          # linters only when files under .github/ changed. Fail-safe: any
+          # uncertainty -> true.
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          files="$(gh api --paginate \
+            "repos/${REPO}/compare/${BASE_SHA}...${HEAD_SHA}" \
+            --jq '.files[].filename' 2>/dev/null || true)"
+          printf '%s\n' "${files:-<none>}"
+          if [ -z "${files}" ]; then echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0; fi
+          if printf '%s\n' "${files}" | grep -qE '^\.github/'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
+
   actionlint:
+    needs: detect
+    if: needs.detect.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -34,6 +74,8 @@ jobs:
           fail_level: error
 
   zizmor:
+    needs: detect
+    if: needs.detect.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -52,3 +94,34 @@ jobs:
           # Informational findings (e.g. style suggestions like
           # superfluous-actions) are reported but do not fail the job.
           min-severity: low
+
+  # Single stable required-check name for branch protection. The workflow
+  # runs on every PR (no trigger `paths` filter) so this gate always
+  # reports, but the gated jobs only execute when .github/ changed. The
+  # gate runs `if: always()`, requires `detect` to have succeeded, and
+  # passes only when both actionlint and zizmor are `success` or
+  # (intentionally) `skipped` — so a workflow-file regression on a PR that
+  # touches .github/ fails the gate and blocks the merge, while a PR that
+  # touches no .github/ file skips both linters and the gate stays green.
+  actions-lint-required:
+    name: Actions Lint & Scan
+    needs: [detect, actionlint, zizmor]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Verify gated jobs
+        env:
+          DETECT: ${{ needs.detect.result }}
+          ACTIONLINT: ${{ needs.actionlint.result }}
+          ZIZMOR: ${{ needs.zizmor.result }}
+        run: |
+          if [ "$DETECT" != "success" ]; then
+            echo "::error::detect did not succeed (result=$DETECT)"; exit 1
+          fi
+          for r in "actionlint=$ACTIONLINT" "zizmor=$ZIZMOR"; do
+            case "${r#*=}" in
+              success|skipped) echo "gate satisfied (${r})";;
+              *) echo "::error::${r}"; exit 1;;
+            esac
+          done

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -15,7 +15,7 @@ permissions: {}
 
 jobs:
   validate:
-    name: Validate PR title
+    name: PR Title
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -221,3 +221,30 @@ jobs:
             run-e2e.log
             pod-logs/
           retention-days: 30
+
+  # Single stable required-check name for branch protection. Matrix legs
+  # (E2E Tests (dev/latest)) are not reliably emitted as per-combination
+  # checks when skipped, so a docs-only PR would leave them Pending and
+  # block the merge. This gate runs `if: always()`, collapses both matrix
+  # legs into one `needs.test-e2e.result`, and fails closed if `detect`
+  # itself failed (which would otherwise skip the heavy job and report a
+  # false success).
+  e2e-required:
+    name: E2E Tests
+    needs: [detect, test-e2e]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Verify gated jobs
+        env:
+          DETECT: ${{ needs.detect.result }}
+          E2E: ${{ needs.test-e2e.result }}
+        run: |
+          if [ "$DETECT" != "success" ]; then
+            echo "::error::detect did not succeed (result=$DETECT)"; exit 1
+          fi
+          case "$E2E" in
+            success|skipped) echo "gate satisfied (test-e2e=$E2E)";;
+            *) echo "::error::test-e2e result=$E2E"; exit 1;;
+          esac

--- a/.github/workflows/test-helm.yaml
+++ b/.github/workflows/test-helm.yaml
@@ -164,3 +164,28 @@ jobs:
 
       - name: Verify website quickstart bundle
         run: make helm-test-website KIND_CLUSTER="${KIND_CLUSTER}"
+
+  # Single stable required-check name for branch protection. `test-helm`
+  # is a single job that already reports success when skipped, but this
+  # gate closes the `detect` fail-open hole (a failed `detect` would skip
+  # the heavy job and report a false success) and gives branch protection
+  # one stable name independent of the worker job.
+  helm-required:
+    name: Helm Tests
+    needs: [detect, test-helm]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Verify gated jobs
+        env:
+          DETECT: ${{ needs.detect.result }}
+          HELM: ${{ needs.test-helm.result }}
+        run: |
+          if [ "$DETECT" != "success" ]; then
+            echo "::error::detect did not succeed (result=$DETECT)"; exit 1
+          fi
+          case "$HELM" in
+            success|skipped) echo "gate satisfied (test-helm=$HELM)";;
+            *) echo "::error::test-helm result=$HELM"; exit 1;;
+          esac

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,3 +56,23 @@ jobs:
         run: make test-property
         env:
           GOPRIVATE: github.com/firebolt-db/*
+
+  # Single stable required-check name for branch protection. The unit
+  # matrix legs (Run on Ubuntu (dev/latest)) were never required directly;
+  # this gate exposes one stable name. The unit suite always runs (no
+  # `detect`), so the gate simply requires `test` to have succeeded.
+  unit-tests:
+    name: Unit Tests
+    needs: [test]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Verify gated jobs
+        env:
+          TEST: ${{ needs.test.result }}
+        run: |
+          if [ "$TEST" != "success" ]; then
+            echo "::error::test result=$TEST"; exit 1
+          fi
+          echo "gate satisfied (test=$TEST)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,10 +257,11 @@ Canonical required-check names (each is a gate job except Lint / PR Title):
 | `Helm Tests` | `test-helm.yaml` | `helm-required` | `test-helm` |
 | `Unit Tests` | `test.yaml` | `unit-tests` | `test` (matrix dev/latest) |
 | `TLC model checker` | `formal-verification.yaml` | `tlc-required` | `tlc` (path-scoped via `detect`) |
+| `Actions Lint & Scan` | `lint-and-scan-actions.yaml` | `actions-lint-required` | `actionlint` + `zizmor` (path-scoped via `detect`) |
 | `Lint` | `lint.yaml` | — (always runs) | `lint` |
 | `PR Title` | `pr-title.yaml` | — (always runs; skip reports success) | `validate` |
 
-The `formal-verification.yaml` `detect` job is **path-scoped**: on a PR it sets `relevant=true` only when changed files match `^formal/`, `^scripts/gen-tla-state-tests.py$`, or `_tla_states_data_test.go$` (fail-safe: any uncertainty → `true`); on push to `main` it is always `true`. The required name `TLC model checker` lives on the gate so the worker job could be renamed to `TLC` with no branch-protection change. When adding a new conditional/matrix workflow that should gate merges, add a gate following this shape rather than requiring matrix-leg or worker names directly. A gate name must complete on `main` at least once before it appears in the branch-protection picker.
+The `formal-verification.yaml` `detect` job is **path-scoped**: on a PR it sets `relevant=true` only when changed files match `^formal/`, `^scripts/gen-tla-state-tests.py$`, or `_tla_states_data_test.go$` (fail-safe: any uncertainty → `true`); on push to `main` it is always `true`. `lint-and-scan-actions.yaml` follows the same shape (`detect` scoped to `^\.github/`); its `pull_request` trigger drops the `paths` filter so the gate reports on every PR while `actionlint`/`zizmor` run only when workflow/action files changed (the `push` trigger keeps its `paths` filter since pushes do not gate merges). The required name `TLC model checker` lives on the gate so the worker job could be renamed to `TLC` with no branch-protection change. When adding a new conditional/matrix workflow that should gate merges, add a gate following this shape rather than requiring matrix-leg or worker names directly. A gate name appears in the branch-protection / ruleset picker once it has been reported as a completed check on **any ref** — a single PR-branch CI run is enough, so the new required names can be pre-selected from an open PR before the workflow change merges to `main` (no merge-to-`main`-first step required).
 
 ### Commit conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,25 @@ E2E rules:
 
 Do not delete Docker images or kind clusters; assume the kind cluster is already set up.
 
+### Required checks / rollup gates
+
+GitHub branch protection requires checks by **job `name`** (not workflow name). A check counts as passing when it is `success`, `skipped`, or `neutral` — but **where** the skip happens matters: a workflow skipped by an `on:` filter stays *Pending* (blocks the PR), whereas a job skipped by a job-level `if:` reports *Success*. Matrix-leg names are also not reliably emitted when the leg is skipped. To keep path/branch-conditional workflows compatible with required checks (docs-only PRs must not block forever, but real failures must still fail closed), each conditional or matrix workflow exposes **one stable required-check name backed by a rollup gate job**.
+
+Gate convention: the gate job runs `if: always()`, `needs` the `detect` job plus the heavy/worker job, has `permissions: {}`, uses inline `run:` only (no new pinned action — keeps the action-lint/zizmor surface unchanged), and passes only when `detect` succeeded **and** the gated job is `success` or (intentionally) `skipped`. A failed `detect` fails the gate closed (a skipped heavy job would otherwise count as a false success). `needs.<job>.result` collapses all matrix legs into one result.
+
+Canonical required-check names (each is a gate job except Lint / PR Title):
+
+| Required check | Workflow | Gate job | Worker job |
+|----------------|----------|----------|------------|
+| `E2E Tests` | `test-e2e.yaml` | `e2e-required` | `test-e2e` (matrix dev/latest) |
+| `Helm Tests` | `test-helm.yaml` | `helm-required` | `test-helm` |
+| `Unit Tests` | `test.yaml` | `unit-tests` | `test` (matrix dev/latest) |
+| `TLC model checker` | `formal-verification.yaml` | `tlc-required` | `tlc` (path-scoped via `detect`) |
+| `Lint` | `lint.yaml` | — (always runs) | `lint` |
+| `PR Title` | `pr-title.yaml` | — (always runs; skip reports success) | `validate` |
+
+The `formal-verification.yaml` `detect` job is **path-scoped**: on a PR it sets `relevant=true` only when changed files match `^formal/`, `^scripts/gen-tla-state-tests.py$`, or `_tla_states_data_test.go$` (fail-safe: any uncertainty → `true`); on push to `main` it is always `true`. The required name `TLC model checker` lives on the gate so the worker job could be renamed to `TLC` with no branch-protection change. When adding a new conditional/matrix workflow that should gate merges, add a gate following this shape rather than requiring matrix-leg or worker names directly. A gate name must complete on `main` at least once before it appears in the branch-protection picker.
+
 ### Commit conventions
 
 Ask before creating or amending commits.


### PR DESCRIPTION
**Background**

FB-1816: Path/branch-conditional CI workflows are incompatible with GitHub branch-protection required checks, so docs-only (and other irrelevant) PRs are blocked forever on Pending matrix-leg checks, while a failed `detect` job can let an unverified PR merge.

**Summary**

GitHub treats `success`, `skipped`, and `neutral` as passing for required checks, but a workflow skipped by an `on:` filter stays *Pending* (blocks the PR) whereas a job skipped by a job-level `if:` reports *Success*. Matrix-leg names (`E2E Tests (dev/latest)`) are not reliably emitted when a leg is skipped, so docs-only PRs sat Pending and blocked merges. Separately, `needs: detect` means a failed `detect` skips the heavy job and counts as a false success.

This adds **one stable required-check name per conditional/matrix workflow**, backed by a rollup gate job that runs `if: always()`, depends on `detect` plus the worker job, and passes only when `detect` succeeded **and** the worker is `success` or (intentionally) `skipped`. `needs.<job>.result` collapses both matrix legs into a single result.

- `test-e2e.yaml` — `e2e-required` gate (name **`E2E Tests`**, `needs: [detect, test-e2e]`).
- `test-helm.yaml` — `helm-required` gate (name **`Helm Tests`**, `needs: [detect, test-helm]`); closes the `detect` fail-open hole.
- `test.yaml` — `unit-tests` gate (name **`Unit Tests`**, `needs: [test]`); no `detect`, so it requires `test == success`. The unit suite becomes a newly required check via this stable name.
- `formal-verification.yaml` — adds a **path-scoped** `detect` job (`relevant=true` only for `^formal/`, `^scripts/gen-tla-state-tests.py$`, `_tla_states_data_test.go$`; always true on push to `main`; fail-safe → true), renames the worker job to **`TLC`**, and adds a `tlc-required` gate keeping the stable name **`TLC model checker`** so branch protection is unchanged for TLC.
- `pr-title.yaml` — renames the job display name from `Validate PR title` to **`PR Title`** so the emitted check matches the required-check name (the context is the job name, not the workflow name).

Gates use inline `run:` only (no new pinned action), so the actionlint/zizmor surface is unchanged. `AGENTS.md` documents the convention and the canonical required-check names.

Going forward: new conditional/matrix workflows that gate merges should add a gate following this shape rather than requiring matrix-leg or worker job names directly.

**Follow-up (manual, not in this PR):**
- Branch protection: remove `E2E Tests (dev)`, `E2E Tests (latest)`, `test-helm`; add `E2E Tests`, `Helm Tests`, `Unit Tests` — in one edit, after this lands on `main` so the gate names appear in the picker. Final set: `TLC model checker`, `Lint`, `PR Title`, `Unit Tests`, `Helm Tests`, `E2E Tests`.

**Test Plan**

- `actionlint` passes clean on all five modified workflows.
- `zizmor --min-severity low` reports no findings on all five workflows (no new pinned action added).
- Logic walkthrough: docs-only PR → `detect` docs-only, heavy jobs skipped, gates report success; Go-change PR → heavy jobs run, gates mirror them; forced `detect` failure → gate fails closed; TLC path gate → `formal/**` change runs `tlc`, unrelated change skips `tlc` but `TLC model checker` gate stays green, push to `main` always runs `tlc`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes merge gating and branch-protection check names; misconfigured gates could block merges or allow false greens, though the design explicitly fails closed on `detect` failure.
> 
> **Overview**
> Adds **rollup gate jobs** so branch protection can require one stable check name per workflow instead of matrix legs or path-skipped workflows that stay *Pending*.
> 
> **E2E, Helm, and unit tests** — New gates **`E2E Tests`**, **`Helm Tests`**, and **`Unit Tests`** run `if: always()`, depend on `detect` (where present) plus the worker job, and pass only when `detect` succeeded and the worker is `success` or intentionally `skipped`, so docs-only PRs are not blocked and a failed `detect` cannot merge unverified.
> 
> **Formal verification** — Introduces path-scoped **`detect`** (TLA+ / fixture paths on PRs; always on `main` push), renames the worker to **`TLC`**, and adds **`tlc-required`** keeping the required name **`TLC model checker`**.
> 
> **Actions lint** — Removes `pull_request` `paths` filter, adds **`.github/` `detect`**, and adds **`actions-lint-required`** (**`Actions Lint & Scan`**) so the gate reports on every PR while `actionlint`/`zizmor` run only when workflow files change.
> 
> **PR title** — Job display name **`PR Title`** aligned with the required check.
> 
> **`AGENTS.md`** — Documents the gate convention and canonical required-check names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2617e103c83aa93b433e3c0a38888bbb8f6d27d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->