### PR TITLE
docs(storage): remove breaking-change notices from object-storage pages (FB-2168)

### DIFF
--- a/docs/engine/object-storage/amazon-s3.mdx
+++ b/docs/engine/object-storage/amazon-s3.mdx
@@ -4,10 +4,6 @@ description: Configure Amazon S3 as the backing object storage for Firebolt Oper
 sidebarTitle: Amazon S3
 ---
 
-<Warning>
-  **Breaking change.** Managed-table storage now uses `managed_table_storage` and `managed_table_bucket_name` with a per-cloud `storage.aws` / `gcp` / `azure` block. The former keys — `type`, `api_scheme`, `bucket_name`, and the `minio` / `azurite` types — are removed and are rejected by the engine at startup. This schema requires a recent engine image; keep the operator and engine on matching versions.
-</Warning>
-
 Every `FireboltEngine` requires object storage for managed tablet data. The Firebolt Operator does not support local filesystem storage mode, so an engine does not start until you point it at object storage. On a production cluster, that backing store is an Amazon S3 bucket.
 
 With S3 as the backing store for table data, durability does not depend on the per-pod data volumes mounted to each engine node. Even a complete loss of those volumes does not cause data loss, because the authoritative copy of managed table data lives in the bucket.

--- a/docs/engine/object-storage/s3-compatible.mdx
+++ b/docs/engine/object-storage/s3-compatible.mdx
@@ -4,10 +4,6 @@ description: Configure a non-AWS S3-compatible object store (Nebius, CoreWeave, 
 sidebarTitle: S3-compatible
 ---
 
-<Warning>
-  **Breaking change.** Managed-table storage now uses `managed_table_storage` and `managed_table_bucket_name` with a per-cloud `storage.aws` / `gcp` / `azure` block. The former keys — `type`, `api_scheme`, `bucket_name`, and the `minio` / `azurite` types — are removed and are rejected by the engine at startup. This schema requires a recent engine image; keep the operator and engine on matching versions.
-</Warning>
-
 Every `FireboltEngine` requires object storage for managed tablet data. Besides Amazon S3, the engine can use any **S3-compatible** object store — for example [Nebius](https://nebius.com/) Object Storage, [CoreWeave](https://www.coreweave.com/) Object Storage, or a self-hosted [MinIO](https://min.io/). You point the engine at the store's endpoint and supply credentials through the pod environment.
 
 ## How it differs from Amazon S3


### PR DESCRIPTION
# Description

Remove breaking-change notices from object-storage pages.

# Issue

FB-2168

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5b12406bf3b27e16bb927e0bcec90addcab8e74b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->