### PR TITLE
fix(formal): reject vacuous counterexample rows (FB-2609)

### DIFF
--- a/formal/FireboltEngine.tla
+++ b/formal/FireboltEngine.tla
@@ -77,8 +77,11 @@ CONSTANTS
     \* TerminalPhases and {draining, cleaning} are disjoint;
     \* Inv_TerminalConsistency and Inv_QuiescedPhaseMatchesSpec likewise need a
     \* changed assignment rather than a dropped conjunct; and TypeOK cannot be
-    \* violated by any guard change. Those five needing mutated writes are covered
-    \* on the Go side instead, by formal/mutants/manifest.tsv.
+    \* violated by any guard change. The four needing a mutated write are NOT
+    \* pinned anywhere today: formal/mutants/manifest.tsv mutates the Go
+    \* reconciler, not this spec, and none of its rows targets them. Covering
+    \* them takes the AnchorAtDemotion flag shape (change a write, not drop a
+    \* guard) and is a deliberate follow-up, not coverage that already exists.
     SwitchWithoutService,
       \* TRUE removes the cutover gate in ReconcileSwitching_Complete: the
       \* switch finalises even though the cluster Service still points at an

--- a/formal/FireboltEngineNaiveDrift.cfg
+++ b/formal/FireboltEngineNaiveDrift.cfg
@@ -2,8 +2,9 @@
 \* WIDENED -- this configuration MUST FAIL.
 \*
 \* DriftDuringDrain = TRUE lets ReconcileTerminal_Drift fire in draining and
-\* cleaning as well as the terminal phases, modelling drift detection that reacts
-\* to a spec edit wherever it arrives rather than only from a settled state.
+\* cleaning as well as the terminal phases, modelling drift detection that does
+\* not wait for a drain to settle. (It widens only into the drain phases:
+\* creating and switching have their own drift handling and are not affected.)
 \*
 \* That is a tempting change -- it looks like faster convergence on a spec edit
 \* that lands mid-rollout. What it actually does is abandon the drain: phase goes

--- a/scripts/ci/check-counterexamples.sh
+++ b/scripts/ci/check-counterexamples.sh
@@ -34,9 +34,23 @@ fi
 fail=0
 listed=""
 
+# The current row's TLC log; the trap covers an interrupt mid-row.
+log=""
+trap '[ -n "$log" ] && rm -f "$log"' EXIT
+
 while IFS="$(printf '\t')" read -r cfg spec expect; do
   case "$cfg" in '' | \#*) continue ;; esac
   listed="$listed $cfg"
+
+  # A row with a missing column must fail loudly, not vacuously: grep -F ""
+  # matches every log, so an empty expectation would turn the row into a check
+  # that can never go red — the exact failure mode this script exists to catch.
+  if [ -z "$spec" ] || [ -z "$expect" ]; then
+    echo "ERROR: $MANIFEST row \"$cfg\" is missing its spec or expectation column" >&2
+    echo "       (want <cfg><TAB><spec><TAB><violation line>)." >&2
+    fail=1
+    continue
+  fi
 
   for f in "formal/$cfg" "formal/$spec"; do
     if [ ! -f "$f" ]; then


### PR DESCRIPTION
Follow-ups from reviewing #101 after it merged:

- a `counterexamples.tsv` row with a missing expectation column passed vacuously — `grep -qF ""` matches any TLC log, so the row could never go red. It now fails loudly before anything runs, and the per-row TLC log is cleaned up on interrupt.
- the CONSTANTS comment in `FireboltEngine.tla` claimed the four write-mutation invariants are covered by `formal/mutants/manifest.tsv`; no row there targets them. The comment now says they are deliberately unpinned follow-up work. The NaiveDrift cfg comment also overstated how far the widened drift gate reaches (drain phases only).

Coverage: the new guard is exercised by a crafted two-column row (errors before TLC runs); the full table still passes with all six pinned violations reported, so the comment-only spec edits parse clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI validation and formal comment-only edits; no reconciler or runtime behavior changes.
> 
> **Overview**
> **`check-counterexamples.sh`** now errors when a `counterexamples.tsv` row is missing its spec or expectation column, so an empty `grep -F ""` can’t make a row pass forever. It also registers an **EXIT trap** to remove the per-row TLC temp log if the run is interrupted.
> 
> **`FireboltEngine.tla`** updates the CONSTANTS comment: the four invariants that need a **mutated write** (not a dropped guard) are **not** covered by `formal/mutants/manifest.tsv` (Go mutants, different target) and are called out as deliberate follow-up (AnchorAtDemotion-style flags), not existing coverage.
> 
> **`FireboltEngineNaiveDrift.cfg`** narrows the comment so widened drift applies only in **draining/cleaning**, not creating/switching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b5cf147dd0200ec287311b78b514055900c3001. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->