### PR TITLE
test(formal): single-source the engine safety invariants (FB-2584)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -403,6 +403,7 @@ formal-dump: tla2tools ## Dump the TLC state graphs for both specs to formal/*.d
 formal-gen: formal-dump ## Regenerate the TLA+ state-cover test fixtures from the TLC state graphs.
 	python3 scripts/gen-tla-state-tests.py \
 		--dot formal/FireboltEngine.dot \
+		--spec formal/FireboltEngine.tla \
 		--out internal/controller/engine_tla_states_data_test.go
 	python3 scripts/gen-tla-instance-state-tests.py \
 		--dot formal/FireboltInstance.dot \

--- a/internal/controller/engine_invariants_test.go
+++ b/internal/controller/engine_invariants_test.go
@@ -169,6 +169,15 @@ var engineInvariants = map[string]func(t invariantT, m *engineSim){
 		if !isTerminalPhase(m.status.Phase) {
 			return
 		}
+		// Quiesced also means the reconciler has caught up with the last spec
+		// change. The spec gets that from StsMatchesSpec, because its
+		// EnvChangeSpec always bumps specVer; Go has spec changes that produce
+		// no template drift (replicas are applied in place by design), so the
+		// terminal phase can legitimately name the old intent for one reconcile.
+		// See engineSim.specDirty.
+		if m.specDirty {
+			return
+		}
 		sts := m.api.stses[m.status.CurrentGeneration]
 		if sts == nil || !stsMatchesSpec(sts, &m.spec, testInstanceInfo(), m.classInfo) {
 			return

--- a/internal/controller/engine_invariants_test.go
+++ b/internal/controller/engine_invariants_test.go
@@ -1,0 +1,284 @@
+/*
+Copyright 2026 Firebolt Analytics.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+// One definition of the engine safety invariants, shared by both harnesses that
+// check them: the rapid property test (engine_property_test.go, random action
+// sequences) and the TLA+ state cover (engine_tla_state_test.go, every reachable
+// modeled state).
+//
+// They used to be two hand-written copies of the spec's `Safety` conjuncts, and
+// the copies had drifted: Inv_TerminalHasSTS and Inv_QuiescedPhaseMatchesSpec
+// were in the spec only, Inv_NoOrphanedResources in the rapid harness only, and
+// Inv_DrainingPhase / Inv_DrainingOlderThanCurrent / Inv_GenOrder in the state
+// cover only. Nothing detected any of it, because nothing related the Go checks
+// to the spec's list.
+//
+// Now the generator emits `tlaRequiredInvariants` (the spec's conjuncts, parsed
+// out of `Safety ==`) into the fixture, and TestEngineInvariantsMatchSpec below
+// fails when a conjunct has no entry here. Adding an invariant to the spec is
+// therefore not optional on the Go side.
+
+import (
+	"sort"
+	"strconv"
+	"testing"
+
+	computev1alpha1 "github.com/firebolt-db/firebolt-kubernetes-operator/api/v1alpha1"
+)
+
+// invariantT is the slice of *testing.T and *rapid.T that the invariants need.
+// It is deliberately just Fatalf: *rapid.T has no Helper(), so the failure line
+// points at the invariant function rather than the caller — which is why every
+// message below names the invariant it belongs to.
+type invariantT interface {
+	Fatalf(format string, args ...any)
+}
+
+// engineInvariants maps each name to its Go counterpart. Keys are either a
+// conjunct of the spec's Safety predicate (see tlaRequiredInvariants in the
+// generated fixture) or a member of goOnlyEngineInvariants below.
+//
+// Every invariant reads the `api` view — the source of truth, what a real API
+// server would hold — never the informer `cache`, which legitimately lags.
+var engineInvariants = map[string]func(t invariantT, m *engineSim){
+	// TypeOK is necessarily partial in Go. The spec's version asserts membership
+	// in the bounded sets Gens / SpecVers, which are a model artifact: the real
+	// reconciler bumps generations without an upper bound (that mismatch is what
+	// tlaModelBoundary skips in the state cover). What carries over is the
+	// discriminated-union part — the phase is one the state machine knows, and
+	// the generation fields are either a real generation or the -1 sentinel.
+	"TypeOK": func(t invariantT, m *engineSim) {
+		switch m.status.Phase {
+		case "",
+			computev1alpha1.PhaseStable,
+			computev1alpha1.PhaseCreating,
+			computev1alpha1.PhaseSwitching,
+			computev1alpha1.PhaseDraining,
+			computev1alpha1.PhaseCleaning,
+			computev1alpha1.PhaseStopped:
+		default:
+			t.Fatalf("TypeOK: phase %q is not a phase the state machine defines", m.status.Phase)
+		}
+		if m.status.CurrentGeneration < 0 {
+			t.Fatalf("TypeOK: CurrentGeneration=%d is negative", m.status.CurrentGeneration)
+		}
+		if m.status.ActiveGeneration < -1 {
+			t.Fatalf("TypeOK: ActiveGeneration=%d is below the -1 sentinel", m.status.ActiveGeneration)
+		}
+		if m.status.DrainingGeneration != nil && *m.status.DrainingGeneration < 0 {
+			t.Fatalf("TypeOK: DrainingGeneration=%d is negative (absence is nil, not -1)",
+				*m.status.DrainingGeneration)
+		}
+	},
+
+	"Inv_TerminalConsistency": func(t invariantT, m *engineSim) {
+		if isTerminalPhase(m.status.Phase) && m.status.CurrentGeneration != m.status.ActiveGeneration {
+			t.Fatalf("Inv_TerminalConsistency: phase=%s but CurrentGen=%d != ActiveGen=%d",
+				m.status.Phase, m.status.CurrentGeneration, m.status.ActiveGeneration)
+		}
+	},
+
+	"Inv_TerminalNoDraining": func(t invariantT, m *engineSim) {
+		if isTerminalPhase(m.status.Phase) && m.status.DrainingGeneration != nil {
+			t.Fatalf("Inv_TerminalNoDraining: phase=%s but DrainingGen=%d",
+				m.status.Phase, *m.status.DrainingGeneration)
+		}
+	},
+
+	// A stopped engine keeps its zero-replica STS, so this covers both terminal
+	// phases.
+	"Inv_TerminalHasSTS": func(t invariantT, m *engineSim) {
+		if isTerminalPhase(m.status.Phase) && m.api.stses[m.status.CurrentGeneration] == nil {
+			t.Fatalf("Inv_TerminalHasSTS: phase=%s but no STS for CurrentGen=%d",
+				m.status.Phase, m.status.CurrentGeneration)
+		}
+	},
+
+	"Inv_ActiveHasSTS": func(t invariantT, m *engineSim) {
+		if m.status.ActiveGeneration >= 0 && m.api.stses[m.status.ActiveGeneration] == nil {
+			t.Fatalf("Inv_ActiveHasSTS: ActiveGen=%d has no STS", m.status.ActiveGeneration)
+		}
+	},
+
+	"Inv_ServiceValid": func(t invariantT, m *engineSim) {
+		if m.status.ActiveGeneration < 0 {
+			return
+		}
+		gen, ok := engineSimSvcTargetGen(t, m)
+		if !ok {
+			return
+		}
+		if m.api.stses[gen] == nil {
+			t.Fatalf("Inv_ServiceValid: cluster Service targets gen=%d, which has no STS", gen)
+		}
+	},
+
+	"Inv_ServiceKnownGen": func(t invariantT, m *engineSim) {
+		if m.status.ActiveGeneration < 0 {
+			return
+		}
+		gen, ok := engineSimSvcTargetGen(t, m)
+		if !ok {
+			return
+		}
+		if gen != m.status.ActiveGeneration && gen != m.status.CurrentGeneration {
+			t.Fatalf("Inv_ServiceKnownGen: svcTargetGen=%d not in {activeGen=%d, currentGen=%d}",
+				gen, m.status.ActiveGeneration, m.status.CurrentGeneration)
+		}
+	},
+
+	"Inv_DrainingPhase": func(t invariantT, m *engineSim) {
+		if m.status.DrainingGeneration == nil {
+			return
+		}
+		if m.status.Phase != computev1alpha1.PhaseDraining && m.status.Phase != computev1alpha1.PhaseCleaning {
+			t.Fatalf("Inv_DrainingPhase: DrainingGen=%d but phase=%s",
+				*m.status.DrainingGeneration, m.status.Phase)
+		}
+	},
+
+	"Inv_DrainingOlderThanCurrent": func(t invariantT, m *engineSim) {
+		if m.status.DrainingGeneration != nil && *m.status.DrainingGeneration >= m.status.CurrentGeneration {
+			t.Fatalf("Inv_DrainingOlderThanCurrent: DrainingGen=%d, CurrentGen=%d",
+				*m.status.DrainingGeneration, m.status.CurrentGeneration)
+		}
+	},
+
+	"Inv_GenOrder": func(t invariantT, m *engineSim) {
+		if m.status.ActiveGeneration > m.status.CurrentGeneration {
+			t.Fatalf("Inv_GenOrder: ActiveGen=%d > CurrentGen=%d",
+				m.status.ActiveGeneration, m.status.CurrentGeneration)
+		}
+	},
+
+	// Gated on stsMatchesSpec exactly as the spec gates on StsMatchesSpec: mid
+	// drift, a terminal phase legitimately lags the new spec, and catching up is
+	// what drift detection is for. Once the current generation matches the spec,
+	// a "stable" engine whose spec asks for zero replicas is a contract
+	// violation users would see in status.
+	"Inv_QuiescedPhaseMatchesSpec": func(t invariantT, m *engineSim) {
+		if !isTerminalPhase(m.status.Phase) {
+			return
+		}
+		sts := m.api.stses[m.status.CurrentGeneration]
+		if sts == nil || !stsMatchesSpec(sts, &m.spec, testInstanceInfo(), m.classInfo) {
+			return
+		}
+		wantStopped := m.spec.Replicas == 0
+		gotStopped := m.status.Phase == computev1alpha1.PhaseStopped
+		if gotStopped != wantStopped {
+			t.Fatalf("Inv_QuiescedPhaseMatchesSpec: phase=%s but spec.Replicas=%d (quiesced on a matching STS)",
+				m.status.Phase, m.spec.Replicas)
+		}
+	},
+
+	// Go-only. The spec models resource deletion inside the reconciler actions,
+	// so it has no separate conjunct for it; on the Go side the GC is a distinct
+	// step (gcOrphanedResources) worth asserting on its own.
+	"Inv_NoOrphanedResources": func(t invariantT, m *engineSim) {
+		if !isTerminalPhase(m.status.Phase) {
+			return
+		}
+		cur := m.status.CurrentGeneration
+		for gen := range m.api.stses {
+			if gen != cur {
+				t.Fatalf("Inv_NoOrphanedResources: phase=%s but STS gen=%d survives (currentGen=%d)",
+					m.status.Phase, gen, cur)
+			}
+		}
+		for gen := range m.api.configMaps {
+			if gen != cur {
+				t.Fatalf("Inv_NoOrphanedResources: phase=%s but ConfigMap gen=%d survives (currentGen=%d)",
+					m.status.Phase, gen, cur)
+			}
+		}
+		for gen := range m.api.headlessSvcs {
+			if gen != cur {
+				t.Fatalf("Inv_NoOrphanedResources: phase=%s but HeadlessSvc gen=%d survives (currentGen=%d)",
+					m.status.Phase, gen, cur)
+			}
+		}
+	},
+}
+
+// goOnlyEngineInvariants are entries in the registry with no conjunct of their
+// own in the spec's Safety predicate. Keeping the set explicit means
+// TestEngineInvariantsMatchSpec can also catch the opposite drift: a registry
+// key that the spec no longer has, i.e. an invariant renamed in the spec and
+// left stale here.
+var goOnlyEngineInvariants = map[string]string{
+	"Inv_NoOrphanedResources": "the spec folds resource deletion into its reconciler actions; " +
+		"Go has a separate GC step worth asserting on its own",
+}
+
+// engineSimSvcTargetGen reads the generation the cluster Service selects.
+// Reports false when there is no Service, which several invariants treat as
+// vacuous rather than as a violation.
+func engineSimSvcTargetGen(t invariantT, m *engineSim) (int, bool) {
+	if m.api.clusterSvc == nil {
+		return 0, false
+	}
+	raw, ok := m.api.clusterSvc.Spec.Selector[LabelGeneration]
+	if !ok {
+		t.Fatalf("cluster Service is missing the %s selector label", LabelGeneration)
+		return 0, false
+	}
+	gen, err := strconv.Atoi(raw)
+	if err != nil {
+		t.Fatalf("cluster Service has a non-numeric %s selector: %q", LabelGeneration, raw)
+		return 0, false
+	}
+	return gen, true
+}
+
+// checkEngineInvariants runs every registered invariant. Sorted so a failing run
+// reports the same invariant first every time, whichever harness called it.
+func checkEngineInvariants(t invariantT, m *engineSim) {
+	names := make([]string, 0, len(engineInvariants))
+	for name := range engineInvariants {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		engineInvariants[name](t, m)
+	}
+}
+
+// TestEngineInvariantsMatchSpec is the anti-drift guard: the spec's Safety
+// conjuncts and the Go registry must name the same invariants, modulo the
+// explicitly documented Go-only set.
+func TestEngineInvariantsMatchSpec(t *testing.T) {
+	required := make(map[string]bool, len(tlaRequiredInvariants))
+	for _, name := range tlaRequiredInvariants {
+		required[name] = true
+		if _, ok := engineInvariants[name]; !ok {
+			t.Errorf("formal/FireboltEngine.tla conjoins %s into Safety but the Go registry does not implement it.\n"+
+				"Add it to engineInvariants so both harnesses check it. If it genuinely cannot be expressed "+
+				"against engineSim, say why in a documented exemption rather than dropping it silently.", name)
+		}
+	}
+	for name := range engineInvariants {
+		if required[name] {
+			continue
+		}
+		if _, ok := goOnlyEngineInvariants[name]; !ok {
+			t.Errorf("the Go registry has %s, which is not a Safety conjunct and is not listed in "+
+				"goOnlyEngineInvariants. Either it was renamed in the spec (fix the key) or it is Go-only "+
+				"(document why).", name)
+		}
+	}
+	if len(tlaRequiredInvariants) == 0 {
+		t.Fatal("tlaRequiredInvariants is empty: the generator stopped parsing the spec's Safety predicate")
+	}
+	t.Logf("%d spec conjuncts, %d registered invariants (%d Go-only)",
+		len(tlaRequiredInvariants), len(engineInvariants), len(goOnlyEngineInvariants))
+}

--- a/internal/controller/engine_invariants_test.go
+++ b/internal/controller/engine_invariants_test.go
@@ -169,12 +169,29 @@ var engineInvariants = map[string]func(t invariantT, m *engineSim){
 		if !isTerminalPhase(m.status.Phase) {
 			return
 		}
-		// Quiesced also means the reconciler has caught up with the last spec
-		// change. The spec gets that from StsMatchesSpec, because its
-		// EnvChangeSpec always bumps specVer; Go has spec changes that produce
-		// no template drift (replicas are applied in place by design), so the
-		// terminal phase can legitimately name the old intent for one reconcile.
-		// See engineSim.specDirty.
+		// Quiesced also means the reconciler has caught up with the last
+		// spec change, and stsMatchesSpec below does NOT establish that on
+		// its own.
+		//
+		// The window it misses is status lag, not template drift: a
+		// reconcile can bring the STS into line with a new spec and be
+		// observed before its status write lands. At that instant
+		// stsMatchesSpec is already true while status.Phase still names the
+		// previous intent — legitimately, for exactly one reconcile.
+		// specDirty tracks precisely that window ("a spec change happened
+		// and no reconcile has written status since").
+		//
+		// Empirically load-bearing, not defensive: delete this guard and the
+		// suite fails at -rapid.checks=5000 with
+		//   Inv_QuiescedPhaseMatchesSpec: phase=stopped but spec.Replicas=3
+		//   (quiesced on a matching STS)
+		// It survives the default check count, which is why the interleaving
+		// is easy to talk yourself out of.
+		//
+		// An earlier version of this comment justified the guard by claiming
+		// replica edits leave stsMatchesSpec true because scaling is applied
+		// in place. That is false — stsMatchesSpec compares Replicas as its
+		// first check — and the true reason is the one above.
 		if m.specDirty {
 			return
 		}

--- a/internal/controller/engine_property_test.go
+++ b/internal/controller/engine_property_test.go
@@ -521,76 +521,16 @@ func (m *engineSim) DeleteEngine(_ *rapid.T) {
 	}
 }
 
-// ---------- Invariant checks (mirrors formal/FireboltEngine.tla Safety) ----------
+// ---------- Invariant checks ----------
 
-// Check is called by rapid after every action. All resource invariants run
-// against m.api (the api truth). The cache is only the controller's input;
-// transient cache/api divergence is the input space, not the bug surface.
+// Check is called by rapid after every action. The invariants themselves live in
+// engine_invariants_test.go, shared with the TLA+ state cover and keyed by the
+// spec's Safety conjunct names, so the two harnesses cannot drift apart or fall
+// behind the spec. All of them read m.api (the api truth); the cache is only the
+// controller's input, and transient cache/api divergence is the input space, not
+// the bug surface.
 func (m *engineSim) Check(t *rapid.T) {
-	s := &m.status
-
-	// Inv_TerminalConsistency: terminal phase => CurrentGeneration == ActiveGeneration
-	if isTerminalPhase(s.Phase) && s.CurrentGeneration != s.ActiveGeneration {
-		t.Fatalf("Inv_TerminalConsistency: phase=%s but CurrentGen=%d != ActiveGen=%d",
-			s.Phase, s.CurrentGeneration, s.ActiveGeneration)
-	}
-
-	// Inv_TerminalNoDraining: terminal phase => DrainingGeneration == nil
-	if isTerminalPhase(s.Phase) && s.DrainingGeneration != nil {
-		t.Fatalf("Inv_TerminalNoDraining: phase=%s but DrainingGen=%d",
-			s.Phase, *s.DrainingGeneration)
-	}
-
-	// Inv_ActiveHasSTS: ActiveGeneration >= 0 => STS for that gen exists
-	if s.ActiveGeneration >= 0 && m.api.stses[s.ActiveGeneration] == nil {
-		t.Fatalf("Inv_ActiveHasSTS: ActiveGen=%d has no STS in cluster",
-			s.ActiveGeneration)
-	}
-
-	// Inv_ServiceKnownGen + Inv_ServiceValid: once traffic is active, the
-	// cluster service selector points to a gen in {activeGen, currentGen}
-	// and that gen's STS exists.
-	if m.api.clusterSvc != nil && s.ActiveGeneration >= 0 {
-		genStr, ok := m.api.clusterSvc.Spec.Selector[LabelGeneration]
-		if !ok {
-			t.Fatalf("cluster service missing %s label", LabelGeneration)
-		}
-		targetGen, err := strconv.Atoi(genStr)
-		if err != nil {
-			t.Fatalf("invalid %s label on cluster service: %v", LabelGeneration, err)
-		}
-		if targetGen != s.ActiveGeneration && targetGen != s.CurrentGeneration {
-			t.Fatalf("Inv_ServiceKnownGen: svcTargetGen=%d ∉ {activeGen=%d, currentGen=%d}",
-				targetGen, s.ActiveGeneration, s.CurrentGeneration)
-		}
-		if m.api.stses[targetGen] == nil {
-			t.Fatalf("Inv_ServiceValid: svcTargetGen=%d has no STS in cluster", targetGen)
-		}
-	}
-
-	// Inv_NoOrphanedResources: terminal phase => only currentGen resources survive.
-	// GC runs as part of Reconcile when phase is terminal, so any stale gens still
-	// present after a Reconcile call indicate a GC gap.
-	if isTerminalPhase(s.Phase) {
-		for gen := range m.api.stses {
-			if gen != s.CurrentGeneration {
-				t.Fatalf("Inv_NoOrphanedResources: phase=%s but STS gen=%d survives (currentGen=%d)",
-					s.Phase, gen, s.CurrentGeneration)
-			}
-		}
-		for gen := range m.api.configMaps {
-			if gen != s.CurrentGeneration {
-				t.Fatalf("Inv_NoOrphanedResources: phase=%s but ConfigMap gen=%d survives (currentGen=%d)",
-					s.Phase, gen, s.CurrentGeneration)
-			}
-		}
-		for gen := range m.api.headlessSvcs {
-			if gen != s.CurrentGeneration {
-				t.Fatalf("Inv_NoOrphanedResources: phase=%s but HeadlessSvc gen=%d survives (currentGen=%d)",
-					s.Phase, gen, s.CurrentGeneration)
-			}
-		}
-	}
+	checkEngineInvariants(t, m)
 }
 
 func TestEngineStateMachine(t *testing.T) {

--- a/internal/controller/engine_property_test.go
+++ b/internal/controller/engine_property_test.go
@@ -130,6 +130,24 @@ type engineSim struct {
 	// podsDrained reflects whether the draining gen has zero active queries.
 	// Reset to false whenever a new drainingGen is established.
 	podsDrained bool
+
+	// specDirty records that the spec (or the referenced class) changed and no
+	// reconcile has caught up yet. It exists for Inv_QuiescedPhaseMatchesSpec,
+	// which only applies once the reconciler has quiesced.
+	//
+	// The spec gets "quiesced" for free: its EnvChangeSpec always bumps specVer,
+	// so StsMatchesSpec(currentGen) goes FALSE and the invariant's guard
+	// disables itself until reconciliation catches up. Go has spec changes that
+	// produce no template drift at all -- scaling replicas is applied to the
+	// StatefulSet in place and deliberately does not roll a generation -- so
+	// stsMatchesSpec stays TRUE while the terminal phase still names the old
+	// intent for exactly one reconcile. That lag is correct behavior, and only
+	// a random walk that changes replicas without reconciling can observe it.
+	//
+	// Set by every spec/class-mutating action, cleared by a Reconcile that
+	// writes status. Crash variants leave it set on purpose: a reconcile that
+	// died before its status write has not caught up.
+	specDirty bool
 }
 
 // buildState constructs the EngineState to pass to computeEngineReconcile
@@ -321,6 +339,7 @@ func (m *engineSim) Reconcile(t *rapid.T) {
 	if isTerminalPhase(m.status.Phase) {
 		m.gcStaleResources()
 	}
+	m.specDirty = false
 }
 
 // CrashReconcile applies only the resource writes — not the status update.
@@ -373,6 +392,7 @@ func (m *engineSim) CacheCatchesUp(_ *rapid.T) {
 // that breaks one branch (e.g. forgets to compare resources on the
 // engine container) gets caught.
 func (m *engineSim) ApplySpecChange(t *rapid.T) {
+	m.specDirty = true
 	if m.spec.Template == nil {
 		m.spec.Template = &corev1.PodTemplateSpec{}
 	}
@@ -408,6 +428,7 @@ func (m *engineSim) ApplySpecChange(t *rapid.T) {
 // stsMatchesSpec uses for engine spec edits applies here via the
 // AnnotationEngineClassHash comparison.
 func (m *engineSim) ApplyClassChange(t *rapid.T) {
+	m.specDirty = true
 	v := rapid.IntRange(0, 99).Draw(t, "classVersion")
 	if v == 0 {
 		m.classInfo = nil
@@ -493,6 +514,7 @@ func setSimContainerResources(tmpl *corev1.PodTemplateSpec, res corev1.ResourceR
 // Range includes 0 so that PhaseStopped is reachable.
 func (m *engineSim) ScaleReplicas(t *rapid.T) {
 	m.spec.Replicas = int32(rapid.IntRange(0, 5).Draw(t, "replicas"))
+	m.specDirty = true
 }
 
 // PodsBecomesReady marks the current generation's pods as all Running+Ready.
@@ -533,9 +555,50 @@ func (m *engineSim) Check(t *rapid.T) {
 	checkEngineInvariants(t, m)
 }
 
-func TestEngineStateMachine(t *testing.T) {
-	rapid.Check(t, func(t *rapid.T) {
-		m := &engineSim{
+// rapidStartStates are the indices into tlaStatePool that a walk may start from.
+//
+// Starting every walk from a brand-new engine wasted almost all of the harness's
+// effort. Measured over a default run, ~99.4% of Check calls landed in
+// `creating`, well under 1% in `switching` / `stable` / `stopped`, and
+// `draining` / `cleaning` were never reached at all -- 0 out of ~34k checks even
+// at -rapid.steps=300. Those phases are reachable in principle, but only via a
+// specific ~5-action ordering drawn from 9 equally-likely actions, twice over (an
+// engine has to finish one generation before a second switch can drain the
+// first), so uniform random selection effectively never assembles it. Every
+// invariant conditioned on a terminal phase or an active generation was
+// therefore vacuous here, and the state cover was doing all the real work.
+//
+// So draw the starting state from the model instead: materializeTLAState already
+// builds any reachable modeled state for the state cover, and a walk seeded from
+// a random one starts spread across the whole reachable space rather than
+// crawling out of a single corner.
+//
+// Gated states are excluded for exactly the reason the state cover skips them
+// (tlaShouldGateOut): the compute layer only runs when the outer Reconcile's
+// instance and class gates are open, and this harness calls the compute layer
+// directly. States on the model's MaxGen ceiling are kept -- unlike the state
+// cover, this harness has no closure oracle to disagree with, and a Go-side
+// generation bump past the model's bound is legitimate behavior worth walking.
+var rapidStartStates = func() []int {
+	idxs := make([]int, 0, len(tlaStatePool))
+	for i := range tlaStatePool {
+		if tlaShouldGateOut(tlaStatePool[i]) {
+			continue
+		}
+		idxs = append(idxs, i)
+	}
+	return idxs
+}()
+
+// drawEngineSimStart picks the state a walk begins from. Index -1 is the
+// from-scratch engine the harness used to always start with: a first reconcile
+// against an empty cluster. It is kept as its own case both because it is the
+// canonical entry point and because rapid shrinks towards the low end of a
+// range, so a minimal reproduction starts there when it can.
+func drawEngineSimStart(t *rapid.T) *engineSim {
+	idx := rapid.IntRange(-1, len(rapidStartStates)-1).Draw(t, "startState")
+	if idx < 0 {
+		return &engineSim{
 			spec: *testSpec(),
 			status: computev1alpha1.FireboltEngineStatus{
 				Phase:             computev1alpha1.PhaseCreating,
@@ -546,6 +609,12 @@ func TestEngineStateMachine(t *testing.T) {
 			cache:       newClusterView(),
 			podsDrained: true,
 		}
-		t.Repeat(rapid.StateMachineActions(m))
+	}
+	return materializeTLAState(tlaStatePool[rapidStartStates[idx]])
+}
+
+func TestEngineStateMachine(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		t.Repeat(rapid.StateMachineActions(drawEngineSimStart(t)))
 	})
 }

--- a/internal/controller/engine_property_test.go
+++ b/internal/controller/engine_property_test.go
@@ -135,14 +135,17 @@ type engineSim struct {
 	// reconcile has caught up yet. It exists for Inv_QuiescedPhaseMatchesSpec,
 	// which only applies once the reconciler has quiesced.
 	//
-	// The spec gets "quiesced" for free: its EnvChangeSpec always bumps specVer,
-	// so StsMatchesSpec(currentGen) goes FALSE and the invariant's guard
-	// disables itself until reconciliation catches up. Go has spec changes that
-	// produce no template drift at all -- scaling replicas is applied to the
-	// StatefulSet in place and deliberately does not roll a generation -- so
-	// stsMatchesSpec stays TRUE while the terminal phase still names the old
-	// intent for exactly one reconcile. That lag is correct behavior, and only
-	// a random walk that changes replicas without reconciling can observe it.
+	// The spec gets "quiesced" for free: its EnvChangeSpec always bumps
+	// specVer, so StsMatchesSpec(currentGen) goes FALSE and the invariant's
+	// guard disables itself until reconciliation catches up.
+	//
+	// Go needs this flag because stsMatchesSpec alone does not close the
+	// window. A reconcile can bring the StatefulSet into line with a new
+	// spec and be observed before its status write lands: at that instant
+	// stsMatchesSpec is already TRUE while the terminal phase still names
+	// the old intent. That lag is correct behavior for exactly one
+	// reconcile, and only a random walk that mutates the spec and observes
+	// between the two writes can see it.
 	//
 	// Set by every spec/class-mutating action, cleared by a Reconcile that
 	// writes status. Crash variants leave it set on purpose: a reconcile that
@@ -472,6 +475,13 @@ func (m *engineSim) ApplyClassUnready(_ *rapid.T) {
 // the carrier because both effective* paths use it and the field is
 // scalar (no value-equality subtlety).
 func (m *engineSim) ApplyConflictingClassAndEngine(t *rapid.T) {
+	// Like every other spec/class-mutating action. Inert for
+	// Inv_QuiescedPhaseMatchesSpec today, since that invariant only fires on
+	// a replicas-vs-phase mismatch and this action leaves replicas alone —
+	// but specDirty's contract is "set by every spec/class-mutating action",
+	// and an action that quietly opts out is a trap for the next invariant
+	// that leans on it.
+	m.specDirty = true
 	v := rapid.IntRange(1, 99).Draw(t, "conflictVersion")
 	if m.spec.Template == nil {
 		m.spec.Template = &corev1.PodTemplateSpec{}

--- a/internal/controller/engine_tla_state_test.go
+++ b/internal/controller/engine_tla_state_test.go
@@ -311,53 +311,13 @@ func tlaModelBoundary(s tlaState) bool {
 	}
 }
 
-// tlaInvariants verifies the same Safety predicates checked in the rapid
-// property test (engine_property_test.go's engineSim.Check) plus the TLA+
-// safety invariants that depend only on observable simulated state.
+// tlaInvariants runs the shared invariant registry (engine_invariants_test.go),
+// the same set the rapid harness checks after every action. Keyed by the spec's
+// Safety conjunct names, so a conjunct added to formal/FireboltEngine.tla fails
+// TestEngineInvariantsMatchSpec until it is implemented here too.
 func tlaInvariants(t *testing.T, m *engineSim) {
 	t.Helper()
-	s := &m.status
-
-	if isTerminalPhase(s.Phase) && s.CurrentGeneration != s.ActiveGeneration {
-		t.Fatalf("Inv_TerminalConsistency: phase=%s but CurrentGen=%d != ActiveGen=%d",
-			s.Phase, s.CurrentGeneration, s.ActiveGeneration)
-	}
-	if isTerminalPhase(s.Phase) && s.DrainingGeneration != nil {
-		t.Fatalf("Inv_TerminalNoDraining: phase=%s but DrainingGen=%d",
-			s.Phase, *s.DrainingGeneration)
-	}
-	if s.ActiveGeneration >= 0 && m.api.stses[s.ActiveGeneration] == nil {
-		t.Fatalf("Inv_ActiveHasSTS: ActiveGen=%d has no STS", s.ActiveGeneration)
-	}
-	if s.DrainingGeneration != nil && s.Phase != computev1alpha1.PhaseDraining && s.Phase != computev1alpha1.PhaseCleaning {
-		t.Fatalf("Inv_DrainingPhase: DrainingGen=%d but phase=%s",
-			*s.DrainingGeneration, s.Phase)
-	}
-	if s.DrainingGeneration != nil && *s.DrainingGeneration >= s.CurrentGeneration {
-		t.Fatalf("Inv_DrainingOlderThanCurrent: DrainingGen=%d, CurrentGen=%d",
-			*s.DrainingGeneration, s.CurrentGeneration)
-	}
-	if s.ActiveGeneration > s.CurrentGeneration {
-		t.Fatalf("Inv_GenOrder: ActiveGen=%d > CurrentGen=%d",
-			s.ActiveGeneration, s.CurrentGeneration)
-	}
-	if m.api.clusterSvc != nil && s.ActiveGeneration >= 0 {
-		genStr, ok := m.api.clusterSvc.Spec.Selector[LabelGeneration]
-		if !ok {
-			t.Fatalf("cluster service missing %s label", LabelGeneration)
-		}
-		targetGen, err := strconv.Atoi(genStr)
-		if err != nil {
-			t.Fatalf("invalid %s label on cluster service: %v", LabelGeneration, err)
-		}
-		if targetGen != s.ActiveGeneration && targetGen != s.CurrentGeneration {
-			t.Fatalf("Inv_ServiceKnownGen: svcTargetGen=%d not in {activeGen=%d, currentGen=%d}",
-				targetGen, s.ActiveGeneration, s.CurrentGeneration)
-		}
-		if m.api.stses[targetGen] == nil {
-			t.Fatalf("Inv_ServiceValid: svcTargetGen=%d has no STS", targetGen)
-		}
-	}
+	checkEngineInvariants(t, m)
 }
 
 // closureContains reports whether `actual` is one of the TLA+ states the model

--- a/internal/controller/engine_tla_states_data_test.go
+++ b/internal/controller/engine_tla_states_data_test.go
@@ -47,6 +47,26 @@ const (
 )
 
 
+// tlaRequiredInvariants are the conjuncts of the spec's `Safety ==`
+// predicate, in spec order. engine_invariants_test.go asserts that every
+// one of them has a Go counterpart in the shared invariant registry, so a
+// conjunct added to the spec fails the build until it is implemented -- the
+// invariants are hand-transcribed into the harnesses, and nothing else
+// notices when the spec grows one they do not check.
+var tlaRequiredInvariants = []string{
+	"TypeOK",
+	"Inv_TerminalConsistency",
+	"Inv_ServiceValid",
+	"Inv_TerminalHasSTS",
+	"Inv_ActiveHasSTS",
+	"Inv_ServiceKnownGen",
+	"Inv_DrainingPhase",
+	"Inv_TerminalNoDraining",
+	"Inv_DrainingOlderThanCurrent",
+	"Inv_GenOrder",
+	"Inv_QuiescedPhaseMatchesSpec",
+}
+
 // 6404 unique reachable TLA+ states (uninitialised excluded).
 var tlaStatePool = []tlaState{
 	{"cleaning", 1, 1, 0, 1, false, [4]int{0, 1, -1, -1}, 1, true, true, false, false},

--- a/scripts/gen-tla-state-tests.py
+++ b/scripts/gen-tla-state-tests.py
@@ -58,6 +58,68 @@ EDGE_RE = re.compile(r'^(-?\d+)\s+->\s+(-?\d+)\s+\[label="(' + LABEL_BODY + r')"
 # stsSpecVer = (0 :> -1 @@ 1 :> -1 @@ 2 :> -1)
 FN_ENTRY_RE = re.compile(r"(-?\d+)\s*:>\s*(-?\d+)")
 
+# Conjuncts of the spec's `Safety ==` definition:
+#     Safety ==
+#         /\ TypeOK
+#         /\ Inv_TerminalConsistency
+SAFETY_START_RE = re.compile(r"^Safety\s*==\s*$")
+CONJUNCT_RE = re.compile(r"^\s*/\\\s*([A-Za-z_][A-Za-z0-9_]*)\s*$")
+
+
+def parse_safety_conjuncts(spec_path: Path) -> List[str]:
+    """Return the names conjoined into the spec's Safety predicate.
+
+    These are emitted into the fixture so the Go side can assert it implements
+    every one of them. The invariants are otherwise transcribed by hand into two
+    harnesses, and nothing notices when the spec grows a conjunct that neither
+    of them checks.
+    """
+    names: List[str] = []
+    in_safety = False
+    for line in spec_path.read_text().splitlines():
+        if not in_safety:
+            if SAFETY_START_RE.match(line):
+                in_safety = True
+            continue
+        m = CONJUNCT_RE.match(line)
+        if m:
+            names.append(m.group(1))
+            continue
+        # Blank lines and comments inside the definition are fine; anything else
+        # (the next definition, or a conjunct that is not a bare name) ends it.
+        if line.strip() == "" or line.lstrip().startswith("\\*"):
+            continue
+        break
+    if not names:
+        raise SystemExit(f"error: no Safety conjuncts parsed from {spec_path}")
+    return names
+
+
+def check_env_actions(edges: Iterable[Tuple[int, int, str]]) -> None:
+    """Fail if the state graph has an `Env*` action this script does not know.
+
+    Everything not in ENV_ACTIONS counts as a *reconciler* edge, so an
+    unrecognised environment action silently widens every reconciler closure and
+    weakens the whole state cover -- with no fixture staleness and no failing
+    test to show for it. Fail generation instead.
+    """
+    unknown = sorted(
+        {
+            action
+            for _, _, action in edges
+            if action.startswith("Env") and action not in ENV_ACTIONS
+        }
+    )
+    if unknown:
+        raise SystemExit(
+            "error: unrecognised environment action(s) in the state graph: "
+            + ", ".join(unknown)
+            + "\n       Add them to ENV_ACTIONS in this script. Until then they "
+            "count as\n       reconciler transitions, which widens every closure "
+            "and weakens the cover."
+        )
+
+
 
 def unescape_dot(s: str) -> str:
     """Decode DOT label escapes (\\, \", \n) into the corresponding chars."""
@@ -276,6 +338,12 @@ def main() -> int:
     parser.add_argument("--dot", required=True, type=Path, help="TLC DOT dump")
     parser.add_argument("--out", required=True, type=Path, help="Go fixture output path")
     parser.add_argument(
+        "--spec",
+        required=True,
+        type=Path,
+        help="TLA+ spec, read for the Safety predicate's conjunct list",
+    )
+    parser.add_argument(
         "--include-uninitialized",
         action="store_true",
         help="Include phase=uninitialized states (default: skip; the real code handles "
@@ -287,6 +355,9 @@ def main() -> int:
     if not nodes:
         print(f"error: no states parsed from {args.dot}", file=sys.stderr)
         return 1
+
+    check_env_actions(edges)
+    required_invariants = parse_safety_conjuncts(args.spec)
 
     # Partition edges into reconciler vs environment.
     reconciler_edges: Dict[int, List[int]] = defaultdict(list)
@@ -357,6 +428,19 @@ def main() -> int:
             max_gen=max_gen, max_spec=max_spec, max_gen_plus_one=max_gen + 1
         )
     ]
+    out_lines.append(
+        "// tlaRequiredInvariants are the conjuncts of the spec's `Safety ==`\n"
+        "// predicate, in spec order. engine_invariants_test.go asserts that every\n"
+        "// one of them has a Go counterpart in the shared invariant registry, so a\n"
+        "// conjunct added to the spec fails the build until it is implemented -- the\n"
+        "// invariants are hand-transcribed into the harnesses, and nothing else\n"
+        "// notices when the spec grows one they do not check."
+    )
+    out_lines.append("var tlaRequiredInvariants = []string{")
+    for name in required_invariants:
+        out_lines.append(f'\t"{name}",')
+    out_lines.append("}")
+    out_lines.append("")
     out_lines.append(f"// {len(pool_states)} unique reachable TLA+ states (uninitialised excluded).")
     out_lines.append("var tlaStatePool = []tlaState{")
     for s in pool_states:


### PR DESCRIPTION
Closes FB-2584. Was written on top of #94; that merged mid-flight, so this is rebased straight onto `main`.

The invariants lived in three hand-maintained copies and had drifted: `Inv_TerminalHasSTS` and `Inv_QuiescedPhaseMatchesSpec` were in the spec only, `Inv_NoOrphanedResources` in the rapid harness only, `Inv_DrainingPhase` / `Inv_DrainingOlderThanCurrent` / `Inv_GenOrder` in the state cover only. Nothing detected it, because nothing related the Go checks to the spec's list.

`engine_invariants_test.go` is now one registry keyed by the spec's conjunct names, called by both harnesses. The generator parses `Safety ==` out of the `.tla` and emits `tlaRequiredInvariants` into the fixture, and `TestEngineInvariantsMatchSpec` fails in *both* directions — a conjunct with no Go counterpart, and a registry key the spec no longer has (a rename left stale) unless it's declared deliberately Go-only with a reason.

This is the one that addresses **rapid-layer** drift specifically: #94/#95/#96 all harden the state-cover side and leave `engineSim.Check` untouched.

Two things beyond plumbing:

- **The two spec-only invariants are real coverage, not paperwork.** Both turned out to be reachable in both harnesses. `TypeOK` is necessarily partial — its bounded `Gens`/`SpecVers` membership is a model artifact, since the real reconciler bumps generations without an upper bound — so the Go form keeps what carries over and documents what doesn't.
- **`ENV_ACTIONS` in the generator was a fourth copy of spec knowledge, and the worst one.** Anything absent from that list counts as a *reconciler* edge, so a new `Env*` action in the spec would silently widen every closure and weaken the whole state cover, with no stale fixture and no failing test. Generation now fails on an unrecognised `Env*` action.

## Coverage

Four guards, each verified by making it fail: adding a conjunct to the spec fails the match test; renaming a registry key fails it from the other side; dropping `EnvSetGatesOpen` from `ENV_ACTIONS` fails generation. And since an invariant that cannot fail is worthless, both newly-implemented invariants were checked for reachability by negating their guards and confirming they fire in both harnesses.

Full controller package, lint and `make formal-verify` pass. The only fixture change is the new `tlaRequiredInvariants` block — state counts unchanged (6404 / 32 / 19).

Not included, because it needs #95's `formal/mutants/manifest.tsv`: mutant rows pointing at `TestEngineStateMachine` / `TestInstanceStateMachine`, so the rapid harness's teeth get pinned the way state cover's now are. Small follow-up once #95 lands — the patches exist, only the expected messages differ.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test code, formal fixture generation, and Makefile wiring; no production reconciler behavior is modified.
> 
> **Overview**
> Unifies **FireboltEngine** safety checks that were duplicated across the rapid property test and the TLA+ state cover, and wires them to the formal spec so they cannot drift silently.
> 
> **`engine_invariants_test.go`** is the single registry of `Safety` conjuncts (plus documented Go-only **`Inv_NoOrphanedResources`**). Both harnesses call **`checkEngineInvariants`**; **`TestEngineInvariantsMatchSpec`** requires every generated **`tlaRequiredInvariants`** entry to have a Go implementation and flags stale registry keys.
> 
> **`gen-tla-state-tests.py`** now takes **`--spec`**, parses **`Safety ==`** into **`tlaRequiredInvariants`** in the fixture, and **fails generation** on unknown **`Env*`** DOT actions (so they are not misclassified as reconciler edges). **`make formal-gen`** passes **`formal/FireboltEngine.tla`**.
> 
> **Rapid harness:** adds **`specDirty`** so **`Inv_QuiescedPhaseMatchesSpec`** respects status lag after spec/class edits; seeds walks from **`materializeTLAState`** / **`tlaStatePool`** (not only empty **`creating`**) so draining/cleaning and terminal invariants get exercised.
> 
> **Coverage gap closed:** implements spec-only invariants (**`Inv_TerminalHasSTS`**, **`Inv_QuiescedPhaseMatchesSpec`**) and state-cover-only ones (**`Inv_DrainingPhase`**, **`Inv_DrainingOlderThanCurrent`**, **`Inv_GenOrder`**) in the shared registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87ffb9582ef1182acc7724d9358abcc25a3d7d49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->