### PR TITLE
build: default image variant to latest (FB-1835)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,8 @@ GINKGO_FOCUS="your test description" make test-e2e
 | `e2e,heavy` | Same as `e2e` but uses the heavy query configuration. |
 | `latest` | Swaps embedded defaults to `defaults.latest.env`. Combine with `e2e` for the latest-variant E2E run. |
 
+The rows above describe the raw Go build tags. The build tooling defaults the variant to **latest**: `IMAGE_VARIANT` defaults to `latest` in the `Makefile`, `Dockerfile.ci`, `scripts/load-e2e-images.sh`, and `scripts/ci/verify-quickstart-full.sh`, so `make build` / `make docker-build` / `make test-e2e` (and the released operator image and Helm chart) embed `defaults.latest.env` by default and add the `latest` tag. Set `IMAGE_VARIANT=dev` to build the `dev` variant. A bare `go build` / `go test` with no tag still embeds `defaults.dev.env`.
+
 ### Release workflow (main)
 
 [`/.github/workflows/release-main.yaml`](.github/workflows/release-main.yaml) runs on every push to `main`:

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -4,10 +4,10 @@ ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION=dev
 # IMAGE_VARIANT selects which config/images/defaults.<variant>.env file is
-# embedded into the binary. "dev" (the default) embeds defaults.dev.env;
-# "latest" embeds defaults.latest.env via the `latest` Go build tag. Any
-# other value is treated as "dev" (the !latest embed file matches).
-ARG IMAGE_VARIANT=dev
+# embedded into the binary. "latest" (the default) embeds defaults.latest.env
+# via the `latest` Go build tag; "dev" embeds defaults.dev.env. Any value
+# other than "latest" is treated as "dev" (the !latest embed file matches).
+ARG IMAGE_VARIANT=latest
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -5,17 +5,15 @@ LDFLAGS := -X main.version=$(VERSION)
 
 # IMAGE_VARIANT selects which config/images/defaults.<variant>.env file is
 # embedded into the operator binary and which images the E2E suite expects to
-# be loaded into Kind. "dev" (default) tracks the mutable `:dev` aliases on
-# the engine/metadata GHCR packages so a regression on `:dev` surfaces in CI
-# before a partner pulling `:dev` sees it; "latest" pins to release-* build
-# tags. "dev" stays the implicit default until the engine/metadata `:latest`
-# GHCR aliases (and the auto-PR that bumps `defaults.latest.env`) are in
-# place; once they land, flip the default back to "latest". The operator
-# binary, the gateway pod template the operator stamps out, the image-load
-# step, and the test process all derive their defaults from the same
-# variant — set IMAGE_VARIANT consistently across `build`,
-# `prepare-test-e2e`, and `test-e2e`.
-IMAGE_VARIANT ?= dev
+# be loaded into Kind. "latest" (default) pins to the release-* build tags in
+# defaults.latest.env and is what ships in the operator image and the Helm
+# chart; "dev" tracks the mutable `:dev` aliases on the engine/metadata GHCR
+# packages so a regression on `:dev` surfaces in CI before a partner pulling
+# `:dev` sees it. The operator binary, the gateway pod template the operator
+# stamps out, the image-load step, and the test process all derive their
+# defaults from the same variant — set IMAGE_VARIANT consistently across
+# `build`, `prepare-test-e2e`, and `test-e2e`.
+IMAGE_VARIANT ?= latest
 
 ifeq ($(IMAGE_VARIANT),latest)
 GO_BUILD_TAGS_BASE := latest

--- a/config/images/defaults.dev.env
+++ b/config/images/defaults.dev.env
@@ -1,10 +1,9 @@
-# Default image references for the "dev" build variant. This is the implicit
-# default — picked up by operator builds and the E2E suite when no extra Go
-# build tag is set (i.e. `make build` / `make test-e2e` with no
-# IMAGE_VARIANT). The "latest" variant must be opted into with
-# `IMAGE_VARIANT=latest` (which adds the `latest` build tag); once the
-# engine/metadata `:latest` GHCR aliases and the auto-PR that maintains
-# `defaults.latest.env` are in place, flip the default back to "latest".
+# Default image references for the "dev" build variant. Opt-in: picked up by
+# operator builds and the E2E suite when `IMAGE_VARIANT=dev` is set, which
+# builds without the `latest` Go build tag (the `!latest` embed file matches).
+# The "latest" variant (defaults.latest.env) is the implicit default that
+# ships in the operator image and the Helm chart and is what `make build` /
+# `make docker-build` / `make test-e2e` use when IMAGE_VARIANT is unset.
 #
 # Convention for the dev variant:
 #   - ENGINE_TAG / METADATA_TAG track the mutable `:dev` aliases on the

--- a/config/images/defaults.latest.env
+++ b/config/images/defaults.latest.env
@@ -1,10 +1,8 @@
-# Default image references for the "latest" build variant. Opt-in: picked up
-# by operator builds and the E2E suite when `IMAGE_VARIANT=latest` (which
-# adds the `latest` Go build tag). Until the engine/metadata `:latest` GHCR
-# aliases — and the auto-PR that bumps this file off them — are in place,
-# the project default is the "dev" variant; once they land, flip the
-# default back so this file is what ships in the operator image and the
-# Helm chart.
+# Default image references for the "latest" build variant. This is the
+# implicit default: it ships in the operator image and the Helm chart, and is
+# picked up by `make build` / `make docker-build` / `make test-e2e` when
+# IMAGE_VARIANT is unset (the `latest` Go build tag is on by default). The
+# "dev" variant (defaults.dev.env) must be opted into with `IMAGE_VARIANT=dev`.
 #
 # This file is rewritten by an automated PR whenever a new stable engine or
 # metadata release is published; the PR runs the full unit and E2E suite so a

--- a/config/images/images.go
+++ b/config/images/images.go
@@ -14,13 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package images embeds one of the variant-specific defaults files
-// (defaults.latest.env by default, defaults.dev.env when built with
-// `-tags=dev`) and exposes the image references used by both the operator
-// controllers and the E2E tests. The two variants must be consistent across
-// the operator binary, the gateway pod template it builds, and the E2E
-// suite — selecting them at compile time via a build tag is what enforces
-// that consistency.
+// Package images embeds one of the variant-specific defaults files and
+// exposes the image references used by both the operator controllers and the
+// E2E tests. The compile-time selector is the `latest` build tag:
+// defaults.latest.env is embedded with `-tags latest`, defaults.dev.env
+// without it. The build tooling (Makefile / Dockerfile.ci) defaults
+// IMAGE_VARIANT to "latest", so operator and chart builds embed
+// defaults.latest.env unless IMAGE_VARIANT=dev is set. The two variants must
+// be consistent across the operator binary, the gateway pod template it
+// builds, and the E2E suite — selecting them at compile time via a build tag
+// is what enforces that consistency.
 package images
 
 import (

--- a/scripts/ci/verify-quickstart-full.sh
+++ b/scripts/ci/verify-quickstart-full.sh
@@ -5,11 +5,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 source "${SCRIPT_DIR}/lib/verify-quickstart.sh"
 source "${SCRIPT_DIR}/lib/setup-floci.sh"
-# Honour the same IMAGE_VARIANT switch as the Makefile (default: dev) so this
-# script picks the matching defaults.<variant>.env that replaced the now-gone
-# defaults.env in commit 554d320.
-IMAGE_VARIANT="${IMAGE_VARIANT:-dev}"
-# shellcheck source=../../config/images/defaults.dev.env
+# Honour the same IMAGE_VARIANT switch as the Makefile (default: latest) so
+# this script picks the matching defaults.<variant>.env that replaced the
+# now-gone defaults.env in commit 554d320.
+IMAGE_VARIANT="${IMAGE_VARIANT:-latest}"
+# shellcheck source=../../config/images/defaults.latest.env
 set -a
 source "${REPO_ROOT}/config/images/defaults.${IMAGE_VARIANT}.env"
 set +a

--- a/scripts/load-e2e-images.sh
+++ b/scripts/load-e2e-images.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # into containerd by scripts/setup-kind-cluster.sh).
 #
 # All image values come from config/images/defaults.<variant>.env (single source
-# of truth, where <variant> is IMAGE_VARIANT, defaulting to "dev").
+# of truth, where <variant> is IMAGE_VARIANT, defaulting to "latest").
 #
 # IMAGE_VARIANT MUST match the build tag of the operator binary and the test
 # binary that will run after this script — otherwise the suite asks Kind for
@@ -32,7 +32,7 @@ set -euo pipefail
 
 CLUSTER_NAME="${1:-operator-test-e2e}"
 LOAD_PARALLELISM="${E2E_LOAD_PARALLELISM:-4}"
-IMAGE_VARIANT="${IMAGE_VARIANT:-dev}"
+IMAGE_VARIANT="${IMAGE_VARIANT:-latest}"
 
 # Local registry endpoints. The host-side endpoint is what `docker push`
 # talks to; the in-cluster endpoint is what containerd resolves through the


### PR DESCRIPTION
**Background**

FB-1835: Operator release and pre-release builds were still embedding `config/images/defaults.dev.env` (the mutable `:dev` engine/metadata aliases); they should ship the pinned `release-*` tags from `defaults.latest.env`.

**Summary**

Flip the default `IMAGE_VARIANT` from `dev` to `latest` so the implicit build variant is `latest` everywhere:

- `Makefile` — `IMAGE_VARIANT ?= latest`, which threads the `latest` Go build tag through `go build` / `go test` / `golangci-lint` / ginkgo by default.
- `Dockerfile.ci` — `ARG IMAGE_VARIANT=latest`. The release / pre-release jobs call `make docker-build` without an explicit `IMAGE_VARIANT`, so the shipped operator image now embeds `defaults.latest.env` with no workflow change.
- `scripts/load-e2e-images.sh` and `scripts/ci/verify-quickstart-full.sh` — standalone defaults flipped to `latest` (plus the shellcheck source hint) so a direct invocation matches the make default.
- `config/images/defaults.dev.env` / `defaults.latest.env` — header comments swapped so `latest` is documented as the implicit default and `dev` as opt-in.
- `config/images/images.go` — corrected the stale package doc (it referenced a non-existent `-tags=dev`) to describe the real `latest`-tag selector and the new tooling default.
- `AGENTS.md` — added a note under the build-tags table that the tooling now defaults `IMAGE_VARIANT` to `latest`.

Going forward, all release and pre-release operator images and the Helm chart embed the pinned `release-*` engine/metadata tags. The `dev` variant remains available via `IMAGE_VARIANT=dev` and is still exercised on every PR by the `dev`/`latest` matrix legs in `test.yaml` and `test-e2e.yaml`. A bare `go build` / `go test` with no tag still embeds `defaults.dev.env` (the `!latest` build constraint is unchanged).

**Test Plan**

- `make build` — compiles with `go build -tags "latest"` (embeds `defaults.latest.env`).
- `make lint` — runs `golangci-lint run --build-tags=latest`, 0 issues.
- CI: the dev/latest matrix legs in `test.yaml` and `test-e2e.yaml` continue to cover both variants on this PR.

Made with [Cursor](https://cursor.com)