### PR TITLE
fix(gateway): wake-on-zero review follow-ups (FB-2553)

### DIFF
--- a/formal/model-scope.tsv
+++ b/formal/model-scope.tsv
@@ -15,8 +15,8 @@
 #
 #   * auto-stop (computeAutoStopDecision) -- covered by a rapid harness with
 #     hand-written precedence invariants (engine_autostop_property_test.go),
-#     which is not a spec binding
-#   * gateway wake-on-zero
+#     which is not a spec binding (FB-2618)
+#   * gateway wake-on-zero (FB-2618)
 #   * FireboltEngineClass merge / drift detection (stsMatchesSpec and the
 #     effective* resolvers)
 #   * drain probing and its timeouts (deliberately deferred: fuzzed time is the

--- a/internal/controller/wake_demand.go
+++ b/internal/controller/wake_demand.go
@@ -343,7 +343,7 @@ func (t *WakeDemandTracker) watches(namespace string) bool {
 // The real fix is authenticating the payload rather than identifying its
 // sender — an operator-provisioned per-instance token the agent presents,
 // or mTLS on the demand endpoint. Worth doing if wake ever gates something
-// costlier than a scale-up. Tracked on FB-2553.
+// costlier than a scale-up. Tracked on FB-2619.
 func (t *WakeDemandTracker) gatewayPods(ctx context.Context, namespace string) ([]corev1.Pod, error) {
 	podList := &corev1.PodList{}
 	if err := t.Client.List(ctx, podList,

--- a/internal/wakeagent/agent_test.go
+++ b/internal/wakeagent/agent_test.go
@@ -165,6 +165,60 @@ func TestShedRequestStillCountsAsDemand(t *testing.T) {
 	}
 }
 
+// Engine names come from an untrusted header and pruning is time-based, so
+// a sustained stream of unique garbage names must hit a hard size bound
+// rather than grow the maps until the container's memory limit does the
+// bounding. Engines already tracked keep the stamp-before-shed contract:
+// their stamps refresh even when the tracker is full.
+func TestDemandTrackerCapsTrackedEngines(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1_700_000_000, 0)
+	d := newDemandTracker(10*time.Minute, func() time.Time { return now })
+
+	for i := 0; i < maxTrackedEngines; i++ {
+		d.Stamp(fmt.Sprintf("engine-%d", i))
+	}
+	now = now.Add(time.Minute)
+
+	d.Stamp("intruder")
+	d.Stamp("engine-0") // known name: must refresh despite the full tracker
+
+	d.mu.RLock()
+	tracked := len(d.last)
+	_, intruderKnown := d.last["intruder"]
+	refreshed := d.last["engine-0"]
+	dropped := d.dropped
+	d.mu.RUnlock()
+
+	if tracked != maxTrackedEngines {
+		t.Errorf("tracked engines = %d, want capped at %d", tracked, maxTrackedEngines)
+	}
+	if intruderKnown {
+		t.Error("stamp past the size cap was admitted")
+	}
+	if !refreshed.Equal(now) {
+		t.Errorf("known engine stamp = %v, want refreshed to %v", refreshed, now)
+	}
+	if dropped != 1 {
+		t.Errorf("dropped = %d, want 1", dropped)
+	}
+
+	// A shed for an unadmitted name must not sneak the name into the shed
+	// map either, and the drop has to be visible on the exposition.
+	if d.AcquireHold("intruder", 0) {
+		t.Fatal("AcquireHold admitted a request at a cap of 0")
+	}
+	d.mu.RLock()
+	_, shedKnown := d.shed["intruder"]
+	d.mu.RUnlock()
+	if shedKnown {
+		t.Error("shed count created an entry for an untracked engine")
+	}
+	if !strings.Contains(d.Render(), MetricDemandDroppedTotal+" 1") {
+		t.Errorf("dropped stamps not visible in render:\n%s", d.Render())
+	}
+}
+
 func TestReadinessTrackerWaitChanReleasesOnReady(t *testing.T) {
 	tr := newReadinessTracker()
 

--- a/internal/wakeagent/demand.go
+++ b/internal/wakeagent/demand.go
@@ -38,7 +38,25 @@ const (
 	// MetricSheddedTotal counts requests rejected because the hold cap was
 	// already reached.
 	MetricSheddedTotal = "firebolt_gateway_wake_shed_total"
+	// MetricDemandDroppedTotal counts demand stamps dropped because the
+	// tracker already holds maxTrackedEngines names. Unlabeled: labeling it
+	// by engine would recreate the growth the cap exists to stop.
+	MetricDemandDroppedTotal = "firebolt_gateway_wake_demand_dropped_total"
 )
+
+// maxTrackedEngines bounds how many engine names the tracker holds at once.
+//
+// Names arrive in an untrusted header and are never checked against engines
+// that exist, and eviction is time-based: entries younger than the retention
+// window (10 minutes) survive every prune. So without a size bound, a
+// sustained stream of unique garbage names grows the maps for a full
+// retention window — at the hold listener's request rate, easily past the
+// agent container's 128Mi memory limit (gatewayWakeAgentMemoryLimit) —
+// and the OOM kill takes the wake feature down exactly when someone is
+// probing it. Each tracked name costs a few hundred bytes across the maps,
+// so 4096 entries stay in the low single-digit MiB while being far more
+// engines than a namespace realistically runs.
+const maxTrackedEngines = 4096
 
 // demandTracker records, per engine, when the gateway last saw a request
 // for a stopped engine.
@@ -56,6 +74,9 @@ type demandTracker struct {
 	last    map[string]time.Time
 	pending map[string]int
 	shed    map[string]int64
+	// dropped counts stamps for new engine names rejected because the
+	// tracker was already at maxTrackedEngines.
+	dropped int64
 	// retention bounds how long an engine's entry survives without being
 	// refreshed. Entries are dropped on read so a gateway that has seen
 	// thousands of engines over its lifetime does not grow without bound,
@@ -79,9 +100,19 @@ func newDemandTracker(retention time.Duration, now func() time.Time) *demandTrac
 }
 
 // Stamp records demand for the engine as of now.
+//
+// A known engine always refreshes, even when the tracker is full — demand
+// is stamped before the hold cap is consulted, and that ordering must hold
+// for every engine already being watched. Only a stamp that would add a
+// new name past maxTrackedEngines is dropped, because admitting it would
+// let unique garbage names grow the maps without bound between prunes.
 func (d *demandTracker) Stamp(engine string) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
+	if _, known := d.last[engine]; !known && len(d.last) >= maxTrackedEngines {
+		d.dropped++
+		return
+	}
 	d.last[engine] = d.now()
 }
 
@@ -102,7 +133,12 @@ func (d *demandTracker) AcquireHold(engine string, limit int) bool {
 		total += n
 	}
 	if limit >= 0 && total >= limit {
-		d.shed[engine]++
+		// Count the shed against the engine only when it is tracked. When
+		// its stamp was dropped at the size cap, a per-engine count here
+		// would re-open the unbounded growth the cap closed.
+		if _, known := d.last[engine]; known {
+			d.shed[engine]++
+		}
 		return false
 	}
 	d.pending[engine]++
@@ -211,5 +247,12 @@ func (d *demandTracker) Render() string {
 	for _, r := range rows {
 		fmt.Fprintf(&b, "%s{engine=%q} %d\n", MetricSheddedTotal, r.engine, r.shed)
 	}
+	d.mu.RLock()
+	dropped := d.dropped
+	d.mu.RUnlock()
+	b.WriteString("# HELP " + MetricDemandDroppedTotal +
+		" Demand stamps dropped because the tracker was at its size cap.\n")
+	b.WriteString("# TYPE " + MetricDemandDroppedTotal + " counter\n")
+	fmt.Fprintf(&b, "%s %d\n", MetricDemandDroppedTotal, dropped)
 	return b.String()
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -58,12 +58,13 @@ const (
 	instanceReadyTimeout     = 300 * time.Second
 	pollInterval             = 1 * time.Second
 
-	// e2eGatewayWakeClusterRole is the name of the chart-managed
-	// ClusterRole that grants get/list/patch on fireboltengines to the
-	// gateway ServiceAccount. The suite creates it once in
-	// SynchronizedBeforeSuite (and deletes it in SynchronizedAfterSuite)
-	// and StartInstanceOperator passes it to every per-instance
-	// FireboltInstanceReconciler via GatewayWakeClusterRole.
+	// e2eGatewayWakeClusterRole is the name of the suite's stand-in for
+	// the chart-managed ClusterRole that grants get/list/watch on
+	// endpointslices to the gateway ServiceAccount — the wake-agent
+	// sidecar's entire, read-only Kubernetes grant. The suite creates it
+	// once in SynchronizedBeforeSuite (and deletes it in
+	// SynchronizedAfterSuite) and StartInstanceOperator passes it to every
+	// per-instance FireboltInstanceReconciler via GatewayWakeClusterRole.
 	e2eGatewayWakeClusterRole = "firebolt-gateway-wake-e2e"
 )
 
@@ -350,17 +351,19 @@ var _ = SynchronizedAfterSuite(func() {
 })
 
 // ensureGatewayWakeClusterRole creates (or refreshes) the cluster-wide
-// gateway-wake ClusterRole that earlier operator versions used to mint as
-// a per-instance Role. The chart ships an equivalent ClusterRole at
+// gateway-wake ClusterRole. The chart ships an equivalent ClusterRole at
 // install time; the E2E suite runs the operator in-process and bypasses
-// Helm, so the equivalent setup happens here.
+// Helm, so the equivalent setup happens here. The rules MUST mirror
+// helm/firebolt-operator/templates/clusterrole-gateway-wake.yaml: the
+// gateway pod terminates untrusted traffic, so its grant is read-only —
+// nothing bound to a gateway ServiceAccount may write to the API.
 func ensureGatewayWakeClusterRole(ctx context.Context, cs *kubernetes.Clientset) {
 	cr := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{Name: e2eGatewayWakeClusterRole},
 		Rules: []rbacv1.PolicyRule{{
-			APIGroups: []string{"compute.firebolt.io"},
-			Resources: []string{"fireboltengines"},
-			Verbs:     []string{"get", "list", "patch"},
+			APIGroups: []string{"discovery.k8s.io"},
+			Resources: []string{"endpointslices"},
+			Verbs:     []string{"get", "list", "watch"},
 		}},
 	}
 	createCtx, cancel := context.WithTimeout(ctx, 15*time.Second)


### PR DESCRIPTION
Follow-ups from reviewing #90 that didn't make the merge:

- the e2e suite still created a gateway ClusterRole with `get/list/patch fireboltengines` — the exact write grant #90 removed — so e2e never validated the read-only property. It now mirrors the chart's `endpointslices get/list/watch` rules.
- the agent's demand maps had no size bound: garbage engine names sprayed between the 10-minute prunes could OOM the agent. Hard cap at 4096 tracked names; new names beyond it are dropped and counted on `firebolt_gateway_wake_demand_dropped_total`, known names still refresh so stamp-before-shed semantics are unchanged.
- the demand-trust comment pointed at FB-2553, which closed with #90; it now points at FB-2619 (demand authentication follow-up).
- `formal/model-scope.tsv` unmodelled entries for auto-stop and wake-on-zero now cite FB-2618.

Coverage: a test pins the cap behavior (drop new names when full, refresh known ones); the wakeagent and controller suites pass, and the e2e RBAC change is exercised by every e2e run since the suite itself creates the role.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches gateway wake demand handling and e2e RBAC that gates wake-agent behavior; bounded-memory change is defensive but alters edge-case demand visibility for floods of unique engine names.
> 
> **Overview**
> Follow-ups from reviewing gateway wake-on-zero (#90): harden the agent against untrusted engine names and make e2e RBAC match production.
> 
> The **wake-agent `demandTracker`** now enforces **`maxTrackedEngines` (4096)**. New names beyond the cap are rejected (incrementing **`firebolt_gateway_wake_demand_demand_dropped_total`** — metric is `MetricDemandDroppedTotal`); engines already tracked still get **`Stamp`** refreshes so stamp-before-shed behavior is unchanged. **`AcquireHold`** no longer records per-engine shed counts for untracked names, avoiding a second unbounded map growth path. **`TestDemandTrackerCapsTrackedEngines`** locks this in.
> 
> **E2E** `ensureGatewayWakeClusterRole` switches from **`get/list/patch fireboltengines`** to **`endpointslices get/list/watch`**, mirroring the chart’s read-only wake-agent grant so tests actually exercise the post-#90 security model.
> 
> **Docs/comments only:** demand-authentication follow-up is **FB-2619** (was FB-2553); **`formal/model-scope.tsv`** cites **FB-2618** for unmodelled auto-stop and wake-on-zero.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5040bcba76a4d32dbbaf59e50af2940567937d01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->