### PR TITLE
ci: upgrade release-please-action to googleapis v5.0.0 (FB-2055)

### DIFF
--- a/.github/workflows/release-main.yaml
+++ b/.github/workflows/release-main.yaml
@@ -77,7 +77,7 @@ jobs:
           permission-pull-requests: write
 
       - name: Release Please
-        uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4.1.1
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Background
FB-2055 — the release automation action moved orgs (`google-github-actions` → `googleapis`); this moves the operator onto the current major, in sync with the internal repo and firebolt-instance-helm.

## Summary
Bumps the release action to `googleapis/release-please-action@v5.0.0` (SHA-pinned) in `.github/workflows/release-main.yaml`. v5.0.0 only upgrades the action runtime to Node 24 and the bundled release-please to 17.6.0; no action outputs changed, so the existing `releases_created` / `<path>--release_created` wiring is unchanged. Committed as `ci:` so the bump itself is non-releasable.

## Test Plan
- Release workflow parses and runs green on `main` after merge; release-please job produces no release when there is nothing to cut.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI dependency pin with no workflow logic or output wiring changes; risk is limited to release-please behavior regressions on `main` pushes.
> 
> **Overview**
> Updates the **Release Please** step in `.github/workflows/release-main.yaml` from `google-github-actions/release-please-action` v4.1.1 to **`googleapis/release-please-action` v5.0.0** (commit SHA pinned), matching the action’s new org and major version.
> 
> Workflow inputs (`config-file`, `manifest-file`, app token) and downstream use of `steps.release.outputs` (`releases_created`, per-component `release_created`, `tag_name`, `version`, `prs`) are unchanged; this is an action/runtime bump only (Node 24 and bundled release-please 17.x per v5 release notes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e9e33a8475913b261ff7f47c3a5c537f366543f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->