### PR TITLE
test(e2e): pin engine query-liveness gauges under real load (FB-2079)

### DIFF
--- a/internal/controller/engine_drain_block_test.go
+++ b/internal/controller/engine_drain_block_test.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2026 Firebolt Analytics.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	computev1alpha1 "github.com/firebolt-db/firebolt-kubernetes-operator/api/v1alpha1"
+	enginemetrics "github.com/firebolt-db/firebolt-kubernetes-operator/internal/metrics"
+)
+
+// TestReconcileDraining_BusyPodBlocksCleanup drives the FULL Reconcile
+// (not isPodDrained in isolation, which engine_scrape_test.go already pins)
+// through the draining phase against a live metrics endpoint: a draining-
+// generation pod reporting active queries must hold the engine in draining
+// with the drain-check requeue, and only after the gauges read zero may the
+// reconciler advance to cleaning and delete the old generation's resources.
+//
+// Transport: the default PodIP scrape mode dials http://<PodIP>:9090/metrics
+// with plain HTTP, so the test points the fixture pod's status.podIP at
+// 127.0.0.1 and serves a real exposition body on the metrics port. This
+// exercises the same read path production uses (getEngineState ->
+// checkDrainComplete -> podIPScraper -> parsePrometheusGauge) with no test
+// seam in the reconciler.
+func TestReconcileDraining_BusyPodBlocksCleanup(t *testing.T) {
+	lc := &net.ListenConfig{}
+	ln, err := lc.Listen(context.Background(), "tcp4", fmt.Sprintf("127.0.0.1:%d", MetricsPort))
+	if err != nil {
+		t.Skipf("cannot bind 127.0.0.1:%d for the fake engine metrics endpoint: %v", MetricsPort, err)
+	}
+	var body atomic.Value
+	body.Store("firebolt_running_queries 2\nfirebolt_suspended_queries 1\n")
+	srv := &http.Server{
+		ReadHeaderTimeout: time.Second,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = fmt.Fprint(w, body.Load().(string))
+		}),
+	}
+	go func() { _ = srv.Serve(ln) }()
+	defer func() { _ = srv.Close() }()
+
+	const (
+		ns       = "ns-drain"
+		instName = "parent"
+		engName  = "eng-drain"
+		oldGen   = 0
+		newGen   = 1
+	)
+	drainInterval := 2 * time.Second
+
+	sch := drainBlockTestScheme(t)
+
+	drainingGen := oldGen
+	engine := &computev1alpha1.FireboltEngine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       engName,
+			Namespace:  ns,
+			Finalizers: []string{finalizerName},
+			Generation: 1,
+		},
+		Spec: computev1alpha1.FireboltEngineSpec{
+			InstanceRef:        instName,
+			Replicas:           1,
+			DrainCheckInterval: &metav1.Duration{Duration: drainInterval},
+			// DrainCheckEnabled left nil: the effective default is true,
+			// which is exactly the production posture under test.
+		},
+		Status: computev1alpha1.FireboltEngineStatus{
+			Phase:              computev1alpha1.PhaseDraining,
+			CurrentGeneration:  newGen,
+			ActiveGeneration:   newGen,
+			DrainingGeneration: &drainingGen,
+			ObservedGeneration: 1,
+		},
+	}
+	instance := &computev1alpha1.FireboltInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: instName, Namespace: ns},
+		Spec:       computev1alpha1.FireboltInstanceSpec{ID: "01H000000000000000000DUMMY"},
+		Status: computev1alpha1.FireboltInstanceStatus{
+			MetadataEndpoint: "metadata." + ns + ".svc.cluster.local:50051",
+		},
+	}
+	oldSTS := drainBlockSTS(genResourceName(engName, oldGen, ""), ns, engName, oldGen)
+	newSTS := drainBlockSTS(genResourceName(engName, newGen, ""), ns, engName, newGen)
+	oldPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      genResourceName(engName, oldGen, "") + "-0",
+			Namespace: ns,
+			Labels: map[string]string{
+				LabelEngine:     engName,
+				LabelGeneration: strconv.Itoa(oldGen),
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "engine", Image: "x"}}},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			PodIP: "127.0.0.1",
+		},
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(sch).
+		WithObjects(instance, engine, oldSTS, newSTS, oldPod).
+		WithStatusSubresource(&computev1alpha1.FireboltEngine{}, &computev1alpha1.FireboltInstance{}).
+		Build()
+
+	r := &FireboltEngineReconciler{
+		Client:          cli,
+		Scheme:          sch,
+		MetricsRecorder: enginemetrics.NoOpEngineRecorder{},
+	}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: engName, Namespace: ns}}
+
+	// Phase 1: the pod reports active queries. Multiple consecutive
+	// reconciles must hold draining, keep the old STS, and requeue at the
+	// drain-check interval.
+	for i := 0; i < 3; i++ {
+		res, err := r.Reconcile(context.Background(), req)
+		if err != nil {
+			t.Fatalf("Reconcile #%d (busy): %v", i, err)
+		}
+		if res.RequeueAfter != drainInterval {
+			t.Fatalf("Reconcile #%d (busy): RequeueAfter = %v, want the drain-check interval %v", i, res.RequeueAfter, drainInterval)
+		}
+		got := drainBlockGetEngine(t, cli, engName, ns)
+		if got.Status.Phase != computev1alpha1.PhaseDraining {
+			t.Fatalf("Reconcile #%d (busy): phase = %q, want draining — a busy pod was released", i, got.Status.Phase)
+		}
+		if got.Status.DrainingGeneration == nil || *got.Status.DrainingGeneration != oldGen {
+			t.Fatalf("Reconcile #%d (busy): drainingGeneration = %v, want %d", i, got.Status.DrainingGeneration, oldGen)
+		}
+		if err := cli.Get(context.Background(), types.NamespacedName{Name: oldSTS.Name, Namespace: ns}, &appsv1.StatefulSet{}); err != nil {
+			t.Fatalf("Reconcile #%d (busy): old-generation STS gone while its pod had active queries: %v", i, err)
+		}
+	}
+
+	// Phase 2: queries finish. The next reconciles must advance through
+	// cleaning and delete the old generation's StatefulSet.
+	body.Store("firebolt_running_queries 0\nfirebolt_suspended_queries 0\n")
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := r.Reconcile(context.Background(), req); err != nil {
+			t.Fatalf("Reconcile (drained): %v", err)
+		}
+		got := drainBlockGetEngine(t, cli, engName, ns)
+		if got.Status.Phase == computev1alpha1.PhaseStable {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("engine never reached stable after drain completed; phase = %q", got.Status.Phase)
+		}
+	}
+
+	got := drainBlockGetEngine(t, cli, engName, ns)
+	if got.Status.DrainingGeneration != nil {
+		t.Errorf("drainingGeneration = %v after cleanup, want nil", *got.Status.DrainingGeneration)
+	}
+	err = cli.Get(context.Background(), types.NamespacedName{Name: oldSTS.Name, Namespace: ns}, &appsv1.StatefulSet{})
+	if !errors.IsNotFound(err) {
+		t.Errorf("old-generation STS still present after drain completed (err=%v), want deleted", err)
+	}
+	if err := cli.Get(context.Background(), types.NamespacedName{Name: newSTS.Name, Namespace: ns}, &appsv1.StatefulSet{}); err != nil {
+		t.Errorf("new-generation STS must survive cleanup: %v", err)
+	}
+}
+
+func drainBlockTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("clientgoscheme.AddToScheme: %v", err)
+	}
+	if err := computev1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("computev1alpha1.AddToScheme: %v", err)
+	}
+	return s
+}
+
+func drainBlockSTS(name, ns, engName string, gen int) *appsv1.StatefulSet {
+	replicas := int32(1)
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels: map[string]string{
+				LabelEngine:     engName,
+				LabelGeneration: strconv.Itoa(gen),
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{LabelEngine: engName}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{LabelEngine: engName}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "engine", Image: "x"}}},
+			},
+		},
+	}
+}
+
+func drainBlockGetEngine(t *testing.T, cli client.Client, name, ns string) *computev1alpha1.FireboltEngine {
+	t.Helper()
+	engine := &computev1alpha1.FireboltEngine{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Name: name, Namespace: ns}, engine); err != nil {
+		t.Fatalf("Get engine: %v", err)
+	}
+	return engine
+}

--- a/test/e2e/autostop_test.go
+++ b/test/e2e/autostop_test.go
@@ -1,0 +1,173 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2026 Firebolt Analytics.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	computev1alpha1 "github.com/firebolt-db/firebolt-kubernetes-operator/api/v1alpha1"
+	"github.com/firebolt-db/firebolt-kubernetes-operator/internal/controller"
+)
+
+// First end-to-end coverage for autoStop. Everything below rides the same
+// query-liveness scrape as the drain check (running+suspended gauges via
+// ApiserverProxy), so this spec exercises the operator's idleness signal
+// against a real engine: continuous load must pin the engine at
+// activeReplicas past the idle timeout, quiet must scale it to
+// idleReplicas=0 (phase stopped), and a fresh gateway wake-up annotation
+// must bring it back.
+const (
+	// autoStopIdleTimeout / autoStopPollInterval are aggressive so the
+	// idle scale-down lands within a test-friendly window. The busy-hold
+	// window is deliberately > idleTimeout: if activity did not refresh
+	// the idle clock, the engine would scale down mid-load and the hold
+	// assertion would catch it.
+	autoStopIdleTimeout  = 25 * time.Second
+	autoStopPollInterval = 5 * time.Second
+	autoStopBusyHold     = 40 * time.Second
+	// autoStopScaleTimeout bounds quiet -> stopped (idle clock + poll
+	// cadence + status/pod teardown) and wake -> stable.
+	autoStopScaleTimeout = 180 * time.Second
+)
+
+var _ = Describe("Firebolt Engine AutoStop", func() {
+	Describe("AutoStop Under Load", Ordered, func() {
+		var (
+			instanceName = "inst-autostop" + queryConfig.Suffix
+			engineName   = "test-autostop" + queryConfig.Suffix + "-engine"
+			clientPod    = "client-autostop" + queryConfig.Suffix
+			lc           *TestInstanceLifecycle
+		)
+		RegisterFailedSpecPodLogDump(&instanceName, &engineName)
+
+		BeforeAll(func() {
+			By("Setting up FireboltInstance with ApiserverProxy metric scraping")
+			var err error
+			lc, err = SetupTestInstanceWithScrapeMode(ctx, instanceName, computev1alpha1.MetricScrapeModeApiserverProxy)
+			Expect(err).NotTo(HaveOccurred())
+			By("Creating client pod")
+			Expect(CreateClientPod(ctx, clientPod)).To(Succeed())
+		})
+
+		AfterAll(func() {
+			By("Cleaning up autoStop test")
+			defer TeardownTestInstance(ctx, lc)
+			DeleteClientPod(ctx, clientPod)
+			Expect(DeleteEngine(ctx, engineName)).To(Succeed())
+			Expect(WaitForResourcesDeleted(ctx, engineName, resourceCleanupTimeout)).To(Succeed())
+		})
+
+		It("should hold replicas under load, stop when idle, and wake on request", func() {
+			By("Creating engine with autoStop enabled")
+			idleReplicas := int32(0)
+			Expect(CreateEngineWithAutoStop(ctx, instanceName, engineName, 1, &computev1alpha1.AutoStopSpec{
+				Enabled:        true,
+				ActiveReplicas: 1,
+				IdleReplicas:   &idleReplicas,
+				IdleTimeout:    &metav1.Duration{Duration: autoStopIdleTimeout},
+				PollInterval:   &metav1.Duration{Duration: autoStopPollInterval},
+			})).To(Succeed())
+			Expect(WaitForEngineReady(ctx, engineName, 1, clusterReadyTimeout)).To(Succeed())
+			Expect(WaitForEngineStable(ctx, engineName, clusterReadyTimeout)).To(Succeed())
+
+			By("Keeping the engine busy past the idle timeout")
+			// Two workers so consecutive queries overlap and every autoStop
+			// poll observes in-flight work.
+			stop := make(chan struct{})
+			var wg sync.WaitGroup
+			var succeeded, failed atomic.Int64
+			for i := 0; i < 2; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					defer GinkgoRecover()
+					for {
+						select {
+						case <-stop:
+							return
+						default:
+						}
+						if _, err := RunQuery(ctx, clientPod, engineName, computeBoundQuery); err != nil {
+							failed.Add(1)
+						} else {
+							succeeded.Add(1)
+						}
+					}
+				}()
+			}
+
+			Consistently(func(g Gomega) {
+				engine, err := GetEngine(ctx, engineName)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(engine.Spec.Replicas).To(Equal(int32(1)),
+					"autoStop scaled a busy engine down (reason=%s)", engine.Status.AutoStopReason)
+				g.Expect(string(engine.Status.Phase)).To(Equal(string(computev1alpha1.PhaseStable)))
+			}, autoStopBusyHold, 2*time.Second).Should(Succeed())
+
+			close(stop)
+			wg.Wait()
+			GinkgoWriter.Printf("Busy-hold load: %d succeeded, %d failed\n", succeeded.Load(), failed.Load())
+			Expect(succeeded.Load()).To(BeNumerically(">", 0),
+				"no query completed (%d failed); the busy-hold assertion proved nothing", failed.Load())
+
+			By("Waiting for the idle engine to scale down to zero")
+			Eventually(func(g Gomega) {
+				engine, err := GetEngine(ctx, engineName)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(engine.Spec.Replicas).To(Equal(int32(0)),
+					"autoStop did not scale the idle engine down (reason=%s, lastActivity=%v)",
+					engine.Status.AutoStopReason, engine.Status.LastActivityTime)
+			}, autoStopScaleTimeout, pollInterval).Should(Succeed())
+			Expect(WaitForEnginePhase(ctx, engineName, computev1alpha1.PhaseStopped, clusterTransitionTimeout)).To(Succeed())
+
+			By("Stamping a wake-up request the way the gateway does")
+			Expect(AnnotateEngine(ctx, engineName, controller.AnnotationWakeRequested,
+				time.Now().UTC().Format(time.RFC3339))).To(Succeed())
+
+			By("Waiting for the engine to wake back up to activeReplicas")
+			Eventually(func(g Gomega) {
+				engine, err := GetEngine(ctx, engineName)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(engine.Spec.Replicas).To(Equal(int32(1)),
+					"wake request was not honored (reason=%s)", engine.Status.AutoStopReason)
+			}, autoStopScaleTimeout, pollInterval).Should(Succeed())
+			Expect(WaitForEngineReady(ctx, engineName, 1, clusterReadyTimeout)).To(Succeed())
+			Expect(WaitForEngineStable(ctx, engineName, clusterReadyTimeout)).To(Succeed())
+
+			By("Verifying the woken engine serves queries")
+			output, err := RunQuery(ctx, clientPod, engineName, queryConfig.Query)
+			Expect(err).NotTo(HaveOccurred())
+			result, err := ParseQueryResult(output)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(queryConfig.Validator(result)).To(BeTrue(), "Query result validation failed")
+
+			By("Deleting engine")
+			Expect(DeleteEngine(ctx, engineName)).To(Succeed())
+			Expect(WaitForResourcesDeleted(ctx, engineName, resourceCleanupTimeout)).To(Succeed())
+		})
+	})
+})

--- a/test/e2e/drain_under_load_test.go
+++ b/test/e2e/drain_under_load_test.go
@@ -1,0 +1,204 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2026 Firebolt Analytics.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	computev1alpha1 "github.com/firebolt-db/firebolt-kubernetes-operator/api/v1alpha1"
+)
+
+// This spec is the consumer-side half of the query-liveness contract pinned
+// by engine_metrics_test.go: with drainCheckEnabled=true, a blue-green
+// rollout must HOLD the old generation in draining while queries are in
+// flight on its pods, and release it promptly once they finish. Every other
+// spec in the suite runs with the drain check off, so before this spec the
+// busy-pod-blocks-cleanup behavior had no end-to-end coverage at all — a
+// drain signal that always read "drained" (as engine builds before
+// 2026-07-07 produced) passed the whole suite.
+//
+// The instance uses metricScrapeMode=ApiserverProxy because the in-process
+// operator scrapes from the host, where kind pod IPs are unreachable.
+const (
+	// drainHoldWindow is how long the spec requires the draining phase to
+	// persist while old-generation pods are busy. With drainCheckInterval=2s
+	// this spans several consecutive drain probes, so a single spurious
+	// "drained" reading cannot pass.
+	drainHoldWindow = 15 * time.Second
+	// drainReleaseTimeout bounds draining -> cleaning -> stable after the
+	// load stops (the last in-flight query may still need to finish).
+	drainReleaseTimeout = 120 * time.Second
+	// rolloutToDrainingTimeout bounds creating -> switching -> draining for
+	// the new generation (pod schedule + engine boot + readiness).
+	rolloutToDrainingTimeout = 300 * time.Second
+
+	// drainRolloutTolerationKey is the no-op toleration the spec adds to
+	// the pod template purely to trigger a blue-green rollout. No node
+	// carries a matching taint, so scheduling is unaffected.
+	drainRolloutTolerationKey = "firebolt.io/e2e-drain-under-load"
+)
+
+// keepPodBusy loops the compute-bound query back-to-back against one pod IP
+// until stop is closed. Two workers so the busy signal has no gaps between
+// consecutive queries (kubectl-exec startup leaves ~0.5s holes with one).
+func keepPodBusy(ctx context.Context, clientPod, podIP string, stop <-chan struct{}) (wait func() (succeeded, failed int64)) {
+	var wg sync.WaitGroup
+	var succeeded, failed atomic.Int64
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer GinkgoRecover()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if _, err := RunQueryAgainstPodIP(ctx, clientPod, podIP, computeBoundQuery); err != nil {
+					failed.Add(1)
+				} else {
+					succeeded.Add(1)
+				}
+			}
+		}()
+	}
+	return func() (int64, int64) {
+		wg.Wait()
+		return succeeded.Load(), failed.Load()
+	}
+}
+
+var _ = Describe("Firebolt Engine Drain", func() {
+	Describe("Drain Under Load", Ordered, func() {
+		var (
+			instanceName = "inst-drain" + queryConfig.Suffix
+			engineName   = "test-drain" + queryConfig.Suffix + "-engine"
+			clientPod    = "client-drain" + queryConfig.Suffix
+			lc           *TestInstanceLifecycle
+		)
+		RegisterFailedSpecPodLogDump(&instanceName, &engineName)
+
+		BeforeAll(func() {
+			By("Setting up FireboltInstance with ApiserverProxy metric scraping")
+			var err error
+			lc, err = SetupTestInstanceWithScrapeMode(ctx, instanceName, computev1alpha1.MetricScrapeModeApiserverProxy)
+			Expect(err).NotTo(HaveOccurred())
+			By("Creating client pod")
+			Expect(CreateClientPod(ctx, clientPod)).To(Succeed())
+		})
+
+		AfterAll(func() {
+			By("Cleaning up drain-under-load test")
+			defer TeardownTestInstance(ctx, lc)
+			DeleteClientPod(ctx, clientPod)
+			Expect(DeleteEngine(ctx, engineName)).To(Succeed())
+			Expect(WaitForResourcesDeleted(ctx, engineName, resourceCleanupTimeout)).To(Succeed())
+		})
+
+		It("should hold the draining generation while queries are in flight and release it after", func() {
+			By("Creating engine with the drain check enabled")
+			Expect(CreateEngineWithDrainCheck(ctx, instanceName, engineName, 1)).To(Succeed())
+			Expect(WaitForEngineReady(ctx, engineName, 1, clusterReadyTimeout)).To(Succeed())
+			Expect(WaitForEngineStable(ctx, engineName, clusterReadyTimeout)).To(Succeed())
+
+			By("Resolving the active-generation pod")
+			_, activeGen, err := GetEngineGeneration(ctx, engineName)
+			Expect(err).NotTo(HaveOccurred())
+			oldPods, err := EnginePodsForGeneration(ctx, engineName, activeGen)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(oldPods).To(HaveLen(1))
+			oldPod := oldPods[0]
+			Expect(oldPod.Status.PodIP).NotTo(BeEmpty())
+
+			By("Starting continuous queries against the old-generation pod")
+			stop := make(chan struct{})
+			waitForLoad := keepPodBusy(ctx, clientPod, oldPod.Status.PodIP, stop)
+
+			By("Triggering a blue-green rollout via a no-op toleration")
+			Expect(UpdateEngineScheduling(ctx, engineName, nil, []corev1.Toleration{{
+				Key:      drainRolloutTolerationKey,
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}}, nil)).To(Succeed())
+
+			By("Waiting for the rollout to reach draining on the old generation")
+			Eventually(func(g Gomega) {
+				engine, err := GetEngine(ctx, engineName)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(engine.Status.Phase)).To(Equal(string(computev1alpha1.PhaseDraining)))
+				g.Expect(engine.Status.DrainingGeneration).NotTo(BeNil())
+				g.Expect(*engine.Status.DrainingGeneration).To(Equal(activeGen))
+			}, rolloutToDrainingTimeout, pollInterval).Should(Succeed())
+
+			By("Verifying the busy old generation is held in draining")
+			Consistently(func(g Gomega) {
+				engine, err := GetEngine(ctx, engineName)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(engine.Status.Phase)).To(Equal(string(computev1alpha1.PhaseDraining)),
+					"draining generation was released while its pod had queries in flight")
+				g.Expect(engine.Status.DrainingGeneration).NotTo(BeNil())
+
+				pod, err := k8sClient.CoreV1().Pods(testNamespace).Get(ctx, oldPod.Name, metav1.GetOptions{})
+				g.Expect(err).NotTo(HaveOccurred(), "old-generation pod disappeared mid-drain")
+				g.Expect(pod.DeletionTimestamp).To(BeNil(), "old-generation pod is terminating while busy")
+			}, drainHoldWindow, 1*time.Second).Should(Succeed())
+
+			By("Stopping the query load")
+			close(stop)
+			succeeded, failed := waitForLoad()
+			GinkgoWriter.Printf("Old-generation load: %d succeeded, %d failed\n", succeeded, failed)
+			Expect(succeeded).To(BeNumerically(">", 0),
+				"no query completed against the old pod (%d failed); the hold assertion proved nothing", failed)
+
+			By("Waiting for the drained generation to be released and cleaned")
+			Eventually(func(g Gomega) {
+				engine, err := GetEngine(ctx, engineName)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(engine.Status.Phase)).To(Equal(string(computev1alpha1.PhaseStable)))
+				g.Expect(engine.Status.DrainingGeneration).To(BeNil())
+
+				pods, err := EnginePodsForGeneration(ctx, engineName, activeGen)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(pods).To(BeEmpty(), "old-generation pods survived drain completion")
+			}, drainReleaseTimeout, pollInterval).Should(Succeed())
+
+			By("Verifying the new generation serves queries")
+			output, err := RunQuery(ctx, clientPod, engineName, queryConfig.Query)
+			Expect(err).NotTo(HaveOccurred())
+			result, err := ParseQueryResult(output)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(queryConfig.Validator(result)).To(BeTrue(), "Query result validation failed")
+
+			By("Deleting engine")
+			Expect(DeleteEngine(ctx, engineName)).To(Succeed())
+			Expect(WaitForResourcesDeleted(ctx, engineName, resourceCleanupTimeout)).To(Succeed())
+		})
+	})
+})

--- a/test/e2e/engine_metrics_test.go
+++ b/test/e2e/engine_metrics_test.go
@@ -1,0 +1,356 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2026 Firebolt Analytics.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// The operator's drain and autoStop logic trusts the engine to report
+// in-flight work through firebolt_running_queries + firebolt_suspended_queries
+// on the pod metrics port (internal/controller/constants.go). Unit tests cover
+// the operator's side of that contract with faked metric bodies; this spec
+// pins the engine's side: the running+suspended sum — the exact quantity
+// isPodDrained and scrapePodActiveQueries consume — must rise while a query
+// is in flight and settle back to its baseline once the load stops.
+const (
+	engineMetricsPort = 9090
+
+	metricRunningQueries   = "firebolt_running_queries"
+	metricSuspendedQueries = "firebolt_suspended_queries"
+	// metricAnyStateQueries counts queries the engine holds in ANY state,
+	// not just RUNNING/SUSPENDED. Tracked alongside the drain gauges so a
+	// failure can distinguish "the engine never saw the queries" from "the
+	// engine saw them but reported them outside RUNNING/SUSPENDED".
+	metricAnyStateQueries = "firebolt_queries"
+
+	// computeBoundQuery burns execution time with a negligible result set,
+	// while HeavyQuery's in-flight time is dominated by streaming its
+	// ~500MB result. The two shapes park an in-flight query in different
+	// engine states, and the drain gauge must count both.
+	// 300M rows keeps each execution multi-second but comfortably inside
+	// RunQuery's 33s curl budget (~60M rows/s observed on the e2e engine).
+	computeBoundQuery = "SELECT sum(x + 1) FROM generate_series(1, 300000000) g(x)"
+
+	// metricRiseWindow bounds how long each load shape keeps queries in
+	// flight while the gauge is polled. Continuous back-to-back queries
+	// run the whole window, so a functioning gauge has many chances to be
+	// observed above baseline.
+	metricRiseWindow = 45 * time.Second
+	// metricSettleTimeout bounds the wait for the gauge to return to its
+	// baseline after the query load stops -- the exact condition the drain
+	// check (isPodDrained) relies on to release pods.
+	metricSettleTimeout = 60 * time.Second
+	metricPollInterval  = 250 * time.Millisecond
+)
+
+// scrapeEnginePodMetrics fetches the Prometheus text exposition from an engine
+// pod's metrics endpoint, curl-ing the pod IP from inside the cluster via the
+// client pod (pod IPs are not routable from the host where this suite runs).
+func scrapeEnginePodMetrics(ctx context.Context, clientPod, podIP string) (string, error) {
+	url := fmt.Sprintf("http://%s:%d/metrics", podIP, engineMetricsPort)
+	args := kubectlArgs("exec", clientPod, "-n", testNamespace, "--",
+		"curl", "-sSf", "--connect-timeout", "2", "--max-time", "5", url)
+	cmd := exec.CommandContext(ctx, "kubectl", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("scraping %s: %w: %s", url, err, strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}
+
+// parseEngineGauge mirrors the operator's parsePrometheusGauge
+// (internal/controller/engine_state.go) line by line: skip blank and "#"
+// metadata lines, match the exact unlabeled sample name followed by a space,
+// strip an optional trailing timestamp ("<value> [<ts>]"), parse as float,
+// clamp to int64. The parser is duplicated here because the operator's is
+// unexported; the semantics must stay aligned so this spec measures exactly
+// the value the drain check consumes — any divergence (e.g. mishandling a
+// timestamped sample) would make the test disagree with production drain.
+func parseEngineGauge(body, name string) (int64, bool) {
+	prefix := name + " "
+	for _, line := range strings.Split(body, "\n") {
+		if line == "" || line[0] == '#' {
+			continue
+		}
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+		rest := strings.TrimSpace(line[len(prefix):])
+		if idx := strings.IndexByte(rest, ' '); idx >= 0 {
+			rest = rest[:idx]
+		}
+		v, err := strconv.ParseFloat(rest, 64)
+		if err != nil {
+			return 0, false
+		}
+		return int64(v), true
+	}
+	return 0, false
+}
+
+// parseActiveQueries returns firebolt_running_queries +
+// firebolt_suspended_queries — the drained/idle signal isPodDrained and
+// scrapePodActiveQueries compute. ok is false when either gauge is missing
+// or unparsable, matching the operator's fail-closed handling.
+func parseActiveQueries(body string) (int64, bool) {
+	running, okR := parseEngineGauge(body, metricRunningQueries)
+	suspended, okS := parseEngineGauge(body, metricSuspendedQueries)
+	if !okR || !okS {
+		return 0, false
+	}
+	return running + suspended, true
+}
+
+// queryGaugeLines extracts the query-state samples from a metrics body so a
+// failure message can show the interesting slice instead of the multi-
+// thousand-line exposition.
+func queryGaugeLines(body string) string {
+	var out []string
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, "firebolt_") && strings.Contains(line, "quer") {
+			out = append(out, line)
+		}
+	}
+	return strings.Join(out, "\n")
+}
+
+// gaugeLoadStats aggregates what was observed while a query load shape ran.
+type gaugeLoadStats struct {
+	succeeded, failed int64
+	failureReasons    map[string]int
+	sampleErrors      []string
+	// maxActive is the maximum running+suspended sum sampled from a single
+	// scrape — the quantity the pass/fail assertions use. The per-gauge
+	// maxima below are diagnostics only.
+	maxActive    int64
+	maxRunning   int64
+	maxSuspended int64
+	maxAnyState  int64
+	polls        int
+	lastBody     string
+}
+
+// observeGaugesUnderLoad keeps the given query continuously in flight
+// (back-to-back worker loops) for the whole window while polling the engine
+// pod's metrics endpoint, recording the maxima of the query-state gauges.
+func observeGaugesUnderLoad(ctx context.Context, clientPod, engineName, podIP, sql string, workers int, window time.Duration) gaugeLoadStats {
+	stats := gaugeLoadStats{failureReasons: map[string]int{}}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	var succeeded, failed atomic.Int64
+	var mu sync.Mutex
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer GinkgoRecover()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if _, err := RunQuery(ctx, clientPod, engineName, sql); err != nil {
+					failed.Add(1)
+					mu.Lock()
+					stats.failureReasons[categorizeQueryError(err.Error())]++
+					if len(stats.sampleErrors) < 3 {
+						msg := err.Error()
+						if len(msg) > 300 {
+							msg = msg[:300] + "..."
+						}
+						stats.sampleErrors = append(stats.sampleErrors, msg)
+					}
+					mu.Unlock()
+				} else {
+					succeeded.Add(1)
+				}
+			}
+		}()
+	}
+
+	deadline := time.Now().Add(window)
+	for time.Now().Before(deadline) {
+		body, err := scrapeEnginePodMetrics(ctx, clientPod, podIP)
+		if err == nil {
+			stats.polls++
+			stats.lastBody = body
+			if v, ok := parseActiveQueries(body); ok && v > stats.maxActive {
+				stats.maxActive = v
+			}
+			if v, ok := parseEngineGauge(body, metricRunningQueries); ok && v > stats.maxRunning {
+				stats.maxRunning = v
+			}
+			if v, ok := parseEngineGauge(body, metricSuspendedQueries); ok && v > stats.maxSuspended {
+				stats.maxSuspended = v
+			}
+			if v, ok := parseEngineGauge(body, metricAnyStateQueries); ok && v > stats.maxAnyState {
+				stats.maxAnyState = v
+			}
+		}
+		time.Sleep(metricPollInterval)
+	}
+
+	close(stop)
+	wg.Wait()
+	stats.succeeded = succeeded.Load()
+	stats.failed = failed.Load()
+	return stats
+}
+
+var _ = Describe("Firebolt Engine Metrics", func() {
+	Describe("Engine Query Metrics", Ordered, func() {
+		var (
+			instanceName = "inst-metrics" + queryConfig.Suffix
+			engineName   = "test-metrics" + queryConfig.Suffix + "-engine"
+			clientPod    = "client-metrics" + queryConfig.Suffix
+			lc           *TestInstanceLifecycle
+		)
+		RegisterFailedSpecPodLogDump(&instanceName, &engineName)
+
+		BeforeAll(func() {
+			By("Setting up FireboltInstance for engine metrics test")
+			var err error
+			lc, err = SetupTestInstance(ctx, instanceName)
+			Expect(err).NotTo(HaveOccurred())
+			By("Creating client pod")
+			Expect(CreateClientPod(ctx, clientPod)).To(Succeed())
+		})
+
+		AfterAll(func() {
+			By("Cleaning up engine metrics test")
+			defer TeardownTestInstance(ctx, lc)
+			DeleteClientPod(ctx, clientPod)
+			Expect(DeleteEngine(ctx, engineName)).To(Succeed())
+			Expect(WaitForResourcesDeleted(ctx, engineName, resourceCleanupTimeout)).To(Succeed())
+		})
+
+		It("should raise the active-query gauges (running+suspended) while queries are in flight", func() {
+			By("Creating engine with 1 replica")
+			Expect(CreateEngine(ctx, instanceName, engineName, 1)).To(Succeed())
+
+			By("Waiting for engine to become ready")
+			Expect(WaitForEngineReady(ctx, engineName, 1, clusterReadyTimeout)).To(Succeed())
+
+			By("Waiting for engine status to be stable")
+			Expect(WaitForEngineStable(ctx, engineName, clusterReadyTimeout)).To(Succeed())
+
+			By("Resolving the engine pod IP")
+			pods, err := k8sClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
+				LabelSelector: "firebolt.io/engine=" + engineName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			podIP := ""
+			for _, pod := range pods.Items {
+				if pod.Status.Phase == corev1.PodRunning && pod.Status.PodIP != "" {
+					podIP = pod.Status.PodIP
+					break
+				}
+			}
+			Expect(podIP).NotTo(BeEmpty(), "no running engine pod with an IP found")
+
+			By("Scraping the idle baseline")
+			body, err := scrapeEnginePodMetrics(ctx, clientPod, podIP)
+			Expect(err).NotTo(HaveOccurred())
+			baseline, ok := parseActiveQueries(body)
+			Expect(ok).To(BeTrue(),
+				"%s and/or %s missing from the engine metrics endpoint; the drain check fails closed without them.\nQuery-state gauges:\n%s",
+				metricRunningQueries, metricSuspendedQueries, queryGaugeLines(body))
+			GinkgoWriter.Printf("Idle baseline: active (running+suspended) = %d\n", baseline)
+
+			// Both load shapes keep two workers looping their query
+			// back-to-back so the engine is continuously busy for the whole
+			// observation window regardless of individual query duration.
+			By("Keeping compute-bound queries in flight while polling the gauge")
+			computeStats := observeGaugesUnderLoad(ctx, clientPod, engineName, podIP, computeBoundQuery, 2, metricRiseWindow)
+			By("Keeping streaming-heavy queries in flight while polling the gauge")
+			// A single worker: two concurrent ~500MB aggregations exceed the
+			// e2e engine's 1.73 GiB memory limit and OOM instead of running.
+			streamStats := observeGaugesUnderLoad(ctx, clientPod, engineName, podIP, HeavyQuery, 1, metricRiseWindow)
+
+			for _, phase := range []struct {
+				name  string
+				stats gaugeLoadStats
+			}{{"compute-bound", computeStats}, {"streaming-heavy", streamStats}} {
+				GinkgoWriter.Printf("%s load: %d succeeded, %d failed, %d polls; max active=%d (%s=%d, %s=%d), %s=%d\n",
+					phase.name, phase.stats.succeeded, phase.stats.failed, phase.stats.polls,
+					phase.stats.maxActive,
+					metricRunningQueries, phase.stats.maxRunning,
+					metricSuspendedQueries, phase.stats.maxSuspended,
+					metricAnyStateQueries, phase.stats.maxAnyState)
+				for reason, count := range phase.stats.failureReasons {
+					GinkgoWriter.Printf("  query failure category: %q x%d\n", reason, count)
+				}
+				for _, msg := range phase.stats.sampleErrors {
+					GinkgoWriter.Printf("  sample query error: %s\n", msg)
+				}
+			}
+
+			Expect(computeStats.succeeded+streamStats.succeeded).To(BeNumerically(">", 0),
+				"no query completed successfully (%d failed); cannot judge the gauge without real in-flight queries",
+				computeStats.failed+streamStats.failed)
+
+			maxObserved := computeStats.maxActive
+			if streamStats.maxActive > maxObserved {
+				maxObserved = streamStats.maxActive
+			}
+			Expect(maxObserved).To(BeNumerically(">", baseline),
+				"active queries (%s+%s) never rose above the idle baseline (%d) while queries were continuously in flight "+
+					"(compute-bound: %d completed, max %s=%d; streaming-heavy: %d completed, max %s=%d) -- "+
+					"the drain check and autoStop cannot see in-flight work.\nQuery-state gauges in the last mid-load scrape:\n%s",
+				metricRunningQueries, metricSuspendedQueries, baseline,
+				computeStats.succeeded, metricAnyStateQueries, computeStats.maxAnyState,
+				streamStats.succeeded, metricAnyStateQueries, streamStats.maxAnyState,
+				queryGaugeLines(streamStats.lastBody))
+
+			By("Waiting for the active-query gauges to settle back to the baseline")
+			Eventually(func(g Gomega) {
+				body, err := scrapeEnginePodMetrics(ctx, clientPod, podIP)
+				g.Expect(err).NotTo(HaveOccurred())
+				v, ok := parseActiveQueries(body)
+				g.Expect(ok).To(BeTrue())
+				g.Expect(v).To(BeNumerically("<=", baseline),
+					"active queries (%s+%s) stuck above baseline after load stopped; isPodDrained would never release the pod",
+					metricRunningQueries, metricSuspendedQueries)
+			}, metricSettleTimeout, metricPollInterval).Should(Succeed())
+
+			By("Deleting engine")
+			Expect(DeleteEngine(ctx, engineName)).To(Succeed())
+
+			By("Waiting for all resources to be deleted")
+			Expect(WaitForResourcesDeleted(ctx, engineName, resourceCleanupTimeout)).To(Succeed())
+		})
+	})
+})

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -26,6 +26,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -287,7 +288,7 @@ func CreateEngine(ctx context.Context, instanceName, name string, replicas int) 
 // FireboltInstance with a specific rollout strategy. The engine container
 // image flows from the operator's embedded default.
 func CreateEngineWithRollout(ctx context.Context, instanceName, name string, replicas int, rollout string) error {
-	return createEngine(ctx, instanceName, name, replicas, rollout, nil)
+	return createEngine(ctx, instanceName, name, replicas, rollout, nil, nil)
 }
 
 // CreateEngineWithClass creates a FireboltEngine that references a
@@ -296,7 +297,32 @@ func CreateEngineWithRollout(ctx context.Context, instanceName, name string, rep
 // for the engine to resolve it. Image override and shared pod-spec
 // defaults flow from the class template.
 func CreateEngineWithClass(ctx context.Context, instanceName, name string, replicas int, classRef string) error {
-	return createEngine(ctx, instanceName, name, replicas, "graceful", &classRef)
+	return createEngine(ctx, instanceName, name, replicas, "graceful", &classRef, nil)
+}
+
+// CreateEngineWithDrainCheck creates a FireboltEngine like CreateEngine but
+// with the query-liveness drain check ON (the suite default is off because
+// most specs don't provision the ApiserverProxy scrape path the in-process
+// operator needs to reach pod metrics from the host). The instance MUST be
+// created with metricScrapeMode=ApiserverProxy (SetupTestInstanceWithScrapeMode),
+// otherwise the drain probe fails closed and every rollout wedges in draining.
+func CreateEngineWithDrainCheck(ctx context.Context, instanceName, name string, replicas int) error {
+	return createEngine(ctx, instanceName, name, replicas, "graceful", nil,
+		func(engine *computev1alpha1.FireboltEngine) {
+			enabled := true
+			engine.Spec.DrainCheckEnabled = &enabled
+		})
+}
+
+// CreateEngineWithAutoStop creates a FireboltEngine like CreateEngine but
+// with the given autoStop policy. Same ApiserverProxy requirement as
+// CreateEngineWithDrainCheck: the autoStop idleness scrape uses the same
+// pod-metrics transport as the drain check.
+func CreateEngineWithAutoStop(ctx context.Context, instanceName, name string, replicas int, autoStop *computev1alpha1.AutoStopSpec) error {
+	return createEngine(ctx, instanceName, name, replicas, "graceful", nil,
+		func(engine *computev1alpha1.FireboltEngine) {
+			engine.Spec.AutoStop = autoStop
+		})
 }
 
 // CreateBareEngineWithClassRef creates the minimum-viable
@@ -368,7 +394,10 @@ func CreateEngineWithResources(ctx context.Context, instanceName, name string, r
 	return cl.Create(ctx, engine)
 }
 
-func createEngine(ctx context.Context, instanceName, name string, replicas int, rollout string, classRef *string) error {
+// createEngine builds the suite's standard FireboltEngine and applies the
+// optional mutate hook right before the API write, so variant creators can
+// flip individual fields without duplicating the whole literal.
+func createEngine(ctx context.Context, instanceName, name string, replicas int, rollout string, classRef *string, mutate func(*computev1alpha1.FireboltEngine)) error {
 	cl, err := getCRDClient()
 	if err != nil {
 		return err
@@ -410,6 +439,10 @@ func createEngine(ctx context.Context, instanceName, name string, replicas int, 
 			Rollout:            computev1alpha1.RolloutStrategy(rollout),
 			CustomEngineConfig: engineStorageConfig(flociBucket, flociEndpoint),
 		},
+	}
+
+	if mutate != nil {
+		mutate(engine)
 	}
 
 	return cl.Create(ctx, engine)
@@ -1395,6 +1428,52 @@ func RunQuery(ctx context.Context, podName, engineName, query string) (string, e
 	return execCurlQuery(ctx, podName, url, query)
 }
 
+// RunQueryAgainstPodIP executes a SQL query against a specific engine pod's
+// IP, bypassing the cluster Service. Used by the drain spec to keep load on
+// the OLD generation after the Service selector has flipped to the new one —
+// exactly the traffic the drain check exists to protect.
+func RunQueryAgainstPodIP(ctx context.Context, podName, podIP, query string) (string, error) {
+	url := fmt.Sprintf("http://%s/?query_label=e2e-test&output_format=JSON_Compact",
+		net.JoinHostPort(podIP, "3473"))
+	return execCurlQuery(ctx, podName, url, query)
+}
+
+// EnginePodsForGeneration lists the pods of one engine generation.
+func EnginePodsForGeneration(ctx context.Context, engineName string, gen int) ([]corev1.Pod, error) {
+	pods, err := k8sClient.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("firebolt.io/engine=%s,firebolt.io/generation=%d", engineName, gen),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return pods.Items, nil
+}
+
+// GetEngine fetches the FireboltEngine CR from testNamespace.
+func GetEngine(ctx context.Context, name string) (*computev1alpha1.FireboltEngine, error) {
+	cl, err := getCRDClient()
+	if err != nil {
+		return nil, err
+	}
+	engine := &computev1alpha1.FireboltEngine{}
+	if err := cl.Get(ctx, types.NamespacedName{Name: name, Namespace: testNamespace}, engine); err != nil {
+		return nil, err
+	}
+	return engine, nil
+}
+
+// AnnotateEngine sets one annotation on the engine CR (retrying on
+// conflict). Used by the autoStop spec to stamp the gateway wake-up
+// annotation the way a real gateway would.
+func AnnotateEngine(ctx context.Context, name, key, value string) error {
+	return retryOnConflict(ctx, name, func(engine *computev1alpha1.FireboltEngine) {
+		if engine.Annotations == nil {
+			engine.Annotations = map[string]string{}
+		}
+		engine.Annotations[key] = value
+	})
+}
+
 // QueryResponse represents the JSON response from fb
 type QueryResponse struct {
 	Data [][]interface{} `json:"data"`
@@ -1619,6 +1698,14 @@ func (o *ClassOperator) Stop() {
 // CreateInstance creates a FireboltInstance CR with the given metadata images.
 // The gateway (Envoy proxy) image is set from the test suite's envoyImage/envoyTag.
 func CreateInstance(ctx context.Context, name, metadataImage, metadataTag string) error {
+	return createInstance(ctx, name, metadataImage, metadataTag, "")
+}
+
+// createInstance builds the suite's standard FireboltInstance. scrapeMode
+// sets spec.metricScrapeMode when non-empty; the in-process operators run on
+// the host, where kind pod IPs are unreachable, so specs that exercise the
+// drain check or autoStop scrape must use MetricScrapeModeApiserverProxy.
+func createInstance(ctx context.Context, name, metadataImage, metadataTag string, scrapeMode computev1alpha1.MetricScrapeMode) error {
 	cl, err := getCRDClient()
 	if err != nil {
 		return err
@@ -1641,7 +1728,8 @@ func CreateInstance(ctx context.Context, name, metadataImage, metadataTag string
 			Namespace: testNamespace,
 		},
 		Spec: computev1alpha1.FireboltInstanceSpec{
-			ID: ulid.MustNew(ulid.Now(), rand.Reader).String(),
+			ID:               ulid.MustNew(ulid.Now(), rand.Reader).String(),
+			MetricScrapeMode: scrapeMode,
 			Metadata: computev1alpha1.MetadataSpec{
 				Replicas: &replicas,
 				Template: &corev1.PodTemplateSpec{
@@ -1763,11 +1851,24 @@ type TestInstanceLifecycle struct {
 // handle that TeardownTestInstance consumes. Engine-operator options (e.g.
 // WithGC) are forwarded to the engine operator it starts.
 func SetupTestInstance(ctx context.Context, name string, opts ...EngineOperatorOption) (*TestInstanceLifecycle, error) {
+	return setupTestInstance(ctx, name, "", opts...)
+}
+
+// SetupTestInstanceWithScrapeMode is SetupTestInstance with an explicit
+// spec.metricScrapeMode on the FireboltInstance. Specs whose engines enable
+// the drain check or autoStop must pass MetricScrapeModeApiserverProxy: the
+// in-process operator scrapes pod metrics from the host, where kind pod IPs
+// (the PodIP default) are unreachable.
+func SetupTestInstanceWithScrapeMode(ctx context.Context, name string, scrapeMode computev1alpha1.MetricScrapeMode, opts ...EngineOperatorOption) (*TestInstanceLifecycle, error) {
+	return setupTestInstance(ctx, name, scrapeMode, opts...)
+}
+
+func setupTestInstance(ctx context.Context, name string, scrapeMode computev1alpha1.MetricScrapeMode, opts ...EngineOperatorOption) (*TestInstanceLifecycle, error) {
 	instanceOp, err := StartInstanceOperator(name)
 	if err != nil {
 		return nil, fmt.Errorf("start instance operator for %s: %w", name, err)
 	}
-	if err := CreateInstance(ctx, name, metadataImage, metadataTag); err != nil {
+	if err := createInstance(ctx, name, metadataImage, metadataTag, scrapeMode); err != nil {
 		instanceOp.Stop()
 		return nil, fmt.Errorf("create instance %s: %w", name, err)
 	}


### PR DESCRIPTION
**Background**

FB-2079: engine builds shipped a dead query-liveness signal (`firebolt_running_queries`/`firebolt_suspended_queries` stuck at 0) and no test noticed — the drain check and autoStop consume exactly those gauges, so both were blind in production.

**Summary**

Tests only; covers the query-liveness contract from both ends so this class of failure can't pass the suite again:

- **Engine Query Metrics** (e2e): a real engine must raise the running+suspended sum under load (compute-bound and streaming-heavy shapes) and settle back to baseline; the gauge parser mirrors the operator's exactly.
- **Drain Under Load** (e2e): first spec with the drain check enabled — a busy old generation is held in draining across several probe intervals and released+cleaned once its queries finish.
- **AutoStop Under Load** (e2e): first autoStop coverage — load holds activeReplicas past idleTimeout, quiet scales to 0/stopped, the gateway wake annotation restores it.
- **TestReconcileDraining_BusyPodBlocksCleanup** (controller): full Reconcile against a live metrics endpoint, no test seam — busy holds draining with the drain-check requeue, drained advances and deletes only the old generation.
- Helpers: ApiserverProxy instance setup (the in-process operator can't reach kind pod IPs from the host), drain-check/autoStop engine creators, pod-IP query runner.

**Test Plan**

All specs green against the current engine image, and each proven to have teeth: the three e2e specs fail on the pre-2026-07-07 engine whose gauges never moved, and the controller test fails when fed a drained body from the start (verified by negation).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to tests and e2e helpers; no production reconciler or API behavior is modified.
> 
> **Overview**
> Adds **test-only** coverage so dead `firebolt_running_queries` / `firebolt_suspended_queries` signals cannot pass CI again—drain check and autoStop both depend on that sum.
> 
> **E2E:** New specs assert the engine exposes rising then settling gauges under real load (`engine_metrics_test`), that blue-green drain **holds** the old generation while pod-IP traffic is busy and **releases** after (`drain_under_load_test`), and that autoStop **keeps** replicas under load, **scales to zero** when idle, and **wakes** on the gateway annotation (`autostop_test`). Drain/autoStop paths use **`MetricScrapeModeApiserverProxy`** via new `SetupTestInstanceWithScrapeMode` because in-process operators on the host cannot reach kind pod IPs.
> 
> **Controller:** `TestReconcileDraining_BusyPodBlocksCleanup` runs full `Reconcile` against a local HTTP metrics server (no fake scraper seam)—busy metrics block cleanup and requeue; zero gauges allow stable and old STS deletion.
> 
> **Helpers:** `createEngine` gains an optional mutate hook; creators for drain-check and autoStop engines; `RunQueryAgainstPodIP`, `EnginePodsForGeneration`, `GetEngine`, `AnnotateEngine`; shared `computeBoundQuery` in metrics/drain specs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5731b18bfce0787f134be9ccc5a80b671fe0c8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->