### PR TITLE
feat(storage)!: emit managed-table storage schema in the CLI/builder (FB-1684)

### DIFF
--- a/cmd/kubectl-firebolt/README.md
+++ b/cmd/kubectl-firebolt/README.md
@@ -35,7 +35,7 @@ kubectl firebolt engine list -n my-ns --instance my-instance -o wide
 kubectl firebolt engine create my-engine -n my-ns \
   --instance my-instance \
   [--bucket my-bucket] [--type <engine-class>] [--replicas 2] [--image <repo>:<tag>] \
-  [--storage-type gcs] [--api-scheme gs://] [--host-path /mnt/nvme] [--timeout 5m]
+  [--storage-type gcs] [--host-path /mnt/nvme] [--timeout 5m]
 kubectl firebolt engine port-forward my-engine -n my-ns --local-port 8123
 kubectl firebolt engine delete my-engine -n my-ns
 
@@ -53,7 +53,7 @@ omitted falls through to the operator's defaults or the referenced
 `FireboltEngineClass`. Flag rules:
 
 - `--instance` — always required.
-- `--bucket` — optional. When given, the plugin writes `customEngineConfig.storage` from `--bucket` plus `--storage-type` (backend selector — `s3` default; `gcs`, `minio`, …) and `--api-scheme` (`s3://` default; `gs://` for GCS) — not tied to S3. Object storage may instead be supplied by the referenced `FireboltEngineClass` (its `customEngineConfig` is inherited). When `--bucket` is omitted, `create` resolves the effective config — it fetches the `--type` class and checks whether *it* sets `customEngineConfig.storage.bucket_name` — and warns only if neither side provides a bucket (naming a class that doesn't configure storage still warns). The operator doesn't require storage, so this is a non-blocking warning. (Under `--print-commands` it falls back to the flag-only heuristic, since it doesn't touch the cluster.)
+- `--bucket` — optional. When given, the plugin writes `customEngineConfig.storage` from `--bucket` plus `--storage-type` (managed-table backend — `s3` default; `gcs`, `abs`), setting `managed_table_storage` and `managed_table_bucket_name`. Object storage may instead be supplied by the referenced `FireboltEngineClass` (its `customEngineConfig` is inherited). When `--bucket` is omitted, `create` resolves the effective config — it fetches the `--type` class and checks whether *it* sets `customEngineConfig.storage.managed_table_bucket_name` — and warns only if neither side provides a bucket (naming a class that doesn't configure storage still warns). The operator doesn't require storage, so this is a non-blocking warning. (Under `--print-commands` it falls back to the flag-only heuristic, since it doesn't touch the cluster.)
 - `--replicas` — defaults to `1`. `--replicas 0` is scale-to-zero: the operator parks the engine in the terminal `Stopped` phase (`Ready=False` by design), so `create` skips the readiness wait instead of blocking until it times out.
 - `--type` — a FireboltEngineClass to reference by name (`engineClassRef`). Optional; omit for no class reference. There is no default class — when omitted, the operator's built-in defaults apply (no class is merged).
 - `--image` — optional; omit to use the operator's embedded default image, pass to override.

--- a/cmd/kubectl-firebolt/main.go
+++ b/cmd/kubectl-firebolt/main.go
@@ -230,7 +230,6 @@ func newEngineCreateCmd() *cobra.Command {
 		engineType  string
 		image       string
 		bucket      string
-		apiScheme   string
 		storageType string
 		hostPath    string
 		timeout     string
@@ -252,7 +251,6 @@ func newEngineCreateCmd() *cobra.Command {
 				Replicas:     replicas,
 				Image:        image,
 				Bucket:       bucket,
-				APIScheme:    apiScheme,
 				StorageType:  storageType,
 				HostPath:     hostPath,
 				EngineType:   engineType,
@@ -298,8 +296,8 @@ func newEngineCreateCmd() *cobra.Command {
 	f.StringVar(&image, "image", "", "Container image in repository:tag form; omit to use the operator's default image")
 	f.StringVar(&bucket, "bucket", "",
 		"Object-storage bucket for managed storage; omit to inherit it from the FireboltEngineClass (--type)")
-	f.StringVar(&storageType, "storage-type", "s3", "Object-storage backend type (e.g. s3, gcs, minio); applies to --bucket")
-	f.StringVar(&apiScheme, "api-scheme", "s3://", "Object-storage scheme for --bucket (e.g. s3://, gs:// for GCS)")
+	f.StringVar(&storageType, "storage-type", "s3",
+		"Managed-table storage backend for --bucket: s3 (default), gcs, or abs")
 	f.StringVar(&hostPath, "host-path", "",
 		"Back the engine data volume with a node hostPath at this path; omit for the operator default (emptyDir)")
 	f.StringVar(&timeout, "timeout", infra.DefaultReadyTimeout,

--- a/config/images/defaults.latest.env
+++ b/config/images/defaults.latest.env
@@ -21,9 +21,9 @@
 #     test/e2e/e2e_suite_test.go's SynchronizedBeforeSuite.
 
 ENGINE_IMAGE=ghcr.io/firebolt-db/engine
-ENGINE_TAG=release-5.0.1-0.20260622084213.3ef06de4e9aa
+ENGINE_TAG=release-5.0.1-0.20260708122433.9067f7d2c465
 METADATA_IMAGE=ghcr.io/firebolt-db/metadata
-METADATA_TAG=release-5.0.1-0.20260622084213.3ef06de4e9aa
+METADATA_TAG=release-5.0.1-0.20260708122433.9067f7d2c465
 POSTGRES_IMAGE=postgres:16-alpine
 ENVOY_IMAGE=envoyproxy/envoy
 ENVOY_TAG=v1.37.2

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -47,6 +47,7 @@
                 "group": "Object storage",
                 "pages": [
                   "engine/object-storage/amazon-s3",
+                  "engine/object-storage/s3-compatible",
                   "engine/object-storage/google-cloud-storage",
                   "engine/object-storage/azure-blob-storage"
                 ]

--- a/docs/engine/object-storage/amazon-s3.mdx
+++ b/docs/engine/object-storage/amazon-s3.mdx
@@ -4,6 +4,10 @@ description: Configure Amazon S3 as the backing object storage for Firebolt Oper
 sidebarTitle: Amazon S3
 ---
 
+<Warning>
+  **Breaking change.** Managed-table storage now uses `managed_table_storage` and `managed_table_bucket_name` with a per-cloud `storage.aws` / `gcp` / `azure` block. The former keys — `type`, `api_scheme`, `bucket_name`, and the `minio` / `azurite` types — are removed and are rejected by the engine at startup. This schema requires a recent engine image; keep the operator and engine on matching versions.
+</Warning>
+
 Every `FireboltEngine` requires object storage for managed tablet data. The Firebolt Operator does not support local filesystem storage mode, so an engine does not start until you point it at object storage. On a production cluster, that backing store is an Amazon S3 bucket.
 
 With S3 as the backing store for table data, durability does not depend on the per-pod data volumes mounted to each engine node. Even a complete loss of those volumes does not cause data loss, because the authoritative copy of managed table data lives in the bucket.
@@ -119,7 +123,7 @@ Create an IAM role with the following IAM policy. It grants the engine permissio
 
 Point the engine at the bucket through `spec.customEngineConfig.storage` and run its pods under the ServiceAccount that carries the IAM role.
 
-The engine merges `customEngineConfig` into its rendered configuration, so the `storage` block sets the storage backend (`type`), the storage scheme (`api_scheme`), and the bucket name (`bucket_name`). For Amazon S3, set `type` to `s3`.
+The engine merges `customEngineConfig` into its rendered configuration, so the `storage` block sets the storage backend (`managed_table_storage`) and the bucket name (`managed_table_bucket_name`). For Amazon S3, set `managed_table_storage` to `s3`.
 
 The following manifest creates the ServiceAccount and a `FireboltEngine` that references it. The engine runs the operator's default image, so no `FireboltEngineClass` is required. Replace the IAM role ARN and bucket name with your values, and reference an existing `Ready` instance through `instanceRef`.
 
@@ -144,9 +148,8 @@ spec:
   replicas: 2
   customEngineConfig:
     storage:
-      type: s3
-      api_scheme: "s3://"
-      bucket_name: firebolt-engine-demo-data
+      managed_table_storage: s3
+      managed_table_bucket_name: firebolt-engine-demo-data
   template:
     spec:
       containers:
@@ -179,9 +182,8 @@ spec:
   serviceAccountName: my-engine
   customEngineConfig:
     storage:
-      type: s3
-      api_scheme: "s3://"
-      bucket_name: firebolt-engine-demo-data
+      managed_table_storage: s3
+      managed_table_bucket_name: firebolt-engine-demo-data
   template:
     spec:
       containers:
@@ -250,9 +252,8 @@ spec:
   replicas: 2
   customEngineConfig:
     storage:
-      type: s3
-      api_scheme: "s3://"
-      bucket_name: firebolt-engine-demo-data
+      managed_table_storage: s3
+      managed_table_bucket_name: firebolt-engine-demo-data
       aws:
         intermediary_access_role: arn:aws:iam::<account-id>:role/firebolt-intermediary
 ```

--- a/docs/engine/object-storage/azure-blob-storage.mdx
+++ b/docs/engine/object-storage/azure-blob-storage.mdx
@@ -96,7 +96,7 @@ az identity federated-credential create \
 
 Point the engine at the container through `spec.customEngineConfig.storage` and run its pods under the ServiceAccount that carries the Azure identity.
 
-The engine merges `customEngineConfig` into its rendered configuration, so the `storage` block sets the storage backend (`type`), the storage scheme (`api_scheme`), and the container name (`bucket_name`). For Azure Blob Storage, set `type` to `abs`. The default scheme for `abs` is `azure://`.
+The engine merges `customEngineConfig` into its rendered configuration, so the `storage` block sets the storage backend (`managed_table_storage`) and the container name (`managed_table_bucket_name`). For Azure Blob Storage, set `managed_table_storage` to `abs`.
 
 The following manifest creates the ServiceAccount and a `FireboltEngine` that references it. The engine runs the operator's default image, so no `FireboltEngineClass` is required. Replace the managed identity client ID and container name with your values, and reference an existing `Ready` instance through `instanceRef`. The `azure.workload.identity/use` pod label is required for Workload ID to inject credentials.
 
@@ -121,9 +121,8 @@ spec:
   replicas: 2
   customEngineConfig:
     storage:
-      type: abs
-      api_scheme: "azure://"
-      bucket_name: firebolt-engine-demo-data
+      managed_table_storage: abs
+      managed_table_bucket_name: firebolt-engine-demo-data
       azure:
         storage_account_name: fireboltenginedemo
   template:
@@ -211,9 +210,8 @@ spec:
   replicas: 2
   customEngineConfig:
     storage:
-      type: abs
-      api_scheme: "azure://"
-      bucket_name: firebolt-engine-demo-data
+      managed_table_storage: abs
+      managed_table_bucket_name: firebolt-engine-demo-data
       azure:
         storage_account_name: fireboltenginedemo
         intermediary_service_principal_client_id: 35f11db5-082b-46e8-9f2f-5466d8630003

--- a/docs/engine/object-storage/google-cloud-storage.mdx
+++ b/docs/engine/object-storage/google-cloud-storage.mdx
@@ -68,7 +68,7 @@ gcloud iam service-accounts add-iam-policy-binding "${GSA_EMAIL}" \
 
 Point the engine at the bucket through `spec.customEngineConfig.storage` and run its pods under the ServiceAccount that carries the Google identity.
 
-The engine merges `customEngineConfig` into its rendered configuration, so the `storage` block sets the storage backend (`type`), the storage scheme (`api_scheme`), and the bucket name (`bucket_name`). For Google Cloud Storage, set `type` to `gcs`. The default scheme for `gcs` is `gs://`.
+The engine merges `customEngineConfig` into its rendered configuration, so the `storage` block sets the storage backend (`managed_table_storage`) and the bucket name (`managed_table_bucket_name`). For Google Cloud Storage, set `managed_table_storage` to `gcs`.
 
 The following manifest creates the ServiceAccount and a `FireboltEngine` that references it. The engine runs the operator's default image, so no `FireboltEngineClass` is required. Replace the service account email and bucket name with your values, and reference an existing `Ready` instance through `instanceRef`.
 
@@ -93,9 +93,8 @@ spec:
   replicas: 2
   customEngineConfig:
     storage:
-      type: gcs
-      api_scheme: "gs://"
-      bucket_name: firebolt-engine-demo-data
+      managed_table_storage: gcs
+      managed_table_bucket_name: firebolt-engine-demo-data
   template:
     spec:
       containers:
@@ -173,9 +172,8 @@ spec:
   replicas: 2
   customEngineConfig:
     storage:
-      type: gcs
-      api_scheme: "gs://"
-      bucket_name: firebolt-engine-demo-data
+      managed_table_storage: gcs
+      managed_table_bucket_name: firebolt-engine-demo-data
       gcp:
         intermediary_service_account_id: projects/my-project/serviceAccounts/firebolt-intermediary@my-project.iam.gserviceaccount.com
 ```

--- a/docs/engine/object-storage/s3-compatible.mdx
+++ b/docs/engine/object-storage/s3-compatible.mdx
@@ -1,0 +1,85 @@
+---
+title: S3-compatible storage
+description: Configure a non-AWS S3-compatible object store (Nebius, CoreWeave, MinIO, …) as the backing object storage for Firebolt Operator engines.
+sidebarTitle: S3-compatible
+---
+
+<Warning>
+  **Breaking change.** Managed-table storage now uses `managed_table_storage` and `managed_table_bucket_name` with a per-cloud `storage.aws` / `gcp` / `azure` block. The former keys — `type`, `api_scheme`, `bucket_name`, and the `minio` / `azurite` types — are removed and are rejected by the engine at startup. This schema requires a recent engine image; keep the operator and engine on matching versions.
+</Warning>
+
+Every `FireboltEngine` requires object storage for managed tablet data. Besides Amazon S3, the engine can use any **S3-compatible** object store — for example [Nebius](https://nebius.com/) Object Storage, [CoreWeave](https://www.coreweave.com/) Object Storage, or a self-hosted [MinIO](https://min.io/). You point the engine at the store's endpoint and supply credentials through the pod environment.
+
+## How it differs from Amazon S3
+
+For Amazon S3 you set only `managed_table_storage` and `managed_table_bucket_name`, and credentials come from the pod's AWS identity (IRSA / Pod Identity — see [Amazon S3](./amazon-s3)). For an S3-compatible store you additionally set, under `storage.aws`:
+
+- `endpoint` — the store's S3 API endpoint (`https://…`).
+- `path_style_addressing` — the addressing style. **This applies only to a custom (non-AWS) endpoint; it is ignored for Amazon S3.** Set it to match your provider:
+  - `true` (path-style, `endpoint/bucket/key`) — the default. Used by MinIO, Nebius, and most emulators.
+  - `false` (virtual-hosted, `bucket.endpoint/key`) — required by providers that support virtual-hosted addressing only, such as CoreWeave.
+- `verify_ssl` — set to `false` only for a store with a self-signed certificate or plain HTTP (for example a local emulator).
+
+Credentials are read from the AWS SDK environment chain, so set `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (and `AWS_REGION` if your store requires a specific signing region) on the engine container — typically from a Kubernetes `Secret`.
+
+## Nebius Object Storage
+
+Nebius exposes an S3 API at `https://storage.<region>.nebius.cloud` and supports path-style addressing (the default).
+
+Create a `Secret` from a Nebius static access key:
+
+```bash
+kubectl -n firebolt create secret generic nebius-s3-credentials \
+  --from-literal=AWS_ACCESS_KEY_ID=<nebius-access-key-id> \
+  --from-literal=AWS_SECRET_ACCESS_KEY=<nebius-secret>
+```
+
+```yaml
+apiVersion: compute.firebolt.io/v1alpha1
+kind: FireboltEngine
+metadata:
+  name: my-engine
+  namespace: firebolt
+spec:
+  instanceRef: quickstart
+  replicas: 1
+  customEngineConfig:
+    storage:
+      managed_table_storage: s3
+      managed_table_bucket_name: my-firebolt-bucket
+      aws:
+        endpoint: https://storage.us-central1.nebius.cloud
+        path_style_addressing: true # non-AWS S3-compatible store; ignored for AWS S3
+  template:
+    spec:
+      containers:
+        - name: engine
+          envFrom:
+            - secretRef:
+                name: nebius-s3-credentials # AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+```
+
+## CoreWeave Object Storage
+
+CoreWeave Object Storage supports virtual-hosted addressing only, so set `path_style_addressing: false`. Use the endpoint for your CoreWeave Object Storage account, and create a `Secret` (`coreweave-s3-credentials`) the same way as above.
+
+```yaml
+  customEngineConfig:
+    storage:
+      managed_table_storage: s3
+      managed_table_bucket_name: my-firebolt-bucket
+      aws:
+        endpoint: https://<coreweave-object-storage-endpoint>
+        path_style_addressing: false # CoreWeave supports virtual-hosted addressing only
+  template:
+    spec:
+      containers:
+        - name: engine
+          envFrom:
+            - secretRef:
+                name: coreweave-s3-credentials
+```
+
+## Verify
+
+Apply the manifest, wait for the engine to reach `Ready`, then run a small write/read (for example `CREATE TABLE` + `INSERT` + `SELECT`). Confirm objects appear under your bucket with the provider's CLI (`aws s3 ls s3://my-firebolt-bucket --endpoint-url <endpoint>`). See the [Quickstart](../../quickstart) for connecting to the engine.

--- a/docs/engineclass/overview.mdx
+++ b/docs/engineclass/overview.mdx
@@ -75,15 +75,21 @@ spec:
   replicas: 1
   customEngineConfig:
     storage:
-      type: minio
-      api_scheme: "s3://"
-      bucket_name: my-engine-bucket
-      minio:
+      managed_table_storage: s3
+      managed_table_bucket_name: my-engine-bucket
+      aws:
         endpoint: http://floci.firebolt.svc.cluster.local:4566
+        path_style_addressing: true # non-AWS S3-compatible store; ignored for AWS S3
   template:
     spec:
       containers:
         - name: engine
+          # floci is zero-auth, but the engine still signs S3 requests — supply any creds via env.
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              value: firebolt
+            - name: AWS_SECRET_ACCESS_KEY
+              value: firebolt
           resources:
             requests:
               cpu: "2"

--- a/docs/known_pages.json
+++ b/docs/known_pages.json
@@ -29,6 +29,8 @@
   "/engine/object-storage/azure-blob-storage/",
   "/engine/object-storage/google-cloud-storage",
   "/engine/object-storage/google-cloud-storage/",
+  "/engine/object-storage/s3-compatible",
+  "/engine/object-storage/s3-compatible/",
   "/engine/overview",
   "/engine/overview/",
   "/engineclass",

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -111,15 +111,21 @@ spec:
   replicas: 1
   customEngineConfig:
     storage:
-      type: minio
-      api_scheme: "s3://"
-      bucket_name: my-engine-bucket
-      minio:
+      managed_table_storage: s3
+      managed_table_bucket_name: my-engine-bucket
+      aws:
         endpoint: http://floci.firebolt.svc.cluster.local:4566
+        path_style_addressing: true # non-AWS S3-compatible store; ignored for AWS S3
   template:
     spec:
       containers:
         - name: engine
+          # floci is zero-auth, but the engine still signs S3 requests — supply any creds via env.
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              value: firebolt
+            - name: AWS_SECRET_ACCESS_KEY
+              value: firebolt
           resources:
             requests:
               cpu: "2"

--- a/examples/engine-basic.yaml
+++ b/examples/engine-basic.yaml
@@ -26,12 +26,12 @@ spec:
   replicas: 1
   customEngineConfig:
     storage:
-      type: minio
-      api_scheme: "s3://"
-      bucket_name: my-engine-bucket
-      minio:
+      managed_table_storage: s3
+      managed_table_bucket_name: my-engine-bucket
+      aws:
         # Same-namespace short name; floci must run in this engine's namespace.
         endpoint: http://floci:4566
+        path_style_addressing: true # non-AWS S3-compatible store; ignored for AWS S3
   # Per-engine pod overrides live under spec.template. The
   # operator owns container name "engine"; place per-pod tuning
   # (resources, env, volume mounts, affinity, ...) here.
@@ -39,6 +39,12 @@ spec:
     spec:
       containers:
         - name: engine
+          # floci is zero-auth, but the engine still signs S3 requests — supply any creds via env.
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              value: firebolt
+            - name: AWS_SECRET_ACCESS_KEY
+              value: firebolt
           resources:
             requests:
               cpu: "1"

--- a/examples/engine-image-override.yaml
+++ b/examples/engine-image-override.yaml
@@ -33,11 +33,11 @@ spec:
   replicas: 1
   customEngineConfig:
     storage:
-      type: minio
-      api_scheme: "s3://"
-      bucket_name: my-engine-bucket
-      minio:
+      managed_table_storage: s3
+      managed_table_bucket_name: my-engine-bucket
+      aws:
         endpoint: http://floci:4566
+        path_style_addressing: true # non-AWS S3-compatible store; ignored for AWS S3
   template:
     spec:
       containers:
@@ -48,6 +48,12 @@ spec:
           # pod replacement. Pinned digests can drop back to IfNotPresent.
           image: ghcr.io/firebolt-db/firebolt:dev-feature-x
           imagePullPolicy: Always
+          # floci is zero-auth, but the engine still signs S3 requests — supply any creds via env.
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              value: firebolt
+            - name: AWS_SECRET_ACCESS_KEY
+              value: firebolt
           resources:
             requests:
               cpu: "1"

--- a/examples/object-storage-local.yaml
+++ b/examples/object-storage-local.yaml
@@ -12,15 +12,15 @@
 #
 #   customEngineConfig:
 #     storage:
-#       type: minio                 # S3-compatible / emulator mode
-#       api_scheme: "s3://"
-#       bucket_name: my-engine-bucket
-#       minio:
+#       managed_table_storage: s3   # S3-compatible store via a custom endpoint
+#       managed_table_bucket_name: my-engine-bucket
+#       aws:
 #         endpoint: http://floci.firebolt.svc.cluster.local:4566
+#         path_style_addressing: true
 #
 # floci is zero-auth: requests are still SigV4-signed but the credentials are
-# not validated. `type: minio` makes the engine hardcode dummy credentials
-# internally, so no Secret or AWS env vars are needed.
+# not validated. Set any AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY on the engine
+# container (the AWS SDK env chain); floci accepts them.
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/examples/quickstart-website/quickstart.yaml
+++ b/examples/quickstart-website/quickstart.yaml
@@ -30,8 +30,8 @@ metadata:
   name: firebolt
 ---
 # floci: zero-auth S3-compatible emulator. Requests are still SigV4-signed but
-# the credentials are not validated, so `type: minio` (which makes the engine
-# use dummy credentials internally) needs no Secret or AWS env vars.
+# the credentials are not validated, so the engine only needs any
+# AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY env (set on the engine container).
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -191,11 +191,11 @@ spec:
   replicas: 1
   customEngineConfig:
     storage:
-      type: minio
-      api_scheme: "s3://"
-      bucket_name: my-engine-bucket
-      minio:
+      managed_table_storage: s3
+      managed_table_bucket_name: my-engine-bucket
+      aws:
         endpoint: http://floci.firebolt.svc.cluster.local:4566
+        path_style_addressing: true # non-AWS S3-compatible store; ignored for AWS S3
   # Per-engine pod overrides live under spec.template. The operator owns the
   # container named "engine"; put per-pod tuning (resources, env, image, ...)
   # here.
@@ -203,6 +203,12 @@ spec:
     spec:
       containers:
         - name: engine
+          # floci is zero-auth, but the engine still signs S3 requests — supply any creds via env.
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              value: firebolt
+            - name: AWS_SECRET_ACCESS_KEY
+              value: firebolt
           resources:
             requests:
               cpu: "2"

--- a/internal/infra/engine.go
+++ b/internal/infra/engine.go
@@ -55,14 +55,10 @@ type EngineSpec struct {
 	// customEngineConfig), so the builder guards on empty and omits the storage
 	// block entirely when unset rather than emitting an incomplete one.
 	Bucket string
-	// StorageType is the object-storage backend selector (e.g. "s3", "gcs",
-	// "minio") — customEngineConfig.storage.type. Every documented engine
-	// manifest sets it; without it the storage config is incomplete.
+	// StorageType is the managed-table storage backend selector (e.g. "s3",
+	// "gcs", "abs") — customEngineConfig.storage.managed_table_storage. Every
+	// documented engine manifest sets it; without it the storage config is incomplete.
 	StorageType string
-	// APIScheme is the object-storage scheme paired with Bucket (e.g. "s3://",
-	// "gs://"). Caller-controlled so the plugin is not tied to one cloud. Only
-	// used when Bucket is set.
-	APIScheme string
 	// HostPath, when set, backs the engine's data volume with a node hostPath
 	// at this path. Empty means no storage override is emitted — the operator's
 	// default (emptyDir) or the referenced class applies.
@@ -221,17 +217,15 @@ func buildFireboltEngine(namespace string, spec *EngineSpec) (*v1alpha1.Firebolt
 	// bucket is given; it may instead be inherited from the referenced
 	// FireboltEngineClass (its customEngineConfig deep-merges beneath the
 	// engine's), so --bucket is optional. The block needs a backend type plus the
-	// scheme and bucket name; type and scheme are caller-controlled (StorageType /
-	// APIScheme) so the plugin isn't tied to S3 — GCS/Azure work too. The builder
-	// guards on empty bucket so an unset bucket omits the block rather than
-	// emitting an incomplete one.
+	// bucket name; the backend is caller-controlled (StorageType) so the plugin
+	// isn't tied to S3 — GCS/ABS work too. The builder guards on empty bucket so
+	// an unset bucket omits the block rather than emitting an incomplete one.
 	var customConfig *apiextensionsv1.JSON
 	if spec.Bucket != "" {
 		raw, err := json.Marshal(map[string]any{
 			"storage": map[string]any{
-				"type":        spec.StorageType,
-				"api_scheme":  spec.APIScheme,
-				"bucket_name": spec.Bucket,
+				"managed_table_storage":     spec.StorageType,
+				"managed_table_bucket_name": spec.Bucket,
 			},
 		})
 		if err != nil {
@@ -297,7 +291,7 @@ func engineTemplate(spec *EngineSpec) *corev1.PodTemplateSpec {
 }
 
 // EngineClassProvidesStorage reports whether the named FireboltEngineClass
-// carries object-storage config (customEngineConfig.storage.bucket_name). A
+// carries object-storage config (customEngineConfig.storage.managed_table_bucket_name). A
 // referencing engine that sets no --bucket inherits the class's config, so this
 // lets `engine create` tell whether the effective config will actually have a
 // bucket rather than only checking that some class was named.
@@ -314,21 +308,21 @@ func (c *Client) EngineClassProvidesStorage(ctx context.Context, name string) (b
 }
 
 // customConfigHasBucket reports whether a customEngineConfig payload sets a
-// non-empty storage.bucket_name — the field the engine needs for managed object
-// storage, written the same way by --bucket and by a class.
+// non-empty storage.managed_table_bucket_name — the field the engine needs for
+// managed object storage, written the same way by --bucket and by a class.
 func customConfigHasBucket(raw *apiextensionsv1.JSON) bool {
 	if raw == nil || len(raw.Raw) == 0 {
 		return false
 	}
 	var cfg struct {
 		Storage struct {
-			BucketName string `json:"bucket_name"`
+			ManagedTableBucketName string `json:"managed_table_bucket_name"`
 		} `json:"storage"`
 	}
 	if err := json.Unmarshal(raw.Raw, &cfg); err != nil {
 		return false
 	}
-	return cfg.Storage.BucketName != ""
+	return cfg.Storage.ManagedTableBucketName != ""
 }
 
 // readyFromConditions reports the Ready condition's truth, or nil if absent.

--- a/internal/infra/engine_test.go
+++ b/internal/infra/engine_test.go
@@ -17,7 +17,6 @@ func sampleSpec() *EngineSpec {
 		Image:       "registry.example.com/engine:v1.2.3",
 		Bucket:      "my-test-bucket",
 		StorageType: "s3",
-		APIScheme:   "s3://",
 		HostPath:    "/mnt/data/my-engine",
 		EngineType:  "my-engine-class",
 	}
@@ -108,7 +107,7 @@ func TestCreateScriptIsApplyThenWaitNoPerEngineClass(t *testing.T) {
 		"registry.example.com/engine:v1.2.3",
 		"engineClassRef: my-engine-class",
 		"replicas: 4",
-		"bucket_name: my-test-bucket",
+		"managed_table_bucket_name: my-test-bucket",
 	} {
 		if !strings.Contains(script, want) {
 			t.Errorf("script missing %q:\n%s", want, script)
@@ -222,9 +221,9 @@ func TestCreateWithZeroReplicasSkipsReadyWait(t *testing.T) {
 	}
 }
 
-func TestStorageConfigSetsTypeSchemeAndBucket(t *testing.T) {
+func TestStorageConfigSetsBackendAndBucket(t *testing.T) {
 	raw := string(buildEngine(t).Spec.CustomEngineConfig.Raw)
-	for _, want := range []string{`"type":"s3"`, `"api_scheme":"s3://"`, `"bucket_name":"my-test-bucket"`} {
+	for _, want := range []string{`"managed_table_storage":"s3"`, `"managed_table_bucket_name":"my-test-bucket"`} {
 		if !strings.Contains(raw, want) {
 			t.Errorf("storage config missing %s, got %s", want, raw)
 		}
@@ -249,14 +248,13 @@ func TestBuildEngineOmitsStorageWhenBucketEmpty(t *testing.T) {
 func TestStorageBackendIsConfigurableNotHardcodedToS3(t *testing.T) {
 	spec := sampleSpec()
 	spec.StorageType = "gcs" // GCS, not S3
-	spec.APIScheme = "gs://"
 	e, err := buildFireboltEngine("test-ns", spec)
 	if err != nil {
 		t.Fatal(err)
 	}
 	raw := string(e.Spec.CustomEngineConfig.Raw)
-	if !strings.Contains(raw, `"type":"gcs"`) || !strings.Contains(raw, `"api_scheme":"gs://"`) {
-		t.Errorf("type/scheme must follow flags, got %s", raw)
+	if !strings.Contains(raw, `"managed_table_storage":"gcs"`) {
+		t.Errorf("backend must follow flags, got %s", raw)
 	}
 	if strings.Contains(raw, "s3") {
 		t.Errorf("must not hardcode s3, got %s", raw)
@@ -314,9 +312,9 @@ func TestCustomConfigHasBucket(t *testing.T) {
 		raw  string
 		want bool
 	}{
-		{"with bucket", `{"storage":{"type":"s3","bucket_name":"my-bucket"}}`, true},
-		{"storage but empty bucket", `{"storage":{"type":"s3","bucket_name":""}}`, false},
-		{"storage without bucket", `{"storage":{"type":"s3"}}`, false},
+		{"with bucket", `{"storage":{"managed_table_storage":"s3","managed_table_bucket_name":"my-bucket"}}`, true},
+		{"storage but empty bucket", `{"storage":{"managed_table_storage":"s3","managed_table_bucket_name":""}}`, false},
+		{"storage without bucket", `{"storage":{"managed_table_storage":"s3"}}`, false},
 		{"no storage section", `{"logging":{"level":"debug"}}`, false},
 		{"empty object", `{}`, false},
 	}

--- a/scripts/ci/verify-quickstart-basic.sh
+++ b/scripts/ci/verify-quickstart-basic.sh
@@ -24,19 +24,17 @@ kubectl apply -n "$NAMESPACE" -f "${REPO_ROOT}/examples/instance-basic.yaml"
 
 # Inject the top-level `storage:` block via spec.customEngineConfig so the
 # rendered config.yaml steers tablet I/O at floci instead of the local fs.
-# `type: minio` is what flips the engine's S3 client into MinIO-compat mode
-# and hardcodes the access/secret to firebolt/firebolt internally — floci is
-# zero-auth so those baked-in credentials sign requests just fine. There is
-# no tmp_bucket field in the YAML schema; managed and tmp tablets share
-# bucket_name.
+# managed_table_storage: s3 + aws.endpoint points the engine at floci; floci is
+# zero-auth, so the AWS_* creds from examples/engine-basic.yaml (preserved here,
+# since this patch only replaces customEngineConfig) sign requests fine.
 BUCKET="$FLOCI_BUCKET" ENDPOINT="$FLOCI_ENDPOINT" yq eval '
   (select(.kind == "FireboltEngine").spec.customEngineConfig) = {
     "storage": {
-      "type": "minio",
-      "api_scheme": "s3://",
-      "bucket_name": env(BUCKET),
-      "minio": {
-        "endpoint": env(ENDPOINT)
+      "managed_table_storage": "s3",
+      "managed_table_bucket_name": env(BUCKET),
+      "aws": {
+        "endpoint": env(ENDPOINT),
+        "path_style_addressing": true
       }
     }
   }

--- a/scripts/ci/verify-quickstart-full.sh
+++ b/scripts/ci/verify-quickstart-full.sh
@@ -79,13 +79,17 @@ BUCKET="$FLOCI_BUCKET" ENDPOINT="$FLOCI_ENDPOINT" CLASS="$ENGINE_CLASS_NAME" yq 
   (select(.kind == "FireboltEngine").spec.template.spec.containers[0].resources.limits.cpu) = "250m" |
   (select(.kind == "FireboltEngine").spec.template.spec.containers[0].resources.requests.memory) = "2Gi" |
   (select(.kind == "FireboltEngine").spec.template.spec.containers[0].resources.limits.memory) = "2Gi" |
+  (select(.kind == "FireboltEngine").spec.template.spec.containers[0].env) = [
+    {"name": "AWS_ACCESS_KEY_ID", "value": "firebolt"},
+    {"name": "AWS_SECRET_ACCESS_KEY", "value": "firebolt"}
+  ] |
   (select(.kind == "FireboltEngine").spec.customEngineConfig) = {
     "storage": {
-      "type": "minio",
-      "api_scheme": "s3://",
-      "bucket_name": env(BUCKET),
-      "minio": {
-        "endpoint": env(ENDPOINT)
+      "managed_table_storage": "s3",
+      "managed_table_bucket_name": env(BUCKET),
+      "aws": {
+        "endpoint": env(ENDPOINT),
+        "path_style_addressing": true
       }
     }
   }

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -352,6 +352,10 @@ func CreateEngineWithResources(ctx context.Context, instanceName, name string, r
 					Containers: []corev1.Container{{
 						Name:      computev1alpha1.EngineContainerName,
 						Resources: resources,
+						Env: []corev1.EnvVar{
+							{Name: "AWS_ACCESS_KEY_ID", Value: "firebolt"},
+							{Name: "AWS_SECRET_ACCESS_KEY", Value: "firebolt"},
+						},
 					}},
 				},
 			},
@@ -384,6 +388,10 @@ func createEngine(ctx context.Context, instanceName, name string, replicas int, 
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Name: computev1alpha1.EngineContainerName,
+						Env: []corev1.EnvVar{
+							{Name: "AWS_ACCESS_KEY_ID", Value: "firebolt"},
+							{Name: "AWS_SECRET_ACCESS_KEY", Value: "firebolt"},
+						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("100m"),
@@ -497,26 +505,25 @@ func DeleteFireboltEngineClass(ctx context.Context, name string) error {
 }
 
 // engineStorageConfig returns a customEngineConfig JSON blob that points
-// the engine's top-level `storage:` block at the given MinIO-compatible
+// the engine's top-level `storage:` block at the given S3-compatible
 // endpoint and bucket. Required when the engine runs in dedicated-pensieve
 // mode — the engine refuses to start with managed storage on a local fs,
-// and `storage.bucket_name` maps internally to the
+// and `storage.managed_table_bucket_name` maps internally to the
 // `firebolt.managed_storage.bucket_name_override` signal that toggles it
 // into object-storage mode (engine
 // src/Core/Application/Configuration/StorageConfig.cpp).
 //
-// `type: minio` also flips `firebolt.aws.use_minio=true` internally, which
-// hardcodes the S3 access/secret to `firebolt/firebolt`. Floci is zero-auth
-// (it accepts any SigV4-signed request) so those baked-in credentials work
-// against it without any env-var plumbing on the engine pod.
+// Floci is zero-auth (it accepts any SigV4-signed request), but the engine still
+// signs its requests, so the engine pod must carry AWS_ACCESS_KEY_ID /
+// AWS_SECRET_ACCESS_KEY env (any value); the caller sets these on the engine spec.
 func engineStorageConfig(bucket, endpoint string) *apiextensionsv1.JSON {
 	raw := fmt.Sprintf(`{
   "storage": {
-    "type": "minio",
-    "api_scheme": "s3://",
-    "bucket_name": %q,
-    "minio": {
-      "endpoint": %q
+    "managed_table_storage": "s3",
+    "managed_table_bucket_name": %q,
+    "aws": {
+      "endpoint": %q,
+      "path_style_addressing": true
     }
   }
 }`, bucket, endpoint)


### PR DESCRIPTION
# Description

Migrate the `kubectl-firebolt` engine builder and CLI to emit new
managed-table storage schema (no backward compatibility):

- `internal/infra/engine.go` — builder emits `managed_table_storage` +
  `managed_table_bucket_name` (was `type`/`api_scheme`/`bucket_name`);
  `EngineSpec.APIScheme` removed; `customConfigHasBucket` reads
  `managed_table_bucket_name`.
- `cmd/kubectl-firebolt/main.go` — `--storage-type` now sets
  `managed_table_storage`; `--api-scheme` flag removed.
- `examples/*` + `test/e2e/helpers_test.go` — new schema
  (`managed_table_storage: s3` + `aws.endpoint`); floci engines now carry
  `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` env (any value) because
  `type: minio` no longer hardcodes credentials.

## ⚠️ Breaking — version-matched with the engine

Unlike the GitOps compute charts (which need a transition flag because they deploy
to a mutable engine tag), the operator **ships version-matched with the engine**.
So there's no in-place straddle to support: this version emits config that
**requires a engine after** (packdb #23716) and does not produce config for
older engines. That's the release boundary, per the ask (CLI/builder build the new
storage type only, no back-compat).

# Issue

FB-1684

# How Has This Been Tested?

- `go build ./...` clean; `go test ./internal/infra/...` passes (builder + `customConfigHasBucket`).
- `go vet -tags e2e ./test/e2e/...` clean.

# Other comments to the reviewer

- Docs (`docs/**`, `cmd/kubectl-firebolt/README.md`) migrate in a follow-up commit on this branch.
- `internal/controller` envtest suite needs `KUBEBUILDER_ASSETS` (unavailable locally); untouched by this change.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking storage schema with no backward compatibility; misaligned operator/engine versions or unmigrated manifests will fail at engine startup, and floci/local setups now require explicit AWS env creds.
> 
> **Overview**
> **Breaking change:** managed-table storage moves from `type` / `api_scheme` / `bucket_name` (and `minio` / `azurite` types) to **`managed_table_storage`** + **`managed_table_bucket_name`**, with S3-compatible stores using **`storage.aws`** (`endpoint`, `path_style_addressing`, etc.). Docs call out that older keys are rejected at engine startup and operator/engine versions must match.
> 
> The **`kubectl firebolt engine create`** path and **`internal/infra`** builder now emit only the new keys; **`--api-scheme`** is removed and **`--storage-type`** maps to `managed_table_storage` (`s3`, `gcs`, `abs`). Class storage detection reads **`managed_table_bucket_name`**.
> 
> **Examples, quickstart, CI verify scripts, and e2e helpers** replace `type: minio` with `managed_table_storage: s3` + `aws.endpoint`, and add **`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`** on engine pods (the old minio type no longer injects dummy creds). A new **S3-compatible** doc page is added to the docs nav; default **engine/metadata image tags** are bumped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c12dd5078c7a13350b4f7fa9c895f9790ac4f498. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->