### PR TITLE
ci(helm): cover the engine web UI sidecar in the Helm test workflow (FB-2176)

### DIFF
--- a/.github/workflows/test-helm.yaml
+++ b/.github/workflows/test-helm.yaml
@@ -162,6 +162,12 @@ jobs:
       - name: Run helm-test target
         run: make helm-test
 
+      # Only place in CI that starts the operator-injected engine-web
+      # container against the real (mutable :latest) UI image, so a UI image
+      # regression against the injected pod spec surfaces here.
+      - name: Verify engine web UI sidecar
+        run: make helm-test-ui KIND_CLUSTER="${KIND_CLUSTER}"
+
       - name: Verify website quickstart bundle
         run: make helm-test-website KIND_CLUSTER="${KIND_CLUSTER}"
 

--- a/Makefile
+++ b/Makefile
@@ -256,6 +256,17 @@ helm-test-website: ## Verify the all-in-one website quickstart bundle (examples/
 	fi
 	./scripts/ci/verify-quickstart-website.sh
 
+.PHONY: helm-test-ui
+HELM_TEST_UI_NS ?= helm-verify-ui
+helm-test-ui: ## Verify the engine web UI sidecar (uiSidecar: true) serves on a chart-installed operator (kind).
+	@ctx="$$( $(KUBECTL) config current-context 2>/dev/null || true )"; \
+	if [ "$$ctx" != "$(HELM_TEST_CONTEXT)" ]; then \
+		echo "Refusing to run helm-test-ui on kube context '$$ctx' (expected '$(HELM_TEST_CONTEXT)')." >&2; \
+		echo "Switch context or override HELM_TEST_CONTEXT / KIND_CLUSTER explicitly." >&2; \
+		exit 1; \
+	fi
+	./scripts/ci/verify-ui-sidecar.sh "$(HELM_TEST_UI_NS)"
+
 .PHONY: helm-test-crds
 HELM_TEST_CRDS_NS ?= helm-verify-crds
 helm-test-crds: ## Verify the CRD chart installs within Helm's 1 MiB release-Secret cap (kind).

--- a/scripts/ci/verify-ui-sidecar.sh
+++ b/scripts/ci/verify-ui-sidecar.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify the built-in engine web UI sidecar end to end on a chart-installed
+# operator: deploy an instance and an engine with `uiSidecar: true`, then
+# assert that the injected `engine-web` container becomes Ready, still runs
+# under the hardened securityContext (readOnlyRootFilesystem), and actually
+# serves both the SPA index and the runtime /config.js over HTTP.
+#
+# The sidecar image is tracked at the mutable `:latest` alias, so this check
+# doubles as a canary for UI image regressions against the operator's
+# injected pod spec (e.g. an entrypoint change that conflicts with the
+# read-only root filesystem): nothing else in CI ever starts this container.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+source "${SCRIPT_DIR}/lib/verify-quickstart.sh"
+source "${SCRIPT_DIR}/lib/setup-floci.sh"
+# Sourced for CURL_IMAGE (the in-cluster HTTP probe pod); same variant switch
+# as the Makefile so the image matches what load-e2e-images.sh published.
+IMAGE_VARIANT="${IMAGE_VARIANT:-latest}"
+# shellcheck source=../../config/images/defaults.latest.env
+set -a
+source "${REPO_ROOT}/config/images/defaults.${IMAGE_VARIANT}.env"
+set +a
+
+NAMESPACE="${1:-helm-verify-ui}"
+INSTANCE_NAME="${INSTANCE_NAME:-firebolt}"
+ENGINE_NAME="${ENGINE_NAME:-engine}"
+FLOCI_BUCKET="${FLOCI_BUCKET:-${ENGINE_NAME}-bucket}"
+FLOCI_ENDPOINT="http://floci.${NAMESPACE}.svc.cluster.local:4566"
+UI_PORT=9100
+
+echo "=== verify-ui-sidecar (namespace=${NAMESPACE}) ==="
+kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+# Deploy floci and create the bucket before the engine starts: the engine
+# refuses to come up without bucket_name_override, and once configured it
+# will start hitting floci on its first reconcile pass.
+setup_floci "$NAMESPACE" "$FLOCI_BUCKET"
+
+kubectl apply -n "$NAMESPACE" -f "${REPO_ROOT}/examples/instance-basic.yaml"
+
+# engine-basic.yaml with two patches: floci-backed managed storage (same as
+# verify-quickstart-basic.sh) and the UI sidecar enabled.
+BUCKET="$FLOCI_BUCKET" ENDPOINT="$FLOCI_ENDPOINT" yq eval '
+  (select(.kind == "FireboltEngine").spec.uiSidecar) = true |
+  (select(.kind == "FireboltEngine").spec.customEngineConfig) = {
+    "storage": {
+      "managed_table_storage": "s3",
+      "managed_table_bucket_name": env(BUCKET),
+      "aws": {
+        "endpoint": env(ENDPOINT),
+        "path_style_addressing": true
+      }
+    }
+  }
+' "${REPO_ROOT}/examples/engine-basic.yaml" | kubectl apply -n "$NAMESPACE" -f -
+
+wait_instance_ready "$NAMESPACE" "$INSTANCE_NAME"
+wait_engine_ready "$NAMESPACE" "$ENGINE_NAME"
+
+engine_pod=$(kubectl get pod -n "$NAMESPACE" -l "firebolt.io/engine=${ENGINE_NAME}" \
+  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+if [[ -z "${engine_pod}" ]]; then
+  echo "No engine pod found with label firebolt.io/engine=${ENGINE_NAME} in namespace ${NAMESPACE}"
+  dump_namespace_debug "$NAMESPACE"
+  exit 1
+fi
+
+# The operator's own securityContext contract: the sidecar must stay
+# hardened. If this fails, a regression "fixed" the UI by loosening the
+# read-only root filesystem instead of keeping the image compatible with it.
+rofs=$(kubectl get pod "$engine_pod" -n "$NAMESPACE" \
+  -o jsonpath='{.spec.containers[?(@.name=="engine-web")].securityContext.readOnlyRootFilesystem}')
+if [[ "${rofs}" != "true" ]]; then
+  echo "engine-web readOnlyRootFilesystem = '${rofs:-<unset>}', expected 'true'"
+  dump_namespace_debug "$NAMESPACE"
+  exit 1
+fi
+echo "engine-web securityContext keeps readOnlyRootFilesystem=true"
+
+echo "Waiting for the engine-web container in ${engine_pod} to become Ready..."
+attempts=12
+for i in $(seq 1 "$attempts"); do
+  web_ready=$(kubectl get pod "$engine_pod" -n "$NAMESPACE" \
+    -o jsonpath='{.status.containerStatuses[?(@.name=="engine-web")].ready}' 2>/dev/null || echo "")
+  if [[ "${web_ready}" == "true" ]]; then
+    echo "engine-web Ready after ${i} attempts"
+    break
+  fi
+  if [[ "$i" == "$attempts" ]]; then
+    echo "Timed out waiting for the engine-web container to become Ready"
+    dump_namespace_debug "$NAMESPACE"
+    exit 1
+  fi
+  echo "  attempt ${i}/${attempts}: ready='${web_ready:-<none>}' (sleep 5s)"
+  sleep 5
+done
+
+# Hit the UI over the pod network from a throwaway curl pod: the SPA index
+# must answer 200 and /config.js must carry the runtime config the
+# entrypoint renders at startup.
+pod_ip=$(kubectl get pod "$engine_pod" -n "$NAMESPACE" -o jsonpath='{.status.podIP}')
+echo "Probing the Engine Web UI at ${pod_ip}:${UI_PORT} (index + /config.js)..."
+attempts=6
+for i in $(seq 1 "$attempts"); do
+  if output=$(kubectl run "ui-probe-$i" -n "$NAMESPACE" --rm -i --restart=Never \
+      --image="${CURL_IMAGE}" --quiet -- sh -c \
+      "curl -sf -o /dev/null http://${pod_ip}:${UI_PORT}/ && curl -sf http://${pod_ip}:${UI_PORT}/config.js" 2>/dev/null); then
+    if printf '%s' "$output" | grep -q "__FIREBOLT_CORE_CONFIG__"; then
+      echo "UI index answers 200 and /config.js carries the runtime config:"
+      printf '%s\n' "$output"
+      break
+    fi
+    echo "  attempt ${i}/${attempts}: /config.js answered without __FIREBOLT_CORE_CONFIG__:"
+    printf '%s\n' "$output"
+  fi
+  if [[ "$i" == "$attempts" ]]; then
+    echo "Timed out probing the Engine Web UI on ${pod_ip}:${UI_PORT}"
+    dump_namespace_debug "$NAMESPACE"
+    exit 1
+  fi
+  echo "  attempt ${i}/${attempts}: UI not answering yet (sleep 5s)"
+  sleep 5
+done
+
+echo "✅ verify-ui-sidecar passed (namespace=${NAMESPACE})"
+echo "Cleaning up namespace ${NAMESPACE}..."
+kubectl delete namespace "$NAMESPACE" --wait=false

--- a/scripts/load-e2e-images.sh
+++ b/scripts/load-e2e-images.sh
@@ -97,6 +97,7 @@ declare -a IMAGES=(
     "${POSTGRES_IMAGE}|pull"
     "${ENVOY_IMAGE}:${ENVOY_TAG}|pull"
     "${CURL_IMAGE}|pull"
+    "${ENGINE_WEB_IMAGE}:${ENGINE_WEB_TAG}|pull"
 )
 
 # Translate a Docker image reference (possibly without explicit registry


### PR DESCRIPTION
**Background**

FB-2176: nothing in CI ever started the operator-injected `engine-web` container, so a UI image regression against the injected pod spec (the read-only-rootfs crash a customer hit) shipped unnoticed — the sidecar image is tracked at the mutable `:latest` alias and can break with no operator code change.

**Summary**

- New `scripts/ci/verify-ui-sidecar.sh`, run as its own step in the Helm test workflow via `make helm-test-ui`: deploys an instance and an engine with `uiSidecar: true` on the chart-installed operator, then asserts the `engine-web` container becomes Ready, still runs with `readOnlyRootFilesystem: true` (the check guards the image/operator contract, not just "the UI works"), and serves both the SPA index and the runtime `/config.js` over HTTP.
- `scripts/load-e2e-images.sh` now publishes the UI image through the local kind registry mirror like the other workload images.

Going forward this doubles as a canary: a `firebolt-core-ui:latest` publish that breaks under the operator's hardened pod spec fails `Helm Tests` on every PR. No new required check — the step runs inside the existing `test-helm` job behind the `helm-required` gate.

**Test Plan**

The check itself is the coverage: engine-web readiness, securityContext hardening, and HTTP serving of the index and rendered runtime config, with the shared namespace debug dump on failure. Verified by running `make helm-test-ui` against a local kind cluster with the chart-installed operator (passes end to end), plus the image-load script publishing the UI image to the local registry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and image-loading only; no operator runtime or production deployment logic changes.
> 
> **Overview**
> Adds the **first CI path** that actually runs the operator-injected `engine-web` sidecar against the mutable `:latest` UI image, so UI regressions (e.g. breaking under `readOnlyRootFilesystem`) fail **Helm Tests** instead of shipping unnoticed.
> 
> A new `scripts/ci/verify-ui-sidecar.sh` deploys instance + engine with `uiSidecar: true` on the chart-installed operator, waits for readiness, asserts `engine-web` keeps `readOnlyRootFilesystem: true`, and HTTP-probes the SPA and `/config.js` for `__FIREBOLT_CORE_CONFIG__`. **`make helm-test-ui`** wires it with the same kind-context guard as other helm-verify targets; the **test-helm** workflow runs it after `helm-test` and before the website quickstart step.
> 
> **`load-e2e-images.sh`** now pulls and mirrors **`ENGINE_WEB_IMAGE`** into the kind registry so the sidecar can start in that cluster.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcdef4d066878184892edda0f47c502a35f6f2f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->