### PR TITLE
chore(ci): pin golangci-lint to 2.12.2 and clear what it surfaces

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.9.0
+          version: v2.12.2
         env:
           GOPRIVATE: github.com/firebolt-db/*
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -141,6 +141,13 @@ linters:
           - gosec
           - forcetypeassert
         path: _test\.go
+      # Validation code accumulates field.ErrorList by appending variadic
+      # spreads whose lengths are not known at the allocation site, so there
+      # is no honest capacity to preallocate. Sizing from the number of
+      # append CALLS would be a wrong number that only silences the linter.
+      - linters:
+          - prealloc
+        text: 'Consider preallocating (errs|out)'
       # Ginkgo and Gomega are designed around dot imports; this is the standard
       # usage pattern endorsed by the frameworks' documentation.
       - linters:

--- a/api/v1alpha1/operatorauthority.go
+++ b/api/v1alpha1/operatorauthority.go
@@ -19,7 +19,6 @@ package v1alpha1
 import (
 	"fmt"
 	"slices"
-	"sort"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -265,7 +264,7 @@ func ValidateReservedKeyPrefix(path *field.Path, m map[string]string) field.Erro
 	if len(reserved) == 0 {
 		return nil
 	}
-	sort.Strings(reserved)
+	slices.Sort(reserved)
 	errs := make(field.ErrorList, 0, len(reserved))
 	for _, k := range reserved {
 		errs = append(errs, field.Forbidden(path.Key(k),
@@ -780,12 +779,13 @@ func ValidateNoSecretAliasVolumes(
 		"an additional container could read the Instance admin password or a JWT signing key through it"
 	var errs field.ErrorList
 	for i := range volumes {
-		for _, name := range VolumeSecretRefs(&volumes[i]) {
+		vol := &volumes[i]
+		for _, name := range VolumeSecretRefs(vol) {
 			if !isProtected(name) {
 				continue
 			}
 			errs = append(errs, field.Forbidden(base.Index(i),
-				fmt.Sprintf(detail, volumes[i].Name, name, component)))
+				fmt.Sprintf(detail, vol.Name, name, component)))
 		}
 	}
 	return errs

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -109,6 +109,20 @@ const (
 	// silently override the user's spec.replicas==0 intent.
 	AnnotationWakeRequested = "firebolt.io/wake-requested"
 
+	// KindCertificate is the cert-manager Certificate kind, named because
+	// Server-Side Apply requires an explicit apiVersion/kind on every
+	// applied object and the literal would otherwise be repeated across
+	// several files.
+	KindCertificate = "Certificate"
+
+	// KindStatefulSet is the apps/v1 StatefulSet kind. Same rationale as
+	// KindCertificate.
+	KindStatefulSet = "StatefulSet"
+
+	// ReasonInstanceNotReady is the condition reason for an engine blocked
+	// on its parent FireboltInstance.
+	ReasonInstanceNotReady = "InstanceNotReady"
+
 	// SuffixService is appended to form the cluster Service name.
 	SuffixService = "-service"
 	// SuffixGen is appended to form generation-scoped resource names.

--- a/internal/controller/engine_apply.go
+++ b/internal/controller/engine_apply.go
@@ -201,7 +201,7 @@ func (r *FireboltEngineReconciler) ensureConfigMap(ctx context.Context, engine *
 func (r *FireboltEngineReconciler) ensureEngineTLSCert(ctx context.Context, engine *computev1alpha1.FireboltEngine, want *certmanagerv1.Certificate) error {
 	log := logf.FromContext(ctx).WithValues("engine", engine.Name)
 
-	want.TypeMeta = metav1.TypeMeta{APIVersion: certmanagerv1.SchemeGroupVersion.String(), Kind: "Certificate"}
+	want.TypeMeta = metav1.TypeMeta{APIVersion: certmanagerv1.SchemeGroupVersion.String(), Kind: KindCertificate}
 	if err := controllerutil.SetControllerReference(engine, want, r.Scheme); err != nil {
 		return fmt.Errorf("failed to set owner reference: %w", err)
 	}
@@ -224,7 +224,7 @@ func (r *FireboltEngineReconciler) ensureService(ctx context.Context, engine *co
 func (r *FireboltEngineReconciler) ensureStatefulSetResource(ctx context.Context, engine *computev1alpha1.FireboltEngine, want *appsv1.StatefulSet) error {
 	log := logf.FromContext(ctx).WithValues("engine", engine.Name)
 
-	want.TypeMeta = metav1.TypeMeta{APIVersion: "apps/v1", Kind: "StatefulSet"}
+	want.TypeMeta = metav1.TypeMeta{APIVersion: "apps/v1", Kind: KindStatefulSet}
 	if err := controllerutil.SetControllerReference(engine, want, r.Scheme); err != nil {
 		return fmt.Errorf("failed to set owner reference: %w", err)
 	}

--- a/internal/controller/engine_classref_test.go
+++ b/internal/controller/engine_classref_test.go
@@ -19,7 +19,7 @@ package controller
 import (
 	"context"
 	stderrors "errors"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 
@@ -178,7 +178,7 @@ func TestFireboltEngineClassToEngines_NamespaceScoped(t *testing.T) {
 		}
 		gotNames = append(gotNames, req.Name)
 	}
-	sort.Strings(gotNames)
+	slices.Sort(gotNames)
 	want := []string{"a", "b"}
 	if len(gotNames) != len(want) || gotNames[0] != want[0] || gotNames[1] != want[1] {
 		t.Errorf("enqueued engines = %v, want %v (cross-namespace engine e must be filtered out)", gotNames, want)

--- a/internal/controller/engine_controller.go
+++ b/internal/controller/engine_controller.go
@@ -317,7 +317,7 @@ func (r *FireboltEngineReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				Type:               computev1alpha1.ConditionInstanceReady,
 				Status:             metav1.ConditionFalse,
 				ObservedGeneration: engine.Generation,
-				Reason:             "InstanceNotReady",
+				Reason:             ReasonInstanceNotReady,
 				Message:            instanceErr.Error(),
 			})
 			setReadyCondition(&engine.Status, current, engine.Generation)

--- a/internal/controller/engine_reconcile.go
+++ b/internal/controller/engine_reconcile.go
@@ -689,7 +689,7 @@ func buildGenEngineTLSCertificate(engineName, namespace string, gen int, tls *Re
 	issuerKind := resolveCertManagerIssuerKind(tls.CertManager.IssuerRef.Kind)
 
 	return &certmanagerv1.Certificate{
-		TypeMeta: metav1.TypeMeta{APIVersion: certmanagerv1.SchemeGroupVersion.String(), Kind: "Certificate"},
+		TypeMeta: metav1.TypeMeta{APIVersion: certmanagerv1.SchemeGroupVersion.String(), Kind: KindCertificate},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -1203,7 +1203,7 @@ func buildStatefulSet(spec *computev1alpha1.FireboltEngineSpec, engineName, name
 	}
 	podVolumes := []corev1.Volume{
 		{
-			Name: "engine-config",
+			Name: computev1alpha1.EngineConfigVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
@@ -2246,7 +2246,7 @@ func effectiveEngineVolumeMounts(spec *computev1alpha1.FireboltEngineSpec, class
 func appendUserVolumeMounts(dst, src []corev1.VolumeMount) []corev1.VolumeMount {
 	for i := range src {
 		name := src[i].Name
-		if name == "engine-config" || name == DataVolumeName {
+		if name == computev1alpha1.EngineConfigVolumeName || name == DataVolumeName {
 			continue
 		}
 		dst = append(dst, *src[i].DeepCopy())
@@ -2299,7 +2299,7 @@ func buildEngineContainerVolumeMounts(spec *computev1alpha1.FireboltEngineSpec, 
 			MountPath: DataMountPath,
 		},
 		corev1.VolumeMount{
-			Name:      "engine-config",
+			Name:      computev1alpha1.EngineConfigVolumeName,
 			MountPath: ConfigMountPath,
 			SubPath:   ConfigFileName,
 			ReadOnly:  true,
@@ -2589,9 +2589,9 @@ func appendUserPodVolumes(operator []corev1.Volume, spec *computev1alpha1.Firebo
 // making the runtime-derived reservation insufficient.
 func operatorOwnedPodVolumeNames() map[string]struct{} {
 	return map[string]struct{}{
-		"engine-config":             {},
-		DataVolumeName:              {},
-		EngineWebWritableVolumeName: {},
+		computev1alpha1.EngineConfigVolumeName: {},
+		DataVolumeName:                         {},
+		EngineWebWritableVolumeName:            {},
 	}
 }
 

--- a/internal/controller/instance_auth.go
+++ b/internal/controller/instance_auth.go
@@ -480,7 +480,7 @@ func (r *FireboltInstanceReconciler) bootstrapSigningKey(ctx context.Context, in
 // deletes the Certificate and Secret explicitly instead.
 func (r *FireboltInstanceReconciler) applySigningCertificate(ctx context.Context, instance *computev1alpha1.FireboltInstance, key *computev1alpha1.SigningKeyStatus) (bool, error) {
 	desired := buildSigningCertificate(instance, key.ID)
-	desired.TypeMeta = metav1.TypeMeta{APIVersion: certmanagerv1.SchemeGroupVersion.String(), Kind: "Certificate"}
+	desired.TypeMeta = metav1.TypeMeta{APIVersion: certmanagerv1.SchemeGroupVersion.String(), Kind: KindCertificate}
 
 	if err := controllerutil.SetControllerReference(instance, desired, r.Scheme); err != nil {
 		return false, err

--- a/internal/controller/instance_postgres.go
+++ b/internal/controller/instance_postgres.go
@@ -195,7 +195,7 @@ func validatePostgresSecret(s *corev1.Secret) error {
 // alongside the existing ones.
 func (r *FireboltInstanceReconciler) ensurePostgresStatefulSet(ctx context.Context, instance *computev1alpha1.FireboltInstance) error {
 	desired := buildPostgresStatefulSet(instance)
-	desired.TypeMeta = metav1.TypeMeta{APIVersion: "apps/v1", Kind: "StatefulSet"}
+	desired.TypeMeta = metav1.TypeMeta{APIVersion: "apps/v1", Kind: KindStatefulSet}
 
 	if err := controllerutil.SetControllerReference(instance, desired, r.Scheme); err != nil {
 		return err

--- a/internal/controller/instance_tls.go
+++ b/internal/controller/instance_tls.go
@@ -23,7 +23,7 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -305,7 +305,7 @@ func (r *FireboltInstanceReconciler) ensureEngineTLSCertificate(ctx context.Cont
 		secretName = ref.Name
 	} else {
 		desired := buildEngineTLSCertificate(instance)
-		desired.TypeMeta = metav1.TypeMeta{APIVersion: certmanagerv1.SchemeGroupVersion.String(), Kind: "Certificate"}
+		desired.TypeMeta = metav1.TypeMeta{APIVersion: certmanagerv1.SchemeGroupVersion.String(), Kind: KindCertificate}
 
 		// GC note: same as ensureSigningCertificate — OwnerReference +
 		// Kubernetes' garbage collector, not the manual label-based sweep in
@@ -677,7 +677,7 @@ func caFingerprintsSorted(blobs []string) []string {
 	for i, b := range blobs {
 		fps[i] = caFingerprint(b)
 	}
-	sort.Strings(fps)
+	slices.Sort(fps)
 	return fps
 }
 
@@ -739,7 +739,7 @@ func dedupCABlobs(inputs [][]byte) []string {
 		seen[b] = struct{}{}
 		blobs = append(blobs, b)
 	}
-	sort.Strings(blobs)
+	slices.Sort(blobs)
 	return blobs
 }
 
@@ -977,7 +977,7 @@ func (r *FireboltInstanceReconciler) ensureGatewayTLSCertificate(ctx context.Con
 		secretName = ref.Name
 	} else {
 		desired := buildGatewayTLSCertificate(instance)
-		desired.TypeMeta = metav1.TypeMeta{APIVersion: certmanagerv1.SchemeGroupVersion.String(), Kind: "Certificate"}
+		desired.TypeMeta = metav1.TypeMeta{APIVersion: certmanagerv1.SchemeGroupVersion.String(), Kind: KindCertificate}
 
 		if err := controllerutil.SetControllerReference(instance, desired, r.Scheme); err != nil {
 			return false, false, err

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -25,7 +25,7 @@ import (
 	"context"
 	"math/rand/v2"
 	"runtime"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -208,7 +208,7 @@ func engineVersions(engines []computev1alpha1.FireboltEngine, classes map[string
 	for version := range versions {
 		result = append(result, version)
 	}
-	sort.Strings(result)
+	slices.Sort(result)
 	return strings.Join(result, ",")
 }
 


### PR DESCRIPTION
**Background**

CI pinned golangci-lint to v2.9.0 while local installs are on 2.12.2, so a clean local run said nothing about whether CI would pass — and vice versa.

**Summary**

Pins CI to v2.12.2 to match what people actually run locally, and clears the 22 findings the newer release reports that v2.9.0 did not.

Mostly mechanical — `slices.Sort` over `sort.Strings`, two misspellings, and constants for the `Certificate` / `StatefulSet` kind strings that Server-Side Apply forces us to repeat in `TypeMeta` literals across files.

Two worth a look:

- `validateNoSecretAliasVolumes` indexed `volumes[i]` twice across a nested loop, which gosec flagged as a possible out-of-range read. Binding the element once is clearer regardless of the linter.
- `prealloc` is now excluded for `field.ErrorList` accumulators rather than satisfied. Those append variadic spreads whose lengths aren't known at the allocation site, so any capacity we passed would be a made-up number that quiets the linter without making anything faster.

Going forward, `make lint` locally and the CI gate agree.

**Test Plan**

`golangci-lint run ./...` reports 0 issues at the pinned version. Full unit suite passes and `go vet -tags e2e` is clean; no behavioural change is intended anywhere in this diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint version bump and style/refactor-only changes; no security or reconciliation logic changes intended.
> 
> **Overview**
> Aligns CI with **golangci-lint v2.12.2** (from v2.9.0) so local `make lint` and the workflow gate report the same findings.
> 
> Clears the newer linter output with mostly mechanical fixes: **`sort.Strings` → `slices.Sort`** across validation, TLS, telemetry, and tests; shared **`KindCertificate`**, **`KindStatefulSet`**, and **`ReasonInstanceNotReady`** constants for repeated SSA `TypeMeta` and condition reasons; engine reconcile uses **`computev1alpha1.EngineConfigVolumeName`** instead of the `"engine-config"` literal.
> 
> **`.golangci.yml`** adds a targeted **`prealloc`** exclusion for `field.ErrorList` append sites where capacity cannot be known honestly. **`ValidateNoSecretAliasVolumes`** binds the volume pointer once in the nested loop (gosec index concern).
> 
> No intended runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f86da5e25ae9186e60ed6f302f78710f69f3b1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->