### PR TITLE
chore(deps): bump packdb engine/metadata to 5.0.0-pre.0.20260803130231.8ec167d19785

### DIFF
--- a/config/images/defaults.latest.env
+++ b/config/images/defaults.latest.env
@@ -21,9 +21,9 @@
 #     test/e2e/e2e_suite_test.go's SynchronizedBeforeSuite.
 
 ENGINE_IMAGE=oci.firebolt.io/firebolt-db/engine
-ENGINE_TAG=release-5.0.1-0.20260727005216.d09b51086f14
+ENGINE_TAG=release-5.0.0-pre.0.20260803130231.8ec167d19785
 METADATA_IMAGE=ghcr.io/firebolt-db/metadata
-METADATA_TAG=release-5.0.1-0.20260727005216.d09b51086f14
+METADATA_TAG=release-5.0.0-pre.0.20260803130231.8ec167d19785
 POSTGRES_IMAGE=postgres:16-alpine
 ENVOY_IMAGE=envoyproxy/envoy
 ENVOY_TAG=v1.37.2


### PR DESCRIPTION
## Summary

Bump default engine/metadata images to packdb `5.0.0-pre.0.20260803130231.8ec167d19785`
— the build the engine/metadata `:latest` GHCR tags were just re-pointed to.

> [!NOTE]
> Opened automatically by packdb's `promote-ghcr-latest` workflow (weekly
> Monday refresh or a manual promotion) right after it re-pointed the
> engine/metadata `:latest` GHCR tags at this build, so `:latest` and this
> repo's pinned tags move together. An unmerged PR is overwritten by the
> next run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin-only change in `config/images/defaults.latest.env`; full unit and E2E suites are intended to gate regressions before merge.
> 
> **Overview**
> Updates the **latest** image variant defaults so `ENGINE_TAG` and `METADATA_TAG` both point at packdb build `release-5.0.0-pre.0.20260803130231.8ec167d19785`, replacing the previous `release-5.0.1-0.20260727005216.d09b51086f14` pins.
> 
> This keeps the operator image, Helm chart, and `IMAGE_VARIANT=latest` builds/tests aligned with the engine/metadata `:latest` GHCR tags after the weekly `promote-ghcr-latest` refresh. No other images or config change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4536fa8d01c7d6f48754c296949b4daff61f17aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->