### PR TITLE
ci(e2e): add workflow_dispatch trigger to E2E Tests (FB-1835)

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -2,6 +2,18 @@ name: E2E Tests
 
 on:
   pull_request:
+  # Manual trigger so the suite can run on demand without opening a PR — the
+  # mutable `:dev` engine/metadata aliases change continuously, and this lets
+  # a new `:dev` image be validated against the operator without an empty PR.
+  # `variant` selects which leg(s) run: "dev" (default) for the common
+  # dev-image check, "latest" for the pinned release-* images, or "both".
+  workflow_dispatch:
+    inputs:
+      variant:
+        description: Image variant(s) to run
+        type: choice
+        options: [dev, latest, both]
+        default: dev
 
 permissions: {}
 
@@ -29,9 +41,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          # The docs-only short-circuit only applies to pull_request events.
+          # A workflow_dispatch run is an explicit request to run the suite,
+          # so always run it (no PR diff exists to inspect anyway).
+          if [ "${EVENT_NAME}" != "pull_request" ]; then
+            echo "Event '${EVENT_NAME}' is not a pull_request; running full suite."
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           # List the PR's changed files via the compare API (no checkout
           # needed). "docs" = markdown anywhere, plus docs/.
           # Fail-safe: any uncertainty leaves docs_only=false so the full
@@ -65,9 +86,13 @@ jobs:
       # variant's failure from cancelling the other so a variant-specific
       # regression stays visible, and each matrix leg runs on its own
       # runner (so the hardcoded KIND_CLUSTER name does not collide).
+      #
+      # A pull_request always runs both legs (full merge gate). A manual
+      # workflow_dispatch runs only the selected `variant` input ("both"
+      # expands to the full pair).
       fail-fast: false
       matrix:
-        variant: [dev, latest]
+        variant: ${{ (github.event_name == 'pull_request' || inputs.variant == 'both') && fromJSON('["dev","latest"]') || fromJSON(format('["{0}"]', inputs.variant)) }}
     steps:
       - name: Clean Up Disk Space on public GitHub Runner
         if: runner.os == 'Linux'

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -213,9 +213,10 @@ jobs:
         run: |
           set -o pipefail
           go mod tidy
-          make prepare-test-e2e KIND_CLUSTER="e2e-ci" IMAGE_VARIANT=${{ matrix.variant }} 2>&1 | tee prepare-kind.log
+          make prepare-test-e2e KIND_CLUSTER="e2e-ci" IMAGE_VARIANT="${IMAGE_VARIANT}" 2>&1 | tee prepare-kind.log
         env:
           GOPRIVATE: github.com/firebolt-db/*
+          IMAGE_VARIANT: ${{ matrix.variant }}
 
       - name: Run E2E tests (${{ matrix.variant }} variant)
         id: run-e2e
@@ -224,10 +225,11 @@ jobs:
         # connection between the failing step and its log file.
         run: |
           set -o pipefail
-          make test-e2e KIND_CLUSTER="e2e-ci" IMAGE_VARIANT=${{ matrix.variant }} GINKGO_PROCS=6 2>&1 | tee run-e2e.log
+          make test-e2e KIND_CLUSTER="e2e-ci" IMAGE_VARIANT="${IMAGE_VARIANT}" GINKGO_PROCS=6 2>&1 | tee run-e2e.log
         env:
           GOPRIVATE: github.com/firebolt-db/*
           E2E_ARTIFACT_DIR: ${{ github.workspace }}
+          IMAGE_VARIANT: ${{ matrix.variant }}
 
       - name: E2E failure summary (JUnit)
         if: always()


### PR DESCRIPTION
**Background**

FB-1835: New mutable `:dev` engine/metadata images are published continuously, but the E2E Tests workflow only triggered `on: pull_request`, so the only way to validate a fresh `:dev` image against the operator was to open a throwaway (`--allow-empty`) PR.

**Summary**

Add a `workflow_dispatch` trigger to `.github/workflows/test-e2e.yaml` so the suite can be run on demand from the Actions UI / `gh workflow run`:

- A `variant` choice input (`dev` default, `latest`, or `both`) selects which leg(s) run. The common case — validating a new `:dev` image — is a one-click `dev` run.
- The docs-only detector now short-circuits only on `pull_request` events; any non-PR event (manual dispatch) always runs the suite, since there is no PR diff to inspect.
- The `matrix.variant` is event-aware: a `pull_request` always runs both legs (unchanged merge gate), while a `workflow_dispatch` honors the selected input (`both` expands to the full pair).

Going forward, a regression introduced by a new `:dev` image can be caught with a manual run instead of an empty PR. PR behavior and the `E2E Tests` required-check gate are unchanged.

Note: `workflow_dispatch` only becomes available from the UI/CLI once this lands on the default branch.

**Test Plan**

- `actionlint .github/workflows/test-e2e.yaml` — no findings.
- After merge: trigger `gh workflow run "E2E Tests" --field variant=dev` and confirm only the dev leg runs; confirm a PR still runs both legs.

Made with [Cursor](https://cursor.com)