### PR TITLE
test(formal): pin every falsifiable engine guard as a counterexample (FB-2609)

### DIFF
--- a/.github/workflows/formal-verification.yaml
+++ b/.github/workflows/formal-verification.yaml
@@ -49,7 +49,7 @@ jobs:
             exit 0
           fi
           if printf '%s\n' "${files}" \
-            | grep -qE '^formal/|^scripts/gen-tla-[a-z-]*state-tests\.py$|_tla_states_data_test\.go$'; then
+            | grep -qE '^formal/|^scripts/gen-tla-[a-z-]*state-tests\.py$|_tla_states_data_test\.go$|^scripts/ci/check-counterexamples\.sh$'; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
           else
             echo "relevant=false" >> "$GITHUB_OUTPUT"
@@ -114,20 +114,14 @@ jobs:
             -config formal/SigningKeyRotation.cfg \
             formal/SigningKeyRotation.tla
 
-      - name: Run TLC — SigningKeyRotation naive anchor must still fail
-        run: |
-          # Requires TLC's specific violation line rather than a non-zero exit:
-          # a parse error or OOM also exits non-zero and would otherwise pass.
-          out="$(java -cp tla2tools.jar tlc2.TLC -workers 2 -nowarning \
-            -config formal/SigningKeyRotationNaive.cfg \
-            formal/SigningKeyRotation.tla 2>&1 || true)"
-          if echo "$out" | grep -q 'Invariant NoValidationGap is violated'; then
-            echo "OK: the naive retain-window anchor still violates NoValidationGap"
-          else
-            echo "::error::SigningKeyRotationNaive.cfg no longer produces the expected NoValidationGap violation"
-            echo "$out" | tail -40
-            exit 1
-          fi
+      - name: Every naive config must still produce its pinned violation
+        # Delegates to the same script and table the Makefile target uses. This
+        # step used to inline one config, and inlining is what made it wrong: the
+        # table grew to six negative controls while a hardcoded copy would have
+        # gone on checking one of them and reporting success.
+        # Through `bash`, matching the model-scope step: the invocation does not
+        # need to depend on the file mode.
+        run: bash scripts/ci/check-counterexamples.sh tla2tools.jar
 
       - name: Verify state-cover fixtures are up to date
         run: |

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,16 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+# Defined up here, not next to the `$(LOCALBIN): mkdir` rule down in Build
+# Dependencies, because rule TARGETS are expanded when the makefile is read.
+# While this lived below the Formal Verification section, `$(TLA2TOOLS):`
+# expanded to the literal `/tla2tools.jar` -- a path that never exists, so the
+# rule fired on every single invocation. The recipe still wrote to the right
+# place (recipes expand at execution time, by which point LOCALBIN is set), which
+# is why it looked like it worked. Rule LOOKUP is order-independent, so the mkdir
+# rule can stay where it is.
+LOCALBIN ?= $(shell pwd)/bin
+
 # CONTAINER_TOOL defines the container tool to be used for building images.
 # Be aware that the target commands are only tested with Docker which is
 # scaffolded by default. However, you might want to replace it to use other
@@ -356,7 +366,11 @@ TLA2TOOLS ?= $(LOCALBIN)/tla2tools.jar
 TLA2TOOLS_VERSION ?= v1.8.0
 TLA2TOOLS_URL ?= https://github.com/tlaplus/tlaplus/releases/download/$(TLA2TOOLS_VERSION)/tla2tools.jar
 
-$(TLA2TOOLS): $(LOCALBIN)
+# Order-only prerequisite (the `|`) so bin/'s mtime does not count: as a normal
+# prerequisite, any rule that writes into bin/ bumps the directory past the jar
+# and the download runs again. Together with hoisting LOCALBIN (see above) this
+# stops every formal target re-fetching 4.5MB, and lets caching bin/ in CI work.
+$(TLA2TOOLS): | $(LOCALBIN)
 	wget -q -O "$(TLA2TOOLS)" "$(TLA2TOOLS_URL)"
 
 .PHONY: tla2tools
@@ -462,7 +476,6 @@ formal-verify: formal-gen ## CI guard: regenerate the fixtures and fail if any g
 ##@ Dependencies
 
 ## Location to install dependencies to
-LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN):
 	mkdir -p "$(LOCALBIN)"
 

--- a/Makefile
+++ b/Makefile
@@ -369,20 +369,11 @@ formal-check: tla2tools ## Run TLC model checker on all TLA+ specs.
 	java -cp "$(TLA2TOOLS)" tlc2.TLC -workers auto -config formal/SigningKeyRotation.cfg formal/SigningKeyRotation.tla
 
 .PHONY: formal-check-counterexample
-formal-check-counterexample: tla2tools ## Assert the naive retain-window anchor still violates NoValidationGap.
-	@# Requires TLC's specific violation line, not merely a non-zero exit: TLC also
-	@# exits non-zero on a parse error, a missing constant, or OOM, any of which
-	@# would otherwise make a broken spec look like a passing counterexample.
-	@out=$$(java -cp "$(TLA2TOOLS)" tlc2.TLC -workers auto -nowarning \
-		-config formal/SigningKeyRotationNaive.cfg formal/SigningKeyRotation.tla 2>&1 || true); \
-	if echo "$$out" | grep -q "Invariant NoValidationGap is violated"; then \
-		echo "OK: the naive retain-window anchor still violates NoValidationGap"; \
-	else \
-		echo "ERROR: SigningKeyRotationNaive.cfg no longer produces the expected NoValidationGap violation." >&2; \
-		echo "       Either the shipped convergence gate was weakened, or the model stopped expressing the hazard." >&2; \
-		echo "$$out" | tail -40 >&2; \
-		exit 1; \
-	fi
+formal-check-counterexample: tla2tools ## Assert every naive config still produces its pinned violation.
+	@# Table-driven off formal/counterexamples.tsv: adding a negative control is a
+	@# one-line change, and the script refuses any formal/*Naive*.cfg the table
+	@# omits, so a config cannot be added without also being run.
+	@scripts/ci/check-counterexamples.sh "$(TLA2TOOLS)"
 
 .PHONY: formal-check-mutants
 formal-check-mutants: ## Assert each pinned mutant still makes the state-cover suite fail.

--- a/formal/FireboltEngine.cfg
+++ b/formal/FireboltEngine.cfg
@@ -10,15 +10,21 @@
 \*   MaxSpec=4 gives spec versions 0..4 (covers 3 spec changes mid-creating)
 \*
 \* Expected TLC runtime: ~2 seconds on a laptop. The deeper bounds explore
-\* ~3,200 reachable states (vs ~1,400 at MaxGen=2/MaxSpec=3) for negligible
-\* extra time, so there is no separate "shallow vs deep" config.
+\* 6,476 distinct states (vs 2,772 at MaxGen=2/MaxSpec=3) for negligible extra
+\* time, so there is no separate "shallow vs deep" config. Both figures measured
+\* 2026-07-28; the previous ones (~3,200 / ~1,400) predated the classReady gate.
 
 CONSTANTS
     MaxGen = 3
     MaxSpec = 4
-    \* FALSE selects the shipped cutover gate. See
-    \* FireboltEngineNaiveService.cfg for the counterexample.
+    \* Every counterexample flag is FALSE here: this config checks the design as
+    \* it ships. Each one has a FireboltEngineNaive*.cfg that flips it and pins
+    \* the resulting violation; see formal/counterexamples.tsv.
     SwitchWithoutService = FALSE
+    GCOutsideTerminalPhase = FALSE
+    GCCurrentGeneration = FALSE
+    AdvanceWithoutMatchingSTS = FALSE
+    DriftDuringDrain = FALSE
 
 SPECIFICATION Spec
 

--- a/formal/FireboltEngine.cfg
+++ b/formal/FireboltEngine.cfg
@@ -16,6 +16,9 @@
 CONSTANTS
     MaxGen = 3
     MaxSpec = 4
+    \* FALSE selects the shipped cutover gate. See
+    \* FireboltEngineNaiveService.cfg for the counterexample.
+    SwitchWithoutService = FALSE
 
 SPECIFICATION Spec
 

--- a/formal/FireboltEngine.tla
+++ b/formal/FireboltEngine.tla
@@ -58,7 +58,15 @@ EXTENDS Integers, TLC
 
 CONSTANTS
     MaxGen,     \* upper bound on generation numbers (e.g. 2)
-    MaxSpec     \* upper bound on spec versions (e.g. 2)
+    MaxSpec,    \* upper bound on spec versions (e.g. 2)
+    SwitchWithoutService
+      \* TRUE removes the cutover gate in ReconcileSwitching_Complete: the
+      \* switch finalises even though the cluster Service still points at an
+      \* older generation. The shipped design is FALSE;
+      \* FireboltEngineNaiveService.cfg flips it and
+      \* `make formal-check-counterexample` requires that TLC still reports the
+      \* Inv_ServiceKnownGen violation. Same shape as AnchorAtDemotion in
+      \* SigningKeyRotation.tla.
 
 Gens     == 0..MaxGen
 SpecVers == 0..MaxSpec
@@ -332,7 +340,7 @@ ReconcileSwitching_Complete ==
     \* (first deployment, activeGen = -1) go directly to a terminal phase
     \* chosen by TerminalPhase (stable or stopped).
     /\ phase = "switching"
-    /\ svcTargetGen = currentGen
+    /\ (svcTargetGen = currentGen \/ SwitchWithoutService)
     /\ activeGen' = currentGen
     /\ \/ \* First deployment: no old generation to drain.
           /\ activeGen = -1

--- a/formal/FireboltEngine.tla
+++ b/formal/FireboltEngine.tla
@@ -59,20 +59,63 @@ EXTENDS Integers, TLC
 CONSTANTS
     MaxGen,     \* upper bound on generation numbers (e.g. 2)
     MaxSpec,    \* upper bound on spec versions (e.g. 2)
-    SwitchWithoutService
+    \* The five flags below each remove ONE shipped guard. All are FALSE in
+    \* FireboltEngine.cfg -- that config checks the design as it ships. Each has a
+    \* FireboltEngineNaive*.cfg that flips exactly one of them and names the
+    \* invariant TLC must then report; `make formal-check-counterexample` runs
+    \* them and fails if any stops failing. Same shape as AnchorAtDemotion in
+    \* SigningKeyRotation.tla.
+    \*
+    \* They exist because a passing invariant is only evidence if it could have
+    \* failed. Five of the eleven invariants in this spec are falsifiable by
+    \* removing a guard, and those five are the ones flagged here. The other six
+    \* are not, for reasons worth writing down rather than leaving as a gap:
+    \* Inv_GenOrder and Inv_DrainingOlderThanCurrent hold structurally (activeGen
+    \* and drainingGen are only ever assigned currentGen or a smaller gen, so no
+    \* guard removal reaches them -- only a mutated WRITE would);
+    \* Inv_TerminalNoDraining is implied by Inv_DrainingPhase, since
+    \* TerminalPhases and {draining, cleaning} are disjoint;
+    \* Inv_TerminalConsistency and Inv_QuiescedPhaseMatchesSpec likewise need a
+    \* changed assignment rather than a dropped conjunct; and TypeOK cannot be
+    \* violated by any guard change. Those five needing mutated writes are covered
+    \* on the Go side instead, by formal/mutants/manifest.tsv.
+    SwitchWithoutService,
       \* TRUE removes the cutover gate in ReconcileSwitching_Complete: the
       \* switch finalises even though the cluster Service still points at an
-      \* older generation. The shipped design is FALSE;
-      \* FireboltEngineNaiveService.cfg flips it and
-      \* `make formal-check-counterexample` requires that TLC still reports the
-      \* Inv_ServiceKnownGen violation. Same shape as AnchorAtDemotion in
-      \* SigningKeyRotation.tla.
+      \* older generation. Violates Inv_ServiceKnownGen.
+    GCOutsideTerminalPhase,
+      \* TRUE removes the phase gate on GCOrphans, which in the implementation
+      \* is the `phase \in {PhaseStable, PhaseStopped}` check in Reconcile that
+      \* decides whether gcOrphanedResources runs at all. Mid-rollout the
+      \* still-serving generation is neither currentGen nor drainingGen, so GC
+      \* deletes the StatefulSet traffic is landing on. Violates Inv_ActiveHasSTS.
+    GCCurrentGeneration,
+      \* TRUE removes GCOrphans' `g # currentGen` exclusion, so GC deletes the
+      \* generation it is meant to be keeping. Violates Inv_TerminalHasSTS.
+    AdvanceWithoutMatchingSTS,
+      \* TRUE removes `StsMatchesSpec(currentGen)` from ReconcileCreating_Advance,
+      \* so creating advances to switching before the new generation's
+      \* StatefulSet exists; the Service selector is then flipped to a generation
+      \* that has none. Violates Inv_ServiceValid.
+    DriftDuringDrain
+      \* TRUE lets ReconcileTerminal_Drift fire in draining/cleaning, modelling
+      \* drift detection that is not gated on phase. Starting a new generation
+      \* mid-drain abandons drainingGen, leaking the StatefulSet it was going to
+      \* delete. Violates Inv_DrainingPhase.
 
 Gens     == 0..MaxGen
 SpecVers == 0..MaxSpec
 
 Phases == {"uninitialized", "stable", "creating", "switching", "draining", "cleaning", "stopped"}
 TerminalPhases == {"stable", "stopped"}
+
+\* Phase gates, widened by the counterexample flags. Written as sets rather than
+\* inline disjunctions so the guard at the use site still reads as one membership
+\* test and the shipped behaviour is what you get with every flag FALSE.
+GCPhases    == IF GCOutsideTerminalPhase THEN Phases ELSE TerminalPhases
+DriftPhases == IF DriftDuringDrain
+               THEN TerminalPhases \cup {"draining", "cleaning"}
+               ELSE TerminalPhases
 
 VARIABLES
     phase,          \* current reconciler phase
@@ -222,7 +265,7 @@ ReconcileInit ==
 ReconcileTerminal_Drift ==
     \* Spec changed or STS missing -> bump currentGen, go to creating.
     \* This is the only path out of a terminal phase.
-    /\ phase \in TerminalPhases
+    /\ phase \in DriftPhases
     /\ instanceReady
     /\ classReady
     /\ ~StsMatchesSpec(currentGen)
@@ -237,10 +280,10 @@ ReconcileTerminal_Drift ==
 \* Models gcOrphanedResources() in engine_gc.go, which is gated on
 \* phase \in {PhaseStable, PhaseStopped} in the top-level Reconcile.
 GCOrphans ==
-    /\ phase \in TerminalPhases
+    /\ phase \in GCPhases
     /\ \E g \in Gens :
            /\ StsExists(g)
-           /\ g # currentGen
+           /\ (g # currentGen \/ GCCurrentGeneration)
            /\ g # drainingGen   \* drainingGen=-1 never equals any gen in Gens
            /\ stsSpecVer' = [stsSpecVer EXCEPT ![g] = -1]
     /\ UNCHANGED <<phase, currentGen, activeGen, drainingGen, specVer, specWantsStop,
@@ -314,7 +357,7 @@ ReconcileCreating_Advance ==
     /\ phase = "creating"
     /\ instanceReady
     /\ classReady
-    /\ StsMatchesSpec(currentGen)
+    /\ (StsMatchesSpec(currentGen) \/ AdvanceWithoutMatchingSTS)
     /\ svcTargetGen # -1
     /\ podsReady
     /\ phase' = "switching"

--- a/formal/FireboltEngineNaiveAdvance.cfg
+++ b/formal/FireboltEngineNaiveAdvance.cfg
@@ -1,0 +1,39 @@
+\* TLC configuration for FireboltEngine.tla with the creating-phase readiness
+\* gate REMOVED -- this configuration MUST FAIL.
+\*
+\* AdvanceWithoutMatchingSTS = TRUE drops `StsMatchesSpec(currentGen)` from
+\* ReconcileCreating_Advance, so the reconciler leaves creating for switching
+\* before the new generation's StatefulSet exists or matches the spec.
+\*
+\* The damage is not in switching itself: ReconcileSwitching_UpdateService
+\* deliberately carries no StatefulSet check, because by the time switching is
+\* entered the StatefulSet is supposed to have been verified. Remove the
+\* verification and the selector is flipped to a generation with no StatefulSet
+\* behind it, while activeGen still names the previous one -- the cluster Service
+\* points at nothing. TLC reports:
+\*
+\*   Invariant Inv_ServiceValid is violated.
+\*
+\* So this config also documents WHY switching needs no such guard of its own:
+\* the property is established once, on the way in.
+\*
+\* Only Inv_ServiceValid is listed, not Safety. See formal/counterexamples.tsv.
+\*
+\* No PROPERTIES and CHECK_DEADLOCK FALSE: a spec that violates safety says
+\* nothing useful about progress.
+
+CONSTANTS
+    MaxGen = 3
+    MaxSpec = 4
+    SwitchWithoutService = FALSE
+    GCOutsideTerminalPhase = FALSE
+    GCCurrentGeneration = FALSE
+    AdvanceWithoutMatchingSTS = TRUE
+    DriftDuringDrain = FALSE
+
+SPECIFICATION Spec
+
+CHECK_DEADLOCK FALSE
+
+INVARIANTS
+    Inv_ServiceValid

--- a/formal/FireboltEngineNaiveDrift.cfg
+++ b/formal/FireboltEngineNaiveDrift.cfg
@@ -1,0 +1,42 @@
+\* TLC configuration for FireboltEngine.tla with drift detection's phase gate
+\* WIDENED -- this configuration MUST FAIL.
+\*
+\* DriftDuringDrain = TRUE lets ReconcileTerminal_Drift fire in draining and
+\* cleaning as well as the terminal phases, modelling drift detection that reacts
+\* to a spec edit wherever it arrives rather than only from a settled state.
+\*
+\* That is a tempting change -- it looks like faster convergence on a spec edit
+\* that lands mid-rollout. What it actually does is abandon the drain: phase goes
+\* back to creating with drainingGen still set, so the old generation is never
+\* cleaned up and its StatefulSet leaks. Nothing later re-reads drainingGen,
+\* because every path that clears it starts from draining or cleaning. TLC
+\* reports:
+\*
+\*   Invariant Inv_DrainingPhase is violated.
+\*
+\* The correct handling is what ships: let the drain finish and pick the drift up
+\* on the next pass from the terminal phase, which costs one extra rollout and
+\* leaks nothing.
+\*
+\* Only Inv_DrainingPhase is listed, not Safety -- this mutation also trips
+\* Inv_TerminalNoDraining, which Inv_DrainingPhase implies. See
+\* formal/counterexamples.tsv.
+\*
+\* No PROPERTIES and CHECK_DEADLOCK FALSE: a spec that violates safety says
+\* nothing useful about progress.
+
+CONSTANTS
+    MaxGen = 3
+    MaxSpec = 4
+    SwitchWithoutService = FALSE
+    GCOutsideTerminalPhase = FALSE
+    GCCurrentGeneration = FALSE
+    AdvanceWithoutMatchingSTS = FALSE
+    DriftDuringDrain = TRUE
+
+SPECIFICATION Spec
+
+CHECK_DEADLOCK FALSE
+
+INVARIANTS
+    Inv_DrainingPhase

--- a/formal/FireboltEngineNaiveGCCurrent.cfg
+++ b/formal/FireboltEngineNaiveGCCurrent.cfg
@@ -1,0 +1,42 @@
+\* TLC configuration for FireboltEngine.tla with GC's currentGen exclusion
+\* REMOVED -- this configuration MUST FAIL.
+\*
+\* GCCurrentGeneration = TRUE drops `g # currentGen` from GCOrphans, so the
+\* garbage collector deletes the StatefulSet of the generation it is supposed to
+\* be keeping. An engine sitting in stable or stopped ends up with no StatefulSet
+\* for its current generation at all. TLC reports:
+\*
+\*   Invariant Inv_TerminalHasSTS is violated.
+\*
+\* Worth pinning even though it looks obvious, because Inv_TerminalHasSTS is the
+\* invariant that keeps a STOPPED engine's zero-replica StatefulSet around (see
+\* docs/operator-based-scaling.md). "Nothing is running, so nothing needs the
+\* StatefulSet" is a plausible-sounding simplification, and this is the config
+\* that says no.
+\*
+\* Note the sibling `g # drainingGen` exclusion is NOT falsifiable this way:
+\* GCOrphans only runs in terminal phases, where Inv_TerminalNoDraining already
+\* guarantees drainingGen = -1, so that conjunct is vacuously true and removing
+\* it changes no reachable state. It earns its place as defence for the
+\* GCOutsideTerminalPhase case, not as a guard TLC can exercise here.
+\*
+\* Only Inv_TerminalHasSTS is listed, not Safety. See formal/counterexamples.tsv.
+\*
+\* No PROPERTIES and CHECK_DEADLOCK FALSE: a spec that violates safety says
+\* nothing useful about progress.
+
+CONSTANTS
+    MaxGen = 3
+    MaxSpec = 4
+    SwitchWithoutService = FALSE
+    GCOutsideTerminalPhase = FALSE
+    GCCurrentGeneration = TRUE
+    AdvanceWithoutMatchingSTS = FALSE
+    DriftDuringDrain = FALSE
+
+SPECIFICATION Spec
+
+CHECK_DEADLOCK FALSE
+
+INVARIANTS
+    Inv_TerminalHasSTS

--- a/formal/FireboltEngineNaiveGCPhase.cfg
+++ b/formal/FireboltEngineNaiveGCPhase.cfg
@@ -1,0 +1,42 @@
+\* TLC configuration for FireboltEngine.tla with GC's phase gate REMOVED --
+\* this configuration MUST FAIL.
+\*
+\* GCOutsideTerminalPhase = TRUE lets GCOrphans run in any phase, modelling an
+\* implementation that calls gcOrphanedResources unconditionally instead of only
+\* for phase in {PhaseStable, PhaseStopped}.
+\*
+\* GC excludes currentGen and drainingGen, which is sufficient in a terminal
+\* phase -- there, currentGen = activeGen and there is nothing draining. It is
+\* NOT sufficient mid-rollout: between the generation bump and the cutover the
+\* still-serving generation is activeGen, which is neither currentGen (the new
+\* one being built) nor drainingGen (not set until switching completes). So GC
+\* deletes the StatefulSet that traffic is currently landing on. TLC reports:
+\*
+\*   Invariant Inv_ActiveHasSTS is violated.
+\*
+\* This is why the gate is on the phase and not on the generation set: no
+\* per-generation exclusion list inside GCOrphans would fix it, because activeGen
+\* is legitimately excluded from both sets during a rollout.
+\*
+\* Only Inv_ActiveHasSTS is listed, not Safety: with `INVARIANTS Safety` TLC
+\* prints only "Invariant Safety is violated" with no attribution. See
+\* formal/counterexamples.tsv.
+\*
+\* No PROPERTIES and CHECK_DEADLOCK FALSE: a spec that violates safety says
+\* nothing useful about progress.
+
+CONSTANTS
+    MaxGen = 3
+    MaxSpec = 4
+    SwitchWithoutService = FALSE
+    GCOutsideTerminalPhase = TRUE
+    GCCurrentGeneration = FALSE
+    AdvanceWithoutMatchingSTS = FALSE
+    DriftDuringDrain = FALSE
+
+SPECIFICATION Spec
+
+CHECK_DEADLOCK FALSE
+
+INVARIANTS
+    Inv_ActiveHasSTS

--- a/formal/FireboltEngineNaiveService.cfg
+++ b/formal/FireboltEngineNaiveService.cfg
@@ -29,6 +29,10 @@ CONSTANTS
     MaxGen = 3
     MaxSpec = 4
     SwitchWithoutService = TRUE
+    GCOutsideTerminalPhase = FALSE
+    GCCurrentGeneration = FALSE
+    AdvanceWithoutMatchingSTS = FALSE
+    DriftDuringDrain = FALSE
 
 SPECIFICATION Spec
 

--- a/formal/FireboltEngineNaiveService.cfg
+++ b/formal/FireboltEngineNaiveService.cfg
@@ -1,0 +1,38 @@
+\* TLC configuration for FireboltEngine.tla with the cutover gate REMOVED --
+\* this configuration MUST FAIL.
+\*
+\* SwitchWithoutService = TRUE drops `svcTargetGen = currentGen` from
+\* ReconcileSwitching_Complete, so the switch finalises while the cluster
+\* Service still selects an older generation. activeGen advances to a
+\* generation the Service does not point at, and the Service is left aimed at
+\* a generation that is neither active nor current. TLC reports:
+\*
+\*   Invariant Inv_ServiceKnownGen is violated.
+\*
+\* This is the same hazard as the pinned Go mutant
+\* switching-flip-active-without-service.patch, which removes the
+\* ClusterServiceTargetGen check in computeSwitching. Guard, TLA+ invariant and
+\* Go negative control all line up on this one -- the spec side proves the
+\* model's guard is load-bearing, the mutant proves the state-cover suite
+\* notices when the code drops it.
+\*
+\* Only Inv_ServiceKnownGen is listed, not Safety: with `INVARIANTS Safety`
+\* TLC prints only "Invariant Safety is violated" with no attribution, and this
+\* mutation also trips Inv_ServiceValid. Naming one invariant keeps the failure
+\* line unambiguous for the grep-based gate.
+\*
+\* No PROPERTIES and CHECK_DEADLOCK FALSE: a spec that violates safety says
+\* nothing useful about progress, and a mutation that disables an action can
+\* otherwise surface as a deadlock report instead of a violation.
+
+CONSTANTS
+    MaxGen = 3
+    MaxSpec = 4
+    SwitchWithoutService = TRUE
+
+SPECIFICATION Spec
+
+CHECK_DEADLOCK FALSE
+
+INVARIANTS
+    Inv_ServiceKnownGen

--- a/formal/counterexamples.tsv
+++ b/formal/counterexamples.tsv
@@ -24,3 +24,7 @@
 # table omits: a naive config nothing runs looks like coverage and is not.
 SigningKeyRotationNaive.cfg	SigningKeyRotation.tla	Invariant NoValidationGap is violated
 FireboltEngineNaiveService.cfg	FireboltEngine.tla	Invariant Inv_ServiceKnownGen is violated
+FireboltEngineNaiveGCPhase.cfg	FireboltEngine.tla	Invariant Inv_ActiveHasSTS is violated
+FireboltEngineNaiveGCCurrent.cfg	FireboltEngine.tla	Invariant Inv_TerminalHasSTS is violated
+FireboltEngineNaiveAdvance.cfg	FireboltEngine.tla	Invariant Inv_ServiceValid is violated
+FireboltEngineNaiveDrift.cfg	FireboltEngine.tla	Invariant Inv_DrainingPhase is violated

--- a/formal/counterexamples.tsv
+++ b/formal/counterexamples.tsv
@@ -1,0 +1,25 @@
+# Naive configs and the violation each one must still produce.
+#
+# <config>	<spec>	<expected TLC line>
+#
+# Read this as the negative controls for `make formal-check`. Each config flips
+# one boolean CONSTANT that removes a shipped guard from the spec, and the third
+# column is the line TLC must print as a result. A row that stops matching means
+# one of two things, and they are not interchangeable: either the guard is no
+# longer load-bearing (the design changed, and the row should be deleted with a
+# note saying why), or the invariant has gone vacuous (it can no longer fail, so
+# every green run that cites it is worthless). Do not relax the expectation
+# without deciding which of the two happened.
+#
+# The expected line is matched literally (grep -F) against the whole TLC log, so
+# it works for temporal properties ("Temporal property X is violated") as well as
+# invariants. Copy it from a real failing run rather than typing it from memory.
+#
+# Each config lists ONE invariant under INVARIANTS rather than Safety. With
+# `INVARIANTS Safety` TLC prints only "Invariant Safety is violated" with no
+# attribution, so the row could pass on a violation of some other conjunct —
+# a negative control that does not control for anything specific.
+#
+# scripts/ci/check-counterexamples.sh also refuses any formal/*Naive*.cfg this
+# table omits: a naive config nothing runs looks like coverage and is not.
+SigningKeyRotationNaive.cfg	SigningKeyRotation.tla	Invariant NoValidationGap is violated

--- a/formal/counterexamples.tsv
+++ b/formal/counterexamples.tsv
@@ -23,3 +23,4 @@
 # scripts/ci/check-counterexamples.sh also refuses any formal/*Naive*.cfg this
 # table omits: a naive config nothing runs looks like coverage and is not.
 SigningKeyRotationNaive.cfg	SigningKeyRotation.tla	Invariant NoValidationGap is violated
+FireboltEngineNaiveService.cfg	FireboltEngine.tla	Invariant Inv_ServiceKnownGen is violated

--- a/scripts/ci/check-counterexamples.sh
+++ b/scripts/ci/check-counterexamples.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Assert every naive config still produces the violation it was written to produce.
+#
+# A green TLC run is only evidence if the run *could* have gone red. An invariant
+# that no reachable state can violate passes forever, including after the guard it
+# was written to protect is deleted — the check keeps reporting success while it
+# has stopped checking anything. Each row below removes one shipped guard and
+# names the invariant that must then fail; if it stops failing, either the guard
+# was weakened somewhere else or the model no longer expresses the hazard.
+#
+# Usage:
+#   scripts/ci/check-counterexamples.sh [<tlc-jar>]
+#
+# Defaults to bin/tla2tools.jar, so it runs locally the same way it runs in CI.
+set -euo pipefail
+
+MANIFEST="formal/counterexamples.tsv"
+TLC_JAR="${1:-bin/tla2tools.jar}"
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "ERROR: $MANIFEST not found (run from the repository root)" >&2
+  exit 1
+fi
+if [ ! -f "$TLC_JAR" ]; then
+  echo "ERROR: $TLC_JAR not found; run \`make tla2tools\` first" >&2
+  exit 1
+fi
+
+# No `grep -q` on a pipeline anywhere below. Under `set -o pipefail`, grep -q
+# exits at the first match, the producer dies with SIGPIPE, and the pipeline
+# reports 141 — a "match" would read as a failure. Every grep here reads a FILE
+# to completion, which has no such edge. Same reasoning as check-model-scope.sh.
+
+fail=0
+listed=""
+
+while IFS="$(printf '\t')" read -r cfg spec expect; do
+  case "$cfg" in '' | \#*) continue ;; esac
+  listed="$listed $cfg"
+
+  for f in "formal/$cfg" "formal/$spec"; do
+    if [ ! -f "$f" ]; then
+      echo "ERROR: $MANIFEST names $f, which does not exist." >&2
+      fail=1
+      continue 2
+    fi
+  done
+
+  echo "counterexample: $cfg"
+
+  # TLC's own violation line is the assertion, not merely a non-zero exit: TLC
+  # exits non-zero on a parse error, an unassigned constant and OOM too, any of
+  # which would otherwise make a broken spec look like a passing counterexample.
+  log="$(mktemp "${TMPDIR:-/tmp}/counterexample.XXXXXX")"
+  java -cp "$TLC_JAR" tlc2.TLC -workers auto -nowarning \
+    -config "formal/$cfg" "formal/$spec" >"$log" 2>&1 || true
+
+  if grep -qF "$expect" "$log"; then
+    echo "  OK: still reports \"$expect\""
+    rm -f "$log"
+    continue
+  fi
+
+  echo "ERROR: $cfg no longer produces \"$expect\"." >&2
+  echo "       Either the shipped guard was weakened, or the model stopped expressing" >&2
+  echo "       the hazard. Do not relax the expectation without establishing which." >&2
+  tail -40 "$log" >&2
+  rm -f "$log"
+  fail=1
+done <"$MANIFEST"
+
+if [ -z "$listed" ]; then
+  echo "ERROR: $MANIFEST lists no counterexamples at all." >&2
+  exit 1
+fi
+
+# A naive config nothing runs is worse than no config: it looks like coverage in
+# the directory listing and proves nothing. Every one of them must be in the table.
+for path in formal/*Naive*.cfg; do
+  base="$(basename "$path")"
+  case " $listed " in
+  *" $base "*) continue ;;
+  esac
+  echo "ERROR: $path is not listed in $MANIFEST, so nothing ever runs it." >&2
+  fail=1
+done
+
+if [ "$fail" -ne 0 ]; then
+  exit 1
+fi
+echo "OK: every naive config still produces its pinned violation"


### PR DESCRIPTION
Stacked on #96 — review that first.

`formal/` had three specs and one naive config, so the counterexample check proved exactly one property could fail and nothing showed that any FireboltEngine invariant could. A green TLC run says nothing about an invariant no reachable state can violate.

This takes the engine spec from zero negative controls to five, one per guard TLC can actually falsify:

| flag | guard removed | violates |
| --- | --- | --- |
| `SwitchWithoutService` | cutover gate in `ReconcileSwitching_Complete` | `Inv_ServiceKnownGen` |
| `GCOutsideTerminalPhase` | phase gate on `GCOrphans` | `Inv_ActiveHasSTS` |
| `GCCurrentGeneration` | `g # currentGen` in `GCOrphans` | `Inv_TerminalHasSTS` |
| `AdvanceWithoutMatchingSTS` | `StsMatchesSpec` in `ReconcileCreating_Advance` | `Inv_ServiceValid` |
| `DriftDuringDrain` | phase gate on `ReconcileTerminal_Drift` | `Inv_DrainingPhase` |

The GC phase gate is the interesting one. `GCOrphans` excludes `currentGen` and `drainingGen`, which is enough in a terminal phase but not mid-rollout: between the generation bump and the cutover the still-serving generation is `activeGen`, which is neither. So an ungated GC deletes the StatefulSet traffic is landing on — and that's why the gate is on the phase rather than the generation set, since no exclusion list inside `GCOrphans` could fix it.

`DriftDuringDrain` pins a change that looks like an improvement: reacting to a spec edit that arrives mid-rollout instead of waiting for the drain. It abandons `drainingGen` with phase back at creating, and nothing downstream clears it, because every path that does starts from draining or cleaning.

Five of eleven invariants are falsifiable by removing a guard. The `CONSTANTS` block now records why the other six aren't, so it's a documented conclusion rather than a gap nobody looked at — two hold structurally, `Inv_TerminalNoDraining` is implied by `Inv_DrainingPhase`, two need a changed assignment, and `TypeOK` can't be broken by a guard change. Those are covered Go-side by `formal/mutants/manifest.tsv`, which mutates writes.

### Also here

The check is now table-driven off `formal/counterexamples.tsv` via `scripts/ci/check-counterexamples.sh`, matching how #96 does `model-scope.tsv`. Adding a control is one line, and the script refuses any `formal/*Naive*.cfg` the table omits — a naive config nothing runs looks like coverage and isn't.

The CI job had the single config inlined as its own shell step, so these four would never have run there. It calls the script now. Left alone: the three `Run TLC — <spec>` steps still duplicate `make formal-check`.

Separately, `make tla2tools` re-downloaded 4.5MB on *every* formal target. `LOCALBIN` was defined ~100 lines below the rule, and rule targets expand when the makefile is read, so `$(TLA2TOOLS):` expanded to a literal `/tla2tools.jar` that never exists. It looked like it worked because recipes expand at execution time. Hoisted the assignment and made the prerequisite order-only.

### Test coverage

All six negative controls run in ~5s and each reports its named invariant; the shipped config still passes with every flag FALSE, which is what establishes the flag is the cause. The script's three failure paths are covered: a wrong expectation, an unlisted naive config, and a row naming a missing file each exit 1 with the reason.

Two claims in the comments were checked rather than reasoned about. `g # drainingGen` in `GCOrphans` really is vacuous — removing it entirely still passes, because GC only runs in terminal phases where `Inv_TerminalNoDraining` forces `drainingGen = -1`. And the flags add no states: 6,476 distinct either way, which also showed `FireboltEngine.cfg`'s "~3,200" was already stale, so both figures there are now measured.

Every generated state-cover fixture is byte-identical, and all four pinned mutants still pass.

Closes FB-2609.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are formal verification, CI, and Makefile tooling; they do not alter runtime operator reconciliation or production code paths.
> 
> **Overview**
> **FireboltEngine** gains five boolean **counterexample constants** that each drop one shipped reconciler guard (cutover service check, GC phase/currentGen exclusions, creating STS match, terminal-only drift). The main `FireboltEngine.cfg` sets them all **FALSE**; new `FireboltEngineNaive*.cfg` files flip one flag each and pin a **specific invariant violation** TLC must print.
> 
> Negative controls are **table-driven**: `formal/counterexamples.tsv` lists six rows (five engine + existing signing-key rotation). `scripts/ci/check-counterexamples.sh` runs TLC per row, greps for the expected violation line (not just exit code), and **fails if any `formal/*Naive*.cfg` is missing from the table**. CI replaces the single inlined naive check with this script; workflow path detection includes the script.
> 
> **Makefile**: `LOCALBIN` is hoisted so `$(TLA2TOOLS)` resolves correctly at parse time; the jar uses an **order-only** `bin/` prerequisite to stop re-downloading on every formal target. `formal-check-counterexample` delegates to the script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26d7152cc264b476b3d38ad4a4d6b28b946a5f04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->