### PR TITLE
chore(deps): bump packdb engine/metadata to 5.0.1-0.20260727005216.d09b51086f14

### DIFF
--- a/config/images/defaults.latest.env
+++ b/config/images/defaults.latest.env
@@ -21,9 +21,9 @@
 #     test/e2e/e2e_suite_test.go's SynchronizedBeforeSuite.
 
 ENGINE_IMAGE=oci.firebolt.io/firebolt-db/engine
-ENGINE_TAG=release-5.0.1-0.20260713060957.513515666721
+ENGINE_TAG=release-5.0.1-0.20260727005216.d09b51086f14
 METADATA_IMAGE=ghcr.io/firebolt-db/metadata
-METADATA_TAG=release-5.0.1-0.20260713060957.513515666721
+METADATA_TAG=release-5.0.1-0.20260727005216.d09b51086f14
 POSTGRES_IMAGE=postgres:16-alpine
 ENVOY_IMAGE=envoyproxy/envoy
 ENVOY_TAG=v1.37.2


### PR DESCRIPTION
## Summary

Bump default engine/metadata images to packdb `5.0.1-0.20260727005216.d09b51086f14`
— the build the engine/metadata `:latest` GHCR tags were just re-pointed to.

> [!NOTE]
> Opened automatically by packdb's `promote-ghcr-latest` workflow (weekly
> Monday refresh or a manual promotion) right after it re-pointed the
> engine/metadata `:latest` GHCR tags at this build, so `:latest` and this
> repo's pinned tags move together. An unmerged PR is overwritten by the
> next run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only tag bump with no application code changes; risk is limited to compatibility of the new engine/metadata images, which the autobump CI is expected to validate.
> 
> **Overview**
> Updates the **latest** default image pins in `config/images/defaults.latest.env` so `ENGINE_TAG` and `METADATA_TAG` both move from `release-5.0.1-0.20260713060957.513515666721` to **`release-5.0.1-0.20260727005216.d09b51086f14`**, keeping engine and metadata on the same packdb build that GHCR `:latest` was just promoted to.
> 
> No operator, Helm, or runtime logic changes—only the default pull tags used by builds, tests, and chart defaults until someone overrides them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95fb54656aeb029738dd61ce78ce2abf57a1aa2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->