### PR TITLE
chore(deps): group dependabot version updates (FB-1818)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
     open-pull-requests-limit: 20
     cooldown:
       default-days: 7
+    groups:
+      actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "gomod"
     directory: "/"
@@ -26,6 +30,24 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
+    groups:
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      opentelemetry:
+        patterns:
+          - "go.opentelemetry.io/*"
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
+      prometheus:
+        patterns:
+          - "github.com/prometheus/*"
+      ginkgo-gomega:
+        patterns:
+          - "github.com/onsi/ginkgo/*"
+          - "github.com/onsi/gomega"
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
**Background**

FB-1818: Dependabot opens a separate PR per dependency, so coordinated bumps (e.g. the `k8s.io/*` + `sigs.k8s.io/*` 0.36.1 → 0.36.2 set) arrive as many PRs that must be reviewed/merged in tandem.

**Summary**

Add grouped version updates (https://github.blog/changelog/2023-06-29-grouped-version-updates-for-dependabot-public-beta/) to `.github/dependabot.yml`:

- `gomod` ecosystem grouped by upstream: `kubernetes` (`k8s.io/*`, `sigs.k8s.io/*`), `opentelemetry` (`go.opentelemetry.io/*`), `golang-x` (`golang.org/x/*`), `prometheus` (`github.com/prometheus/*`), and `ginkgo-gomega` (`github.com/onsi/ginkgo/*`, `github.com/onsi/gomega`).
- `github-actions` ecosystem collapsed into a single `actions` wildcard (`*`) group.

Going forward, scheduled version updates within a group land in one PR instead of one-per-dependency. Existing `chore(deps):` commit prefix, `cooldown`, and PR limits are unchanged, and these PRs stay scoped to dependency manifests (no impact on the chart `appVersion` release glue). Security updates still open individually per Dependabot behavior.

**Test Plan**

Config-only change. Validated the YAML parses and conforms to the Dependabot v2 `groups` schema; grouping behavior is exercised by Dependabot on the next scheduled run.

Made with [Cursor](https://cursor.com)