### PR TITLE
ci(helm): replay the workspace request contract in the UI sidecar check (FB-2176)

### DIFF
--- a/scripts/ci/ui-workspace-smoke.mjs
+++ b/scripts/ci/ui-workspace-smoke.mjs
@@ -55,38 +55,39 @@ await runButton
 console.log("Workspace rendered (run button visible).");
 
 // Type a query into the CodeMirror editor, replacing any template content.
+// The selected value and alias are unique to this run, so the success
+// assertion below cannot be satisfied by results or errors left on screen
+// by an earlier template/startup query — only by THIS query's rendered
+// result.
+const marker = `ui_smoke_${Date.now()}`;
+const markerValue = String(Math.floor(Date.now() / 1000));
 const editor = page.locator(".cm-content").first();
 await editor.click({ timeout: TIMEOUT_MS });
 await page.keyboard.press("ControlOrMeta+a");
-await page.keyboard.type("SELECT 42 AS ui_smoke;");
+await page.keyboard.type(`SELECT ${markerValue} AS ${marker};`);
 await runButton.first().click();
-console.log("Query submitted from the SQL editor.");
+console.log(`Query submitted from the SQL editor (marker column ${marker}).`);
 
-// Either the results grid renders with our value, or the workspace surfaced
-// a query error — both are deterministic outcomes; anything else times out.
-const outcome = await Promise.race([
-  page
+// Wait only for this query's own result (grid containing the unique marker
+// column). A visible query-error-message is NOT treated as an immediate
+// failure signal — one can legitimately linger from an earlier query while
+// ours is in flight — it is collected as a diagnostic on timeout instead.
+try {
+  await page
     .locator('[data-testid="datagrid"]')
-    .filter({ hasText: "42" })
+    .filter({ hasText: marker })
     .first()
-    .waitFor({ state: "visible", timeout: TIMEOUT_MS })
-    .then(() => "results"),
-  page
-    .locator('[data-testid="query-error-message"]')
-    .first()
-    .waitFor({ state: "visible", timeout: TIMEOUT_MS })
-    .then(() => "query-error"),
-]).catch(() => "timeout");
-
-if (outcome !== "results") {
-  const errText =
-    outcome === "query-error"
-      ? await page.locator('[data-testid="query-error-message"]').first().innerText()
-      : "(no results and no error rendered)";
-  fail(`query did not produce results (outcome=${outcome}): ${errText}; ` +
+    .waitFor({ state: "visible", timeout: TIMEOUT_MS });
+} catch {
+  const errLocator = page.locator('[data-testid="query-error-message"]').first();
+  const errText = (await errLocator.isVisible().catch(() => false))
+    ? await errLocator.innerText()
+    : "(no query error rendered)";
+  fail(`results grid never showed the marker column ${marker}; ` +
+    `last visible query error: ${errText}; ` +
     `page errors: ${JSON.stringify(pageErrors)}; failed requests: ${JSON.stringify(failedRequests)}`);
 }
-console.log("Results grid rendered the query result.");
+console.log("Results grid rendered this query's result (marker column found).");
 
 if (pageErrors.length > 0) {
   fail(`uncaught page errors during the session: ${JSON.stringify(pageErrors)}`);

--- a/scripts/ci/ui-workspace-smoke.mjs
+++ b/scripts/ci/ui-workspace-smoke.mjs
@@ -1,0 +1,96 @@
+// Browser smoke test for the Engine Web UI workspace, run by
+// verify-ui-sidecar.sh inside the pinned Playwright container.
+//
+// Loads the SPA in a real browser, runs a query from the SQL editor, and
+// asserts the result renders. This is the only layer that catches
+// client-side regressions (uncaught exceptions, request storms, broken
+// query construction) — server-side request replay cannot see JavaScript
+// that fails before a request is made.
+//
+// Selector contract with the webui repo (lite build): the run button
+// carries data-testid "execute-query-btn" (or
+// "execute-first-template-query-btn" for the first template script), the
+// results table is data-testid "datagrid", a failed query renders
+// data-testid "query-error-message", and the editor is CodeMirror
+// (".cm-content"). If webui renames these, this test fails loudly — update
+// both sides together.
+import { chromium } from "playwright";
+
+const BASE_URL = process.env.UI_BASE_URL ?? "http://localhost:9100";
+const TIMEOUT_MS = 60_000;
+
+const fail = msg => {
+  console.error(`FAIL: ${msg}`);
+  process.exit(1);
+};
+
+const browser = await chromium.launch();
+// A real browser always carries a locale; the bare container does not, and
+// the SPA's Intl usage throws "Incorrect locale information provided"
+// without one.
+const page = await browser.newPage({ locale: "en-US", timezoneId: "UTC" });
+
+const pageErrors = [];
+const failedRequests = [];
+page.on("pageerror", err => pageErrors.push(String(err)));
+page.on("response", resp => {
+  if (resp.status() >= 400) {
+    failedRequests.push(`${resp.status()} ${resp.request().method()} ${resp.url()}`);
+  }
+});
+
+console.log(`Loading ${BASE_URL} ...`);
+await page.goto(BASE_URL, { waitUntil: "load", timeout: TIMEOUT_MS });
+
+// The run button rendering means the workspace survived startup (engines
+// and databases resolved; no error boundary).
+const runButton = page.locator(
+  '[data-testid="execute-query-btn"], [data-testid="execute-first-template-query-btn"]'
+);
+await runButton
+  .first()
+  .waitFor({ state: "visible", timeout: TIMEOUT_MS })
+  .catch(() => fail(`workspace did not render a run button within ${TIMEOUT_MS}ms; ` +
+    `page errors: ${JSON.stringify(pageErrors)}; failed requests: ${JSON.stringify(failedRequests)}`));
+console.log("Workspace rendered (run button visible).");
+
+// Type a query into the CodeMirror editor, replacing any template content.
+const editor = page.locator(".cm-content").first();
+await editor.click({ timeout: TIMEOUT_MS });
+await page.keyboard.press("ControlOrMeta+a");
+await page.keyboard.type("SELECT 42 AS ui_smoke;");
+await runButton.first().click();
+console.log("Query submitted from the SQL editor.");
+
+// Either the results grid renders with our value, or the workspace surfaced
+// a query error — both are deterministic outcomes; anything else times out.
+const outcome = await Promise.race([
+  page
+    .locator('[data-testid="datagrid"]')
+    .filter({ hasText: "42" })
+    .first()
+    .waitFor({ state: "visible", timeout: TIMEOUT_MS })
+    .then(() => "results"),
+  page
+    .locator('[data-testid="query-error-message"]')
+    .first()
+    .waitFor({ state: "visible", timeout: TIMEOUT_MS })
+    .then(() => "query-error"),
+]).catch(() => "timeout");
+
+if (outcome !== "results") {
+  const errText =
+    outcome === "query-error"
+      ? await page.locator('[data-testid="query-error-message"]').first().innerText()
+      : "(no results and no error rendered)";
+  fail(`query did not produce results (outcome=${outcome}): ${errText}; ` +
+    `page errors: ${JSON.stringify(pageErrors)}; failed requests: ${JSON.stringify(failedRequests)}`);
+}
+console.log("Results grid rendered the query result.");
+
+if (pageErrors.length > 0) {
+  fail(`uncaught page errors during the session: ${JSON.stringify(pageErrors)}`);
+}
+
+await browser.close();
+console.log("UI workspace browser smoke passed.");

--- a/scripts/ci/verify-ui-sidecar.sh
+++ b/scripts/ci/verify-ui-sidecar.sh
@@ -184,6 +184,42 @@ for i in $(seq 1 "$attempts"); do
   sleep 5
 done
 
+# Drive the SPA in a real (containerized) browser: load the workspace, run a
+# query from the SQL editor, assert the results grid renders. This is the
+# only layer that catches client-side regressions — JavaScript that fails
+# before any request is made is invisible to the request replay above.
+# The Playwright image tag and npm package version MUST match so the
+# preinstalled browsers are reused (no download at run time).
+PLAYWRIGHT_VERSION="${PLAYWRIGHT_VERSION:-1.49.1}"
+PLAYWRIGHT_IMAGE="mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-noble"
+UI_SMOKE_PORT="${UI_SMOKE_PORT:-19100}"
+
+echo "Running the browser workspace smoke (${PLAYWRIGHT_IMAGE}) via port-forward on :${UI_SMOKE_PORT}..."
+kubectl port-forward -n "$NAMESPACE" "pod/${engine_pod}" "${UI_SMOKE_PORT}:${UI_PORT}" >/dev/null 2>&1 &
+pf_pid=$!
+trap 'kill "${pf_pid}" 2>/dev/null || true' EXIT
+for i in $(seq 1 10); do
+  curl -sf -o /dev/null "http://localhost:${UI_SMOKE_PORT}/" && break
+  if [[ "$i" == "10" ]]; then
+    echo "Port-forward to ${engine_pod}:${UI_PORT} never became reachable"
+    dump_namespace_debug "$NAMESPACE"
+    exit 1
+  fi
+  sleep 2
+done
+
+if ! docker run --rm --network host \
+    -v "${SCRIPT_DIR}/ui-workspace-smoke.mjs:/smoke.mjs:ro" \
+    -e "UI_BASE_URL=http://localhost:${UI_SMOKE_PORT}" \
+    "${PLAYWRIGHT_IMAGE}" \
+    bash -c "mkdir -p /tmp/smoke && cd /tmp/smoke && cp /smoke.mjs . \
+      && npm i --silent --no-audit --no-fund playwright@${PLAYWRIGHT_VERSION} >/dev/null 2>&1 \
+      && node smoke.mjs"; then
+  echo "Browser workspace smoke failed"
+  dump_namespace_debug "$NAMESPACE"
+  exit 1
+fi
+
 echo "✅ verify-ui-sidecar passed (namespace=${NAMESPACE})"
 echo "Cleaning up namespace ${NAMESPACE}..."
 kubectl delete namespace "$NAMESPACE" --wait=false

--- a/scripts/ci/verify-ui-sidecar.sh
+++ b/scripts/ci/verify-ui-sidecar.sh
@@ -140,10 +140,12 @@ done
 #      bearer token header), asserting the result payload comes back.
 default_database=$(printf '%s' "$output" | sed -n 's/.*defaultDatabase: "\([^"]*\)".*/\1/p')
 default_database="${default_database:-firebolt}"
+# `|| true` keeps a no-match grep (exit 1, fatal under `set -euo pipefail`)
+# from killing the script before the empty-chunk check below can report it.
 chunk=$(kubectl run "ui-chunk" -n "$NAMESPACE" --rm -i --restart=Never \
   --image="${CURL_IMAGE}" --quiet -- sh -c \
   "curl -sf http://${pod_ip}:${UI_PORT}/" 2>/dev/null \
-  | grep -o 'assets/index-[A-Za-z0-9_-]*\.js' | head -1)
+  | grep -o 'assets/index-[A-Za-z0-9_-]*\.js' | head -1 || true)
 if [[ -z "$chunk" ]]; then
   echo "index.html references no hashed bundle chunk (assets/index-*.js)"
   dump_namespace_debug "$NAMESPACE"

--- a/scripts/ci/verify-ui-sidecar.sh
+++ b/scripts/ci/verify-ui-sidecar.sh
@@ -4,8 +4,10 @@ set -euo pipefail
 # Verify the built-in engine web UI sidecar end to end on a chart-installed
 # operator: deploy an instance and an engine with `uiSidecar: true`, then
 # assert that the injected `engine-web` container becomes Ready, still runs
-# under the hardened securityContext (readOnlyRootFilesystem), and actually
-# serves both the SPA index and the runtime /config.js over HTTP.
+# under the hardened securityContext (readOnlyRootFilesystem), serves the SPA
+# index and the runtime /config.js, and honors the workspace's actual request
+# contract (bundle assets, the SPA's startup queries, and a SQL-editor-shaped
+# query through the /query proxy).
 #
 # The sidecar image is tracked at the mutable `:latest` alias, so this check
 # doubles as a canary for UI image regressions against the operator's
@@ -122,6 +124,63 @@ for i in $(seq 1 "$attempts"); do
     exit 1
   fi
   echo "  attempt ${i}/${attempts}: UI not answering yet (sleep 5s)"
+  sleep 5
+done
+
+# Replay the Web UI workspace's request contract, mirroring what the SPA
+# actually sends at runtime (derived from the webui lite build's request
+# paths). Serving 200s on / and /config.js is not enough: the workspace has
+# broken in the past on startup queries the engine stopped supporting while
+# the index still served fine. Requests, in SPA order:
+#   1. a hashed bundle chunk referenced by index.html (asset serving);
+#   2. the databases-list startup query (information_schema.catalogs) with
+#      the SPA's headers;
+#   3. a workspace query in the exact shape the SQL editor sends
+#      (?output_format=JSON_Compact&database=<defaultDatabase>, JSON body,
+#      bearer token header), asserting the result payload comes back.
+default_database=$(printf '%s' "$output" | sed -n 's/.*defaultDatabase: "\([^"]*\)".*/\1/p')
+default_database="${default_database:-firebolt}"
+chunk=$(kubectl run "ui-chunk" -n "$NAMESPACE" --rm -i --restart=Never \
+  --image="${CURL_IMAGE}" --quiet -- sh -c \
+  "curl -sf http://${pod_ip}:${UI_PORT}/" 2>/dev/null \
+  | grep -o 'assets/index-[A-Za-z0-9_-]*\.js' | head -1)
+if [[ -z "$chunk" ]]; then
+  echo "index.html references no hashed bundle chunk (assets/index-*.js)"
+  dump_namespace_debug "$NAMESPACE"
+  exit 1
+fi
+
+echo "Replaying the workspace request contract (chunk=${chunk}, database=${default_database})..."
+attempts=3
+for i in $(seq 1 "$attempts"); do
+  if output=$(kubectl run "ui-contract-$i" -n "$NAMESPACE" --rm -i --restart=Never \
+      --image="${CURL_IMAGE}" --quiet -- sh -c "
+      set -e
+      base=http://${pod_ip}:${UI_PORT}
+      echo '-- SPA bundle chunk'
+      curl -sf -o /dev/null \"\${base}/${chunk}\"
+      echo '-- startup query: databases list (information_schema.catalogs)'
+      curl -sf -o /dev/null -X POST \"\${base}/query?output_format=JSON_Compact\" \
+        -H 'Content-Type: application/json' -H 'Firebolt-Machine-Query: 1' \
+        -d 'SELECT catalog_name, description, catalog_owner, created, last_altered FROM information_schema.catalogs order by LOWER(catalog_name);'
+      echo '-- workspace query execution (SQL editor shape)'
+      curl -sf -X POST \"\${base}/query?output_format=JSON_Compact&database=${default_database}\" \
+        -H 'Content-Type: application/json' -H 'Authorization: Bearer lite' \
+        -d 'SELECT 42;'" 2>/dev/null); then
+    if printf '%s' "$output" | grep -q '"data"' && printf '%s' "$output" | grep -q '42'; then
+      echo "Workspace request contract satisfied; SELECT 42 returned data:"
+      printf '%s\n' "$output" | tail -3
+      break
+    fi
+    echo "  attempt ${i}/${attempts}: workspace query answered without expected data:"
+    printf '%s\n' "$output"
+  fi
+  if [[ "$i" == "$attempts" ]]; then
+    echo "Workspace request contract failed against ${pod_ip}:${UI_PORT}"
+    dump_namespace_debug "$NAMESPACE"
+    exit 1
+  fi
+  echo "  attempt ${i}/${attempts}: contract replay not passing yet (sleep 5s)"
   sleep 5
 done
 


### PR DESCRIPTION
**Background**

FB-2176: the UI sidecar check added there verified serving only (index 200, /config.js content, securityContext). Today's incident showed that is not enough — the workspace broke twice while the check stayed green: the engine stopped exposing a system view the SPA queries at startup (400 storm, workspace never loads), and a client-side URL-construction bug threw on every query run without a single request reaching the wire.

**Summary**

Two layers added to `verify-ui-sidecar.sh`, one commit each:

1. **Workspace request-contract replay** — the SPA's actual requests, derived from the webui lite build: a hashed bundle chunk from `index.html`, the databases-list startup query (`information_schema.catalogs`) with the SPA's headers, and a SQL-editor-shaped query (`?output_format=JSON_Compact&database=<from /config.js>`) asserting the result payload returns. Guards the engine contract, the nginx proxy, and asset serving.
2. **Containerized browser smoke** (`ui-workspace-smoke.mjs`, Playwright, pinned image + matching npm version so preinstalled browsers are reused) — loads the workspace in real Chromium via a port-forward, types a query into the SQL editor, clicks run, asserts the results grid renders; uncaught page errors and failed requests are collected into the failure message. This is the layer that catches client-side regressions like the URL-construction bug (webui#2274).

The selector contract with webui (`execute-query-btn`, `datagrid`, `query-error-message`, CodeMirror `.cm-content`) is documented in the script — a webui rename fails this check loudly, which is intended: it is a cross-repo contract, not an implementation detail.

CI cost: one ~2 GB Playwright image pull per run plus an npm fetch of the matching `playwright` package inside the container.

**Test Plan**

The check is the coverage. `make helm-test-ui` against a local kind cluster with the chart-installed operator passes end to end: securityContext + readiness, request-contract replay (`SELECT 42` returns data through the proxy), and the browser smoke (workspace renders, editor-driven query executes, results grid shows the value, zero page errors). Both historical failure modes are detected: a missing system view fails the replay step; a client-side throw fails the browser step (verified during development — the bare container's missing locale surfaced as an uncaught `Intl` RangeError until the page was given a real browser's locale).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI-only scripts (curl replay + Playwright smoke); no production operator or runtime behavior is modified.
> 
> **Overview**
> **Extends** `verify-ui-sidecar.sh` so a green check means the workspace actually works, not only that the sidecar serves `index` and `/config.js`.
> 
> **Request-contract replay** walks the SPA’s real HTTP sequence: fetch a hashed `assets/index-*.js` chunk from `index.html`, POST the databases-list startup query (`information_schema.catalogs` with SPA headers), then POST a SQL-editor-shaped query (`JSON_Compact`, `database` from `/config.js`, bearer `lite`) and assert `SELECT 42` returns `"data"`. That catches engine/proxy regressions where the shell still loads but startup or query execution breaks.
> 
> **Browser smoke** adds `ui-workspace-smoke.mjs`, run in a pinned Playwright container against a port-forward. Chromium loads the workspace, waits for the run button, types a unique marker query in CodeMirror, runs it, and asserts the `datagrid` shows that marker; uncaught page errors and HTTP ≥400 are fail conditions. Locale/timezone are set on the page to avoid `Intl` failures in bare containers. **data-testid** selectors are documented as a cross-repo contract with webui.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 704e5d3bd9ca9c115b0661da06945179dff34618. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->