### PR TITLE
test(formal): pin state-cover size and compare projections in full (FB-2581)

### DIFF
--- a/internal/controller/engine_tla_state_test.go
+++ b/internal/controller/engine_tla_state_test.go
@@ -27,6 +27,7 @@ package controller
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 	"testing"
 
@@ -172,9 +173,15 @@ func materializeTLAState(s tlaState) *engineSim {
 }
 
 // projectEngineSim extracts the TLA+ observable variables from the simulated
-// cluster state. instanceReady is preserved from the input state because the
-// compute layer cannot change it — the gate is enforced by the outer Reconcile.
-func projectEngineSim(m *engineSim, instanceReady bool) tlaState {
+// cluster state. instanceReady and classReady are preserved from the input state
+// because the compute layer cannot change either — both gates are enforced by
+// the outer Reconcile.
+//
+// Every field of tlaState must be populated here. The round-trip guard in
+// TestTLAEngineStateCover (materialize → project == start) is what enforces
+// that: a field left at its zero value silently narrows what closureContains
+// compares, which weakens every assertion in the suite.
+func projectEngineSim(m *engineSim, instanceReady, classReady bool) tlaState {
 	st := tlaState{
 		Phase:         string(m.status.Phase),
 		CurrentGen:    m.status.CurrentGeneration,
@@ -186,6 +193,7 @@ func projectEngineSim(m *engineSim, instanceReady bool) tlaState {
 		PodsReady:     m.podsReady,
 		PodsDrained:   m.podsDrained,
 		InstanceReady: instanceReady,
+		ClassReady:    classReady,
 	}
 	for g := range st.StsSpecVer {
 		st.StsSpecVer[g] = -1
@@ -371,28 +379,43 @@ func closureContains(closureIDs []int, actual tlaState) bool {
 	return false
 }
 
+// tlaStateEqual compares two projected states by reflection deliberately.
+//
+// A hand-written field-by-field comparison is weakenable in a way nothing
+// catches: drop a field here (ClassReady was in fact missing until this was
+// written) and the closure check silently accepts states the model
+// distinguishes. `make formal-verify` cannot catch it either — it asserts the
+// committed fixture matches the generator's output, not that the fixture is
+// still being compared in full. reflect.DeepEqual covers every field of
+// tlaState, including the StsSpecVer array, so narrowing the comparison now
+// requires deleting a field from the struct, which shows up in the diff.
 func tlaStateEqual(a, b tlaState) bool {
-	if a.Phase != b.Phase ||
-		a.CurrentGen != b.CurrentGen ||
-		a.ActiveGen != b.ActiveGen ||
-		a.DrainingGen != b.DrainingGen ||
-		a.SpecVer != b.SpecVer ||
-		a.SpecWantsStop != b.SpecWantsStop ||
-		a.SvcTargetGen != b.SvcTargetGen ||
-		a.PodsReady != b.PodsReady ||
-		a.PodsDrained != b.PodsDrained ||
-		a.InstanceReady != b.InstanceReady {
-		return false
-	}
-	for i := range a.StsSpecVer {
-		if a.StsSpecVer[i] != b.StsSpecVer[i] {
-			return false
-		}
-	}
-	return true
+	return reflect.DeepEqual(a, b)
 }
 
+// Coverage pins. These are hand-maintained on purpose: they cannot live in the
+// generated fixture, because the fixture is regenerated from the spec and
+// therefore always agrees with itself. A spec change that collapses the state
+// space, or a widened skip predicate that swallows states the compute layer
+// used to be checked against, leaves `make formal-verify` green — the fixture
+// still matches the generator's output, there are simply far fewer cases in it,
+// and the test only logged the counts.
+//
+// Pinning them in hand-written code forces any movement in coverage to appear
+// as an edit in the diff. If one of these assertions fails, the question to
+// answer in the commit message is *why* coverage moved — then update the number.
+const (
+	tlaExpectedCases           = 6404
+	tlaExpectedRan             = 3512
+	tlaExpectedSkippedGate     = 2856
+	tlaExpectedSkippedBoundary = 36
+)
+
 func TestTLAEngineStateCover(t *testing.T) {
+	if len(tlaEngineStateCases) != tlaExpectedCases {
+		t.Fatalf("fixture has %d cases, expected %d: the state space moved. Regenerate with `make formal-gen`, then update tlaExpectedCases and say why in the commit",
+			len(tlaEngineStateCases), tlaExpectedCases)
+	}
 	skippedGate := 0
 	skippedBoundary := 0
 	for i := range tlaEngineStateCases {
@@ -411,6 +434,17 @@ func TestTLAEngineStateCover(t *testing.T) {
 			start.DrainingGen, start.SpecVer)
 		t.Run(name, func(t *testing.T) {
 			m := materializeTLAState(start)
+
+			// Guard the fixture itself: if materialization does not reproduce the
+			// starting state, every closure assertion below is meaningless. It
+			// also forces projectEngineSim to populate every tlaState field — a
+			// dropped field fails the round-trip for any state whose value
+			// differs from that field's zero value. Same guard the rotation
+			// harness already carries.
+			if got := projectEngineSim(m, start.InstanceReady, start.ClassReady); !tlaStateEqual(got, start) {
+				t.Fatalf("materialization does not round-trip\n  want: %+v\n  got:  %+v", start, got)
+			}
+
 			result := computeEngineReconcile(
 				&m.spec, &m.status, m.buildState(),
 				propEngineName, propNamespace, 0, testInstanceInfo(), nil,
@@ -425,16 +459,31 @@ func TestTLAEngineStateCover(t *testing.T) {
 			}
 			tlaInvariants(t, m)
 
-			actual := projectEngineSim(m, start.InstanceReady)
+			actual := projectEngineSim(m, start.InstanceReady, start.ClassReady)
 			if !closureContains(tc.Closure, actual) {
 				t.Fatalf("result not in TLA+ reconciler closure of starting state\n  start:    %+v\n  actual:   %+v\n  closure (%d states):\n%s",
 					start, actual, len(tc.Closure), formatClosure(tc.Closure))
 			}
 		})
 	}
+	ran := len(tlaEngineStateCases) - skippedGate - skippedBoundary
 	t.Logf("state cover: ran %d / %d, skipped %d gated (instanceReady=false OR classReady=false in {stable,stopped,creating}), %d at MaxGen boundary",
-		len(tlaEngineStateCases)-skippedGate-skippedBoundary, len(tlaEngineStateCases),
-		skippedGate, skippedBoundary)
+		ran, len(tlaEngineStateCases), skippedGate, skippedBoundary)
+
+	// The skip predicates are the other way coverage can quietly vanish: widen
+	// tlaShouldGateOut or tlaModelBoundary and states stop being exercised with
+	// no fixture change at all, so `make formal-verify` cannot see it.
+	if skippedGate != tlaExpectedSkippedGate {
+		t.Errorf("tlaShouldGateOut skipped %d cases, expected %d: the gate predicate changed. Justify the new coverage and update tlaExpectedSkippedGate",
+			skippedGate, tlaExpectedSkippedGate)
+	}
+	if skippedBoundary != tlaExpectedSkippedBoundary {
+		t.Errorf("tlaModelBoundary skipped %d cases, expected %d: the boundary predicate changed. Justify the new coverage and update tlaExpectedSkippedBoundary",
+			skippedBoundary, tlaExpectedSkippedBoundary)
+	}
+	if ran != tlaExpectedRan {
+		t.Errorf("ran %d cases against computeEngineReconcile, expected %d", ran, tlaExpectedRan)
+	}
 }
 
 // formatClosure renders the first few entries of a closure index list for

--- a/internal/controller/instance_tla_state_test.go
+++ b/internal/controller/instance_tla_state_test.go
@@ -186,7 +186,17 @@ func tlaInstanceInvariants(t *testing.T, m *instanceSim) {
 	}
 }
 
+// tlaInstanceExpectedCases pins the size of the state cover. Hand-maintained
+// deliberately: the fixture is generated from the spec, so it always agrees with
+// itself and `make formal-verify` stays green even if the state space collapses.
+// See the same reasoning in engine_tla_state_test.go.
+const tlaInstanceExpectedCases = 32
+
 func TestTLAInstanceStateCover(t *testing.T) {
+	if len(tlaInstanceStateCases) != tlaInstanceExpectedCases {
+		t.Fatalf("fixture has %d cases, expected %d: the state space moved. Regenerate with `make formal-gen`, then update tlaInstanceExpectedCases and say why in the commit",
+			len(tlaInstanceStateCases), tlaInstanceExpectedCases)
+	}
 	for i := range tlaInstanceStateCases {
 		tc := tlaInstanceStateCases[i]
 		start := tlaInstanceStatePool[tc.Start]
@@ -195,6 +205,13 @@ func TestTLAInstanceStateCover(t *testing.T) {
 			start.PostgresAvail, start.MetadataAvail, start.GatewayAvail)
 		t.Run(name, func(t *testing.T) {
 			m := materializeTLAInstanceState(start)
+
+			// Guard the fixture itself: if materialization does not reproduce the
+			// starting state, the closure assertion below proves nothing, and a
+			// projection that drops a field would go unnoticed.
+			if got := projectInstanceSim(m); got != start {
+				t.Fatalf("materialization does not round-trip\n  want: %+v\n  got:  %+v", start, got)
+			}
 
 			// Mirror instanceSim.Reconcile in engine_property_test.go style:
 			// init-seed branch when Phase is empty, otherwise the full

--- a/internal/controller/rotation_tla_state_test.go
+++ b/internal/controller/rotation_tla_state_test.go
@@ -34,6 +34,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -283,16 +284,13 @@ func (m *rotationTLASim) project(t *testing.T) tlaRotationState {
 	return out
 }
 
+// rotationStateEqual compares by reflection so the comparison cannot be
+// narrowed without deleting a field from tlaRotationState. A hand-written
+// field-by-field version is weakenable in a way no target catches:
+// `make formal-verify` checks that the fixture matches the generator's output,
+// not that the fixture is still compared in full.
 func rotationStateEqual(a, b tlaRotationState) bool {
-	if a.Gen != b.Gen || a.Converged != b.Converged || len(a.Keys) != len(b.Keys) {
-		return false
-	}
-	for i := range a.Keys {
-		if a.Keys[i] != b.Keys[i] {
-			return false
-		}
-	}
-	return true
+	return reflect.DeepEqual(a, b)
 }
 
 func rotationClosureContains(closureIDs []int, actual tlaRotationState) bool {
@@ -335,7 +333,15 @@ func tlaRotationInvariants(t *testing.T, m *rotationTLASim) {
 	}
 }
 
+// tlaRotationExpectedCases pins the size of the state cover; see the reasoning
+// on the equivalent constant in engine_tla_state_test.go.
+const tlaRotationExpectedCases = 19
+
 func TestTLARotationStateCover(t *testing.T) {
+	if len(tlaRotationStateCases) != tlaRotationExpectedCases {
+		t.Fatalf("fixture has %d cases, expected %d: the state space moved. Regenerate with `make formal-gen`, then update tlaRotationExpectedCases and say why in the commit",
+			len(tlaRotationStateCases), tlaRotationExpectedCases)
+	}
 	for i := range tlaRotationStateCases {
 		tc := tlaRotationStateCases[i]
 		start := tlaRotationStatePool[tc.Start]


### PR DESCRIPTION
Closes FB-2581.

The TLA+ state cover could stop testing anything while every formal target stayed green. Two separate ways:

**Coverage could vanish silently.** The three state-cover tests only logged how many cases they ran, and the engine test skips states via `tlaShouldGateOut` / `tlaModelBoundary`. Widen either predicate and states stop being exercised with no fixture change at all, so `make formal-verify` can't see it. Same if the state space collapses — the fixture still matches its generator. Counts are now pinned and asserted (6404 cases: 3512 ran, 2856 gated, 36 at the MaxGen boundary; 32 instance; 19 rotation).

The pins are hand-maintained rather than emitted by the generator, which is a deviation from the ticket: a number the generator writes into the file it generates always agrees with itself, so it has no teeth. In hand-written code a coverage move has to appear as an edit with a reason.

**The projection could be weakened once and stay weak.** `tlaStateEqual` compared `tlaState` field by field and had already dropped `ClassReady` — the closure check was accepting states the model distinguishes. It and `rotationStateEqual` now compare by reflection, so narrowing means deleting a struct field, which is visible in review. Engine and instance also pick up the materialization round-trip guard rotation already had.

## Coverage

Both new guards were checked against mutations rather than just observed green: widening the gate predicate by one phase fails the skip-count assertion (3867 vs 2856 expected), and dropping `ClassReady` from the projection fails the round-trip guard on the first `cleaning` state. Full controller package and `make formal-verify` pass unchanged — no fixture churn, since no generator changed.

FB-2584 (single-sourcing the invariant lists) builds on this and is blocked until it lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only hardening of formal verification harnesses; no production reconciler or runtime behavior changes.
> 
> **Overview**
> Hardens the TLA+ **state-cover** tests so formal targets can’t stay green while exercising less of the model.
> 
> **Engine, instance, and rotation** suites now assert **hand-pinned fixture sizes** (e.g. 6404 engine cases, with separate pins for gated/boundary skips and cases actually run). Widening skip predicates or shrinking the generated state space must show up as a failing test and an intentional constant update—not only a log line.
> 
> **Engine** projection now threads **`ClassReady`** through `projectEngineSim` (it was omitted from the old field-by-field `tlaStateEqual`). **Engine and rotation** equality checks use **`reflect.DeepEqual`** instead of manual comparisons, so dropping a struct field can’t silently narrow closure checks. **Engine and instance** add a **materialize → project round-trip** guard (rotation already had one) so incomplete projections fail before closure assertions run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a71235d17d682ace741e7ceb620f523a8a83e704. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->