### PR TITLE
docs: document kernel compatibility requirements for Firebolt on K8s (FB-2318)

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -11,7 +11,20 @@ This page explains how to install the Firebolt Operator in a Kubernetes cluster.
 - Kubernetes 1.28 or later. The CRDs use CEL transition rules for field immutability.
 - Helm installed on the machine or automation that deploys the Firebolt Operator.
 - Access to the OCI Helm chart registry that hosts the Firebolt Operator charts.
+- Engine nodes that run Linux kernel 6.1 or later. See [Kernel requirement](#kernel-requirement).
 - Engine nodes that provide a locked-memory (`memlock`) limit of at least 8 GiB. See [Engine node requirements](#engine-node-requirements).
+
+## Kernel requirement
+
+The engine uses `io_uring` for asynchronous I/O, so every engine node must run Linux kernel 6.1 or later. On older kernels, such as 5.10, engines crash-loop at startup.
+
+Check the kernel version on an engine node:
+
+```bash
+uname -r
+```
+
+Any version 6.1 or later is enough. If a node runs an older kernel, move your engine nodes to a node image that ships kernel 6.1 or later. Most current node images from managed Kubernetes providers already meet this requirement.
 
 ## Engine node requirements
 


### PR DESCRIPTION
## What

Document that engine nodes must run Linux kernel 6.1 or later.

The public docs did not mention this. During a Firebolt-on-K8s operator workshop, a customer running nodes on kernel 5.10 hit engine crash-loops, which blocked the final workshop step.

## Changes

`docs/installation.mdx`:
- Add a Prerequisites bullet for the kernel requirement.
- Add a **Kernel requirement** section explaining the `io_uring` dependency, how to check the kernel version (`uname -r`), and how to remediate.

The requirement sits next to the existing `memlock` / `io_uring` engine-node guidance, since both stem from how the engine uses `io_uring`.

## Verification

`make check` in `docs/` passes (navigation, lost-pages, redirects).

Ref: https://linear.app/firebolt-supreme/issue/FB-2318

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to installation prerequisites; no runtime, operator, or engine code is modified.
> 
> **Overview**
> Documents that **engine nodes must run Linux kernel 6.1+** because the engine depends on `io_uring`; older kernels (e.g. 5.10) cause engines to crash-loop at startup.
> 
> Adds a prerequisites bullet linking to a new **Kernel requirement** section with `uname -r` verification and remediation (use a node image with kernel 6.1+), placed alongside the existing `memlock` / `io_uring` engine-node guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba2a8908e7b63f79b06debb1b0239569e8115da7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->