### PR TITLE
fix(controller): render the GC config keys the metadata server actually reads (FB-2259)

### DIFF
--- a/internal/controller/instance_metadata.go
+++ b/internal/controller/instance_metadata.go
@@ -127,8 +127,8 @@ func buildMetadataConfigXML(instance *computev1alpha1.FireboltInstance) string {
       </postgresql>
       <garbage_collection>
         <enabled>true</enabled>
-        <interval_seconds>3600</interval_seconds>
-        <max_age_seconds>86400</max_age_seconds>
+        <interval_ms>3600000</interval_ms>
+        <time_horizon_sec>86400</time_horizon_sec>
       </garbage_collection>
     </metadata_storage>
   </pensieve_lite>

--- a/internal/controller/instance_metadata_test.go
+++ b/internal/controller/instance_metadata_test.go
@@ -163,6 +163,29 @@ func TestBuildMetadataConfigXML_EscapesUserFields(t *testing.T) {
 	}
 }
 
+// TestBuildMetadataConfigXML_GarbageCollectionKeys pins the GC key names to the
+// dialect the dedicated-pensieve server actually reads
+// (pensieve_lite.metadata_storage.garbage_collection.{enabled,time_horizon_sec,interval_ms}).
+// An earlier template rendered <interval_seconds>/<max_age_seconds>, key names no server
+// version has ever read, so GC silently ran on the server defaults (60s interval, 1h
+// horizon) instead of the values below.
+func TestBuildMetadataConfigXML_GarbageCollectionKeys(t *testing.T) {
+	got := buildMetadataConfigXML(mkMetadataInstance())
+	for _, want := range []string{
+		"<interval_ms>3600000</interval_ms>",
+		"<time_horizon_sec>86400</time_horizon_sec>",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in rendered config; got:\n%s", want, got)
+		}
+	}
+	for _, stale := range []string{"<interval_seconds>", "<max_age_seconds>"} {
+		if strings.Contains(got, stale) {
+			t.Errorf("stale GC key %q must not be rendered (the server never read it); got:\n%s", stale, got)
+		}
+	}
+}
+
 // The metadata (pensieve) pod has the same security posture as the
 // internal PostgreSQL and Envoy gateway pods: built-in non-root user,
 // read-only rootfs, all capabilities dropped, RuntimeDefault seccomp, and


### PR DESCRIPTION
**Background**

FB-2259: the pensieve `garbage_collection` block rendered by `buildMetadataConfigXML` uses key names (`<interval_seconds>`/`<max_age_seconds>`) that no dedicated-pensieve version has ever read, so metadata GC silently ran on the server defaults (60s interval, 1h horizon) instead of the intended 1h/24h.

**Summary**

- Render the server's canonical key dialect instead: `<interval_ms>3600000</interval_ms>` / `<time_horizon_sec>86400</time_horizon_sec>`. Semantics are unchanged from what the template always intended — GC every hour with a 24h horizon; they just take effect now.
- Add `TestBuildMetadataConfigXML_GarbageCollectionKeys`, pinning the rendered key names to the dialect the server reads and asserting the stale spelling never reappears. This is the cross-check whose absence let the mismatch go unnoticed.

Going forward the key names are converged on the dialect PackDB has always read (shared with firebolt-core). The server side (PackDB) is being hardened in parallel to honor `<enabled>` and to log a startup warning when it sees the stale spelling, which covers operator/server rollout version skew: an old server given this new config gets the correct interval/horizon, and a new server given an old config warns instead of failing.

**Test Plan**

- `go test ./internal/controller/ -run TestBuildMetadataConfigXML` — all pass, including the new GC key pinning test
- `go build ./...` / `go vet ./internal/controller/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes operator-rendered pensieve config that affects metadata garbage collection at runtime; low blast radius but can alter retention/cleanup behavior once rolled out.
> 
> **Overview**
> **`buildMetadataConfigXML`** now emits garbage-collection settings using the element names dedicated-pensieve actually parses: **`interval_ms`** (3600000) and **`time_horizon_sec`** (86400), instead of **`interval_seconds`** / **`max_age_seconds`**, which the server ignored. Intended behavior is unchanged (hourly GC, 24h retention); those values should apply instead of the server defaults (60s interval, 1h horizon).
> 
> Adds **`TestBuildMetadataConfigXML_GarbageCollectionKeys`** to lock in the canonical keys and block the stale spellings from coming back.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d8f6776cbef93254d68bb9777d28adb2c12970d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->