### PR TITLE
chore(deps): bump packdb engine/metadata to 5.0.1-0.20260709071413.53735f172429

### DIFF
--- a/config/images/defaults.latest.env
+++ b/config/images/defaults.latest.env
@@ -21,9 +21,9 @@
 #     test/e2e/e2e_suite_test.go's SynchronizedBeforeSuite.
 
 ENGINE_IMAGE=ghcr.io/firebolt-db/engine
-ENGINE_TAG=release-5.0.1-0.20260708122433.9067f7d2c465
+ENGINE_TAG=release-5.0.1-0.20260709071413.53735f172429
 METADATA_IMAGE=ghcr.io/firebolt-db/metadata
-METADATA_TAG=release-5.0.1-0.20260708122433.9067f7d2c465
+METADATA_TAG=release-5.0.1-0.20260709071413.53735f172429
 POSTGRES_IMAGE=postgres:16-alpine
 ENVOY_IMAGE=envoyproxy/envoy
 ENVOY_TAG=v1.37.2


### PR DESCRIPTION
## Summary

Bump default engine/metadata images to packdb `5.0.1-0.20260709071413.53735f172429`
— the build the engine/metadata `:latest` GHCR tags were just re-pointed to.

> [!NOTE]
> Opened automatically by packdb's `promote-ghcr-latest` workflow (weekly
> Monday refresh or a manual promotion) right after it re-pointed the
> engine/metadata `:latest` GHCR tags at this build, so `:latest` and this
> repo's pinned tags move together. An unmerged PR is overwritten by the
> next run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only pin bump with no application code changes; CI is expected to validate compatibility via unit and E2E on both image variants.
> 
> **Overview**
> Updates the **latest** image variant pins in `config/images/defaults.latest.env` so `ENGINE_TAG` and `METADATA_TAG` both move from `release-5.0.1-0.20260708122433.9067f7d2c465` to **`release-5.0.1-0.20260709071413.53735f172429`**, staying lockstep as required for operator/Helm defaults and E2E.
> 
> No other images or config change—this aligns the repo’s pinned release build with the packdb promotion that re-pointed GHCR `:latest` at the same build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e15ef548f013229fc53dde34a6bb590d1fc08c61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->