### PR TITLE
chore(deps): bump packdb engine/metadata to 5.0.1-0.20260713060957.513515666721

### DIFF
--- a/config/images/defaults.latest.env
+++ b/config/images/defaults.latest.env
@@ -21,9 +21,9 @@
 #     test/e2e/e2e_suite_test.go's SynchronizedBeforeSuite.
 
 ENGINE_IMAGE=ghcr.io/firebolt-db/engine
-ENGINE_TAG=release-5.0.1-0.20260709071413.53735f172429
+ENGINE_TAG=release-5.0.1-0.20260713060957.513515666721
 METADATA_IMAGE=ghcr.io/firebolt-db/metadata
-METADATA_TAG=release-5.0.1-0.20260709071413.53735f172429
+METADATA_TAG=release-5.0.1-0.20260713060957.513515666721
 POSTGRES_IMAGE=postgres:16-alpine
 ENVOY_IMAGE=envoyproxy/envoy
 ENVOY_TAG=v1.37.2


### PR DESCRIPTION
## Summary

Bump default engine/metadata images to packdb `5.0.1-0.20260713060957.513515666721`
— the build the engine/metadata `:latest` GHCR tags were just re-pointed to.

> [!NOTE]
> Opened automatically by packdb's `promote-ghcr-latest` workflow (weekly
> Monday refresh or a manual promotion) right after it re-pointed the
> engine/metadata `:latest` GHCR tags at this build, so `:latest` and this
> repo's pinned tags move together. An unmerged PR is overwritten by the
> next run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine autobump of container image pins only; behavior change is whatever the new engine/metadata build introduces, gated by the usual CI/E2E on this PR.
> 
> **Overview**
> Pins the **latest** default engine and metadata images in `config/images/defaults.latest.env` to packdb build `release-5.0.1-0.20260713060957.513515666721`, replacing the prior `…20260709071413…` tags. **ENGINE_TAG** and **METADATA_TAG** stay lockstep on the same release flavor, matching what GHCR `:latest` was just re-pointed to.
> 
> No other images or config change; operator/Helm defaults and E2E pulls pick up the new tags via the embedded defaults file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b4b55fc4f605056d1f5a7c37a4cadc60ebccd13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->