### PR TITLE
docs(agents): drop ask-before-commit note and add ci commit guidance (FB-2320)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,8 +272,6 @@ The `formal-verification.yaml` `detect` job is **path-scoped**: on a PR it sets 
 
 ### Commit conventions
 
-Ask before creating or amending commits.
-
 ```
 <type>(<scope>): <description> (<issue-ref>)
 ```
@@ -287,6 +285,7 @@ Rules:
 - Subject: imperative mood, lowercase, no trailing period; keep it under 100 characters.
 - Body: explain what changed and *why*.
 - An issue reference is required: either a GitHub issue (`#123`) or a Linear ticket (`FB-<ticket>`); take it from the branch name or last commit.
+- CI-only changes MUST use `ci:` with an optional scope (for example, `ci(test): ...`), never `fix(ci):`. A `fix:` conventional commit always triggers a patch release, which is not required for CI changes.
 
 Example: `fix(controller): report ready-vs-total pods in PodsNotReady message (#123)`
 


### PR DESCRIPTION
**Background**

FB-2320: the AGENTS.md commit-conventions guidance caused unexpected agent behavior — agents paused on "Ask before creating or amending commits", and nothing steered CI-only changes away from `fix(ci):`, which cuts spurious patch releases.

**Summary**

- Remove the `Ask before creating or amending commits.` line from `### Commit conventions`.
- Add a rule that CI-only changes MUST use `ci:` (optional scope, e.g. `ci(test): ...`), never `fix(ci):`, because a `fix:` conventional commit always triggers a patch release that CI changes do not need.

Going forward, agents commit without pausing and route CI changes to a non-releasing commit type. Mirrors the same fix already made in firecelld.

**Test Plan**

Documentation-only change to `AGENTS.md`; no code paths affected. Reviewed the rendered Markdown.

Made with [Cursor](https://cursor.com)