### PR TITLE
fix(metadata): render dedicated-pensieve config as YAML, not XML (FB-2877)

### DIFF
--- a/config/images/defaults.latest.env
+++ b/config/images/defaults.latest.env
@@ -21,9 +21,9 @@
 #     test/e2e/e2e_suite_test.go's SynchronizedBeforeSuite.
 
 ENGINE_IMAGE=oci.firebolt.io/firebolt-db/engine
-ENGINE_TAG=release-5.0.0-pre.0.20260803130231.8ec167d19785
+ENGINE_TAG=release-5.0.0-pre.0.20260806001005.b7c004a34806
 METADATA_IMAGE=ghcr.io/firebolt-db/metadata
-METADATA_TAG=release-5.0.0-pre.0.20260803130231.8ec167d19785
+METADATA_TAG=release-5.0.0-pre.0.20260806001005.b7c004a34806
 POSTGRES_IMAGE=postgres:16-alpine
 ENVOY_IMAGE=envoyproxy/envoy
 ENVOY_TAG=v1.37.2

--- a/internal/controller/instance_metadata.go
+++ b/internal/controller/instance_metadata.go
@@ -17,11 +17,10 @@ limitations under the License.
 package controller
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/xml"
+	"encoding/json"
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -44,13 +43,13 @@ const (
 func (r *FireboltInstanceReconciler) ensureMetadataResources(ctx context.Context, instance *computev1alpha1.FireboltInstance) error {
 	log := logf.FromContext(ctx)
 
-	configXML := buildMetadataConfigXML(instance)
+	configYAML := buildMetadataConfigYAML(instance)
 
-	if err := r.ensureMetadataConfigMap(ctx, instance, configXML); err != nil {
+	if err := r.ensureMetadataConfigMap(ctx, instance, configYAML); err != nil {
 		return fmt.Errorf("ensuring metadata configmap: %w", err)
 	}
 
-	if err := r.ensureMetadataDeployment(ctx, instance, configXML); err != nil {
+	if err := r.ensureMetadataDeployment(ctx, instance, configYAML); err != nil {
 		return fmt.Errorf("ensuring metadata deployment: %w", err)
 	}
 
@@ -73,7 +72,7 @@ func metadataCredsSecretName(instance *computev1alpha1.FireboltInstance) string 
 	return pgCredentialsSecretName(instance.Name)
 }
 
-func buildMetadataConfigXML(instance *computev1alpha1.FireboltInstance) string {
+func buildMetadataConfigYAML(instance *computev1alpha1.FireboltInstance) string {
 	pgHost := pgResourceName(instance.Name) + "." + instance.Namespace + ".svc.cluster.local"
 	pgPort := int32(PostgresPort)
 	pgDatabase := PostgresDBName
@@ -99,54 +98,48 @@ func buildMetadataConfigXML(instance *computev1alpha1.FireboltInstance) string {
 
 	// All string fields interpolated below originate from user-controlled
 	// CRD inputs (spec.id, spec.metadata.postgres.{host,database,schema})
-	// and MUST be XML-escaped to prevent injection of additional XML
-	// elements that would alter the pensieve configuration. The CRD also
-	// applies a Pattern admission check on host/database/schema as
-	// defense-in-depth.
-	return fmt.Sprintf(`<?xml version="1.0"?>
-<config>
-  <pensieve_lite>
-    <default_account_id>%s</default_account_id>
-    <host>0.0.0.0</host>
-    <port>%d</port>
-    <server_threads>0</server_threads>
-    <log_level>information</log_level>
-    <metadata_storage>
-      <postgresql>
-        <host>%s</host>
-        <port>%d</port>
-        <database>%s</database>
-        <schema>%s</schema>
-        <keepalive>
-          <enabled>1</enabled>
-          <idle_sec>120</idle_sec>
-          <interval_sec>30</interval_sec>
-          <count>5</count>
-        </keepalive>
-        <connect_timeout_sec>5</connect_timeout_sec>
-      </postgresql>
-      <garbage_collection>
-        <enabled>true</enabled>
-        <interval_ms>3600000</interval_ms>
-        <time_horizon_sec>86400</time_horizon_sec>
-      </garbage_collection>
-    </metadata_storage>
-  </pensieve_lite>
-</config>`,
-		xmlEscape(instance.Spec.ID), MetadataServicePort,
-		xmlEscape(pgHost), pgPort, xmlEscape(pgDatabase), xmlEscape(pgSchema))
+	// and MUST be rendered as quoted YAML scalars (via yamlString) to prevent
+	// injection of additional YAML keys that would alter the pensieve
+	// configuration. The CRD also applies a Pattern admission check on
+	// host/database/schema as defense-in-depth.
+	//
+	// dedicated-pensieve (metadata image) loads YAML config since FB-2743;
+	// the document root must be a YAML map (a scalar/sequence root is rejected).
+	return fmt.Sprintf(`pensieve_lite:
+  default_account_id: %s
+  host: 0.0.0.0
+  port: %d
+  server_threads: 0
+  log_level: information
+  metadata_storage:
+    postgresql:
+      host: %s
+      port: %d
+      database: %s
+      schema: %s
+      keepalive:
+        enabled: 1
+        idle_sec: 120
+        interval_sec: 30
+        count: 5
+      connect_timeout_sec: 5
+    garbage_collection:
+      enabled: true
+      interval_ms: 3600000
+      time_horizon_sec: 86400
+`,
+		yamlString(instance.Spec.ID), MetadataServicePort,
+		yamlString(pgHost), pgPort, yamlString(pgDatabase), yamlString(pgSchema))
 }
 
-// xmlEscape returns s with XML metacharacters replaced by their entity
-// references, suitable for safe interpolation as element content. Used
-// for every user-controlled field that buildMetadataConfigXML pastes
-// into the pensieve config template.
-func xmlEscape(s string) string {
-	var buf bytes.Buffer
-	// xml.EscapeText only fails when the writer fails; bytes.Buffer
-	// never returns an error from Write, so the error is unreachable.
-	_ = xml.EscapeText(&buf, []byte(s))
-	return buf.String()
+// yamlString renders s as a YAML-safe double-quoted scalar. A JSON string
+// literal is always a valid YAML double-quoted scalar (YAML is a JSON
+// superset), so json.Marshal yields correct quoting and escaping for every
+// user-controlled field interpolated into the pensieve config template,
+// preventing YAML injection. json.Marshal never returns an error for a string.
+func yamlString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
 }
 
 func metadataConfigMapName(instanceName string) string {
@@ -170,7 +163,7 @@ func metadataConfigMapName(instanceName string) string {
 // bumped when the resulting object matches what is already stored,
 // so the Deployment controller does not see spurious rollouts even
 // though the operator applies on every reconcile.
-func (r *FireboltInstanceReconciler) ensureMetadataConfigMap(ctx context.Context, instance *computev1alpha1.FireboltInstance, configXML string) error {
+func (r *FireboltInstanceReconciler) ensureMetadataConfigMap(ctx context.Context, instance *computev1alpha1.FireboltInstance, configYAML string) error {
 	log := logf.FromContext(ctx).WithValues("instance", instance.Name)
 
 	name := metadataConfigMapName(instance.Name)
@@ -184,7 +177,7 @@ func (r *FireboltInstanceReconciler) ensureMetadataConfigMap(ctx context.Context
 			Labels:    labels,
 		},
 		Data: map[string]string{
-			"config.xml": configXML,
+			"config.yaml": configYAML,
 		},
 	}
 
@@ -208,8 +201,8 @@ func (r *FireboltInstanceReconciler) ensureMetadataConfigMap(ctx context.Context
 // routine node maintenance with no availability gain, because there's no
 // peer to fail over to). The time to add a PDB is when metadata grows a
 // genuine multi-replica HA story (quorum, leader election); revisit then.
-func (r *FireboltInstanceReconciler) ensureMetadataDeployment(ctx context.Context, instance *computev1alpha1.FireboltInstance, configXML string) error {
-	desired := buildMetadataDeployment(instance, configXML)
+func (r *FireboltInstanceReconciler) ensureMetadataDeployment(ctx context.Context, instance *computev1alpha1.FireboltInstance, configYAML string) error {
+	desired := buildMetadataDeployment(instance, configYAML)
 	desired.TypeMeta = metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"}
 
 	if err := controllerutil.SetControllerReference(instance, desired, r.Scheme); err != nil {
@@ -234,7 +227,7 @@ func (r *FireboltInstanceReconciler) ensureMetadataDeployment(ctx context.Contex
 // is false because pensieve does not call the Kubernetes API; an attacker
 // with code execution inside the container therefore has neither a SA
 // token to reach the API server nor a writable rootfs to stage payloads on.
-func buildMetadataDeployment(instance *computev1alpha1.FireboltInstance, configXML string) *appsv1.Deployment {
+func buildMetadataDeployment(instance *computev1alpha1.FireboltInstance, configYAML string) *appsv1.Deployment {
 	name := instance.Name + SuffixMetadataService
 	labels := instanceLabels(instance.Name, "metadata")
 
@@ -243,7 +236,7 @@ func buildMetadataDeployment(instance *computev1alpha1.FireboltInstance, configX
 		replicas = *instance.Spec.Metadata.Replicas
 	}
 
-	configHash := contentHash(configXML)
+	configHash := contentHash(configYAML)
 
 	// Surge=0 + maxUnavailable=1 means the old pod is terminated before the
 	// new one is created. The metadata service assumes single-writer against
@@ -307,7 +300,7 @@ func effectiveMetadataPodTemplate(
 		Name:            computev1alpha1.MetadataContainerName,
 		Image:           image,
 		ImagePullPolicy: pullPolicy,
-		Command:         []string{"/dedicated-pensieve", "--config", "/configs/config.xml"},
+		Command:         []string{"/dedicated-pensieve", "--config", "/configs/config.yaml"},
 		Ports: []corev1.ContainerPort{
 			{Name: "grpc", ContainerPort: int32(MetadataServicePort), Protocol: corev1.ProtocolTCP},
 		},

--- a/internal/controller/instance_metadata_test.go
+++ b/internal/controller/instance_metadata_test.go
@@ -17,17 +17,17 @@ limitations under the License.
 package controller
 
 import (
-	"encoding/xml"
 	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 
 	computev1alpha1 "github.com/firebolt-db/firebolt-kubernetes-operator/api/v1alpha1"
 )
 
-func TestBuildMetadataConfigXMLSchema(t *testing.T) {
+func TestBuildMetadataConfigYAMLSchema(t *testing.T) {
 	tests := []struct {
 		name     string
 		postgres *computev1alpha1.PostgresSpec
@@ -36,7 +36,7 @@ func TestBuildMetadataConfigXMLSchema(t *testing.T) {
 		{
 			name:     "internal postgres uses default schema",
 			postgres: nil,
-			want:     "<schema>public</schema>",
+			want:     `schema: "public"`,
 		},
 		{
 			name: "external postgres without schema falls back to public",
@@ -45,7 +45,7 @@ func TestBuildMetadataConfigXMLSchema(t *testing.T) {
 				Database:             "fb",
 				CredentialsSecretRef: corev1.LocalObjectReference{Name: "creds"},
 			},
-			want: "<schema>public</schema>",
+			want: `schema: "public"`,
 		},
 		{
 			name: "external postgres with custom schema is honored",
@@ -55,7 +55,7 @@ func TestBuildMetadataConfigXMLSchema(t *testing.T) {
 				Schema:               "firebolt_metadata",
 				CredentialsSecretRef: corev1.LocalObjectReference{Name: "creds"},
 			},
-			want: "<schema>firebolt_metadata</schema>",
+			want: `schema: "firebolt_metadata"`,
 		},
 	}
 
@@ -70,7 +70,7 @@ func TestBuildMetadataConfigXMLSchema(t *testing.T) {
 					},
 				},
 			}
-			got := buildMetadataConfigXML(inst)
+			got := buildMetadataConfigYAML(inst)
 			if !strings.Contains(got, tc.want) {
 				t.Errorf("expected %q in rendered config; got:\n%s", tc.want, got)
 			}
@@ -78,108 +78,94 @@ func TestBuildMetadataConfigXMLSchema(t *testing.T) {
 	}
 }
 
-// TestBuildMetadataConfigXML_EscapesUserFields locks in XML escaping:
+// TestBuildMetadataConfigYAML_EscapesUserFields locks in YAML quoting:
 // every user-controlled string interpolated into the pensieve config
-// template must be XML-escaped. Without escaping, a malicious operator
-// could inject extra XML elements (e.g. a second <host>) and redirect
-// the metadata service to an attacker-controlled PostgreSQL.
+// template must be rendered as a quoted YAML scalar. Without quoting, a
+// malicious operator could inject extra YAML keys (e.g. a second host) and
+// redirect the metadata service to an attacker-controlled PostgreSQL.
 //
 // This test pretends the CRD admission Pattern (which also rejects
 // these strings at admission time) is bypassed — controller-internal
 // code must remain safe even if a future change widens the pattern.
-func TestBuildMetadataConfigXML_EscapesUserFields(t *testing.T) {
+func TestBuildMetadataConfigYAML_EscapesUserFields(t *testing.T) {
 	inst := &computev1alpha1.FireboltInstance{
 		ObjectMeta: metav1.ObjectMeta{Name: "inst", Namespace: "ns"},
 		Spec: computev1alpha1.FireboltInstanceSpec{
 			ID: "acc<1>",
 			Metadata: computev1alpha1.MetadataSpec{
 				Postgres: &computev1alpha1.PostgresSpec{
-					Host:                 `evil</host><port>9999</port><host>attacker.example`,
-					Database:             `db&name`,
-					Schema:               `s"chema'`,
+					Host:                 "evil\ninjected: pwned\nhost: attacker.example",
+					Database:             `db: "name"`,
+					Schema:               `s'chema"`,
 					CredentialsSecretRef: corev1.LocalObjectReference{Name: "creds"},
 				},
 			},
 		},
 	}
 
-	got := buildMetadataConfigXML(inst)
+	got := buildMetadataConfigYAML(inst)
 
-	if strings.Contains(got, "</host><port>9999</port><host>") {
-		t.Errorf("host injection not escaped — attacker-controlled XML appears literally:\n%s", got)
+	// The rendered document must parse as YAML with a map root and round-trip
+	// each user field to its exact value. If any field were interpolated
+	// unquoted, the newline / colon payloads above would either break the parse
+	// or surface as an injected sibling key — both caught here.
+	var doc struct {
+		PensieveLite struct {
+			DefaultAccountID string `json:"default_account_id"`
+			MetadataStorage  struct {
+				PostgreSQL struct {
+					Host     string `json:"host"`
+					Database string `json:"database"`
+					Schema   string `json:"schema"`
+				} `json:"postgresql"`
+			} `json:"metadata_storage"`
+		} `json:"pensieve_lite"`
 	}
-	if strings.Contains(got, "<host>attacker.example</host>") {
-		t.Errorf("injected attacker host element appears literally:\n%s", got)
+	if err := yaml.Unmarshal([]byte(got), &doc); err != nil {
+		t.Fatalf("rendered config must be well-formed YAML: %v\n%s", err, got)
 	}
-	wantSubstrings := []string{
-		"acc&lt;1&gt;",
-		"evil&lt;/host&gt;&lt;port&gt;9999&lt;/port&gt;&lt;host&gt;attacker.example",
-		"db&amp;name",
-		"s&#34;chema&#39;",
+	pg := doc.PensieveLite.MetadataStorage.PostgreSQL
+	if pg.Host != inst.Spec.Metadata.Postgres.Host {
+		t.Errorf("host round-trip: got %q, want %q (injection leaked)", pg.Host, inst.Spec.Metadata.Postgres.Host)
 	}
-	for _, s := range wantSubstrings {
-		if !strings.Contains(got, s) {
-			t.Errorf("expected escaped substring %q in rendered config; got:\n%s", s, got)
-		}
+	if pg.Database != inst.Spec.Metadata.Postgres.Database {
+		t.Errorf("database round-trip: got %q, want %q", pg.Database, inst.Spec.Metadata.Postgres.Database)
+	}
+	if pg.Schema != inst.Spec.Metadata.Postgres.Schema {
+		t.Errorf("schema round-trip: got %q, want %q", pg.Schema, inst.Spec.Metadata.Postgres.Schema)
+	}
+	if doc.PensieveLite.DefaultAccountID != inst.Spec.ID {
+		t.Errorf("default_account_id round-trip: got %q, want %q", doc.PensieveLite.DefaultAccountID, inst.Spec.ID)
 	}
 
-	// The rendered document must still be a single well-formed XML
-	// document with exactly the expected element structure: a single
-	// pensieve_lite/metadata_storage/postgresql/host element, not two.
-	type postgresql struct {
-		Host     []string `xml:"host"`
-		Database []string `xml:"database"`
-		Schema   []string `xml:"schema"`
+	// Defense-in-depth: the injected top-level key from the host payload must
+	// not appear as a real map key (it is contained inside the quoted scalar).
+	var raw map[string]any
+	if err := yaml.Unmarshal([]byte(got), &raw); err != nil {
+		t.Fatalf("rendered config must parse into a map: %v\n%s", err, got)
 	}
-	type metadataStorage struct {
-		Postgres postgresql `xml:"postgresql"`
-	}
-	type pensieveLite struct {
-		DefaultAccountID string          `xml:"default_account_id"`
-		Storage          metadataStorage `xml:"metadata_storage"`
-	}
-	type config struct {
-		XMLName xml.Name     `xml:"config"`
-		Lite    pensieveLite `xml:"pensieve_lite"`
-	}
-	var doc config
-	if err := xml.Unmarshal([]byte(got), &doc); err != nil {
-		t.Fatalf("rendered config must be well-formed XML: %v\n%s", err, got)
-	}
-	if got, want := len(doc.Lite.Storage.Postgres.Host), 1; got != want {
-		t.Errorf("postgresql host elements: got %d, want %d (injected element leaked)", got, want)
-	}
-	if got, want := doc.Lite.Storage.Postgres.Host[0], inst.Spec.Metadata.Postgres.Host; got != want {
-		t.Errorf("host element text round-trip: got %q, want %q", got, want)
-	}
-	if got, want := doc.Lite.Storage.Postgres.Database[0], inst.Spec.Metadata.Postgres.Database; got != want {
-		t.Errorf("database element text round-trip: got %q, want %q", got, want)
-	}
-	if got, want := doc.Lite.Storage.Postgres.Schema[0], inst.Spec.Metadata.Postgres.Schema; got != want {
-		t.Errorf("schema element text round-trip: got %q, want %q", got, want)
-	}
-	if got, want := doc.Lite.DefaultAccountID, inst.Spec.ID; got != want {
-		t.Errorf("default_account_id round-trip: got %q, want %q", got, want)
+	if _, leaked := raw["injected"]; leaked {
+		t.Errorf("injected top-level key leaked into the config:\n%s", got)
 	}
 }
 
-// TestBuildMetadataConfigXML_GarbageCollectionKeys pins the GC key names to the
+// TestBuildMetadataConfigYAML_GarbageCollectionKeys pins the GC key names to the
 // dialect the dedicated-pensieve server actually reads
 // (pensieve_lite.metadata_storage.garbage_collection.{enabled,time_horizon_sec,interval_ms}).
-// An earlier template rendered <interval_seconds>/<max_age_seconds>, key names no server
+// An earlier template rendered interval_seconds/max_age_seconds, key names no server
 // version has ever read, so GC silently ran on the server defaults (60s interval, 1h
 // horizon) instead of the values below.
-func TestBuildMetadataConfigXML_GarbageCollectionKeys(t *testing.T) {
-	got := buildMetadataConfigXML(mkMetadataInstance())
+func TestBuildMetadataConfigYAML_GarbageCollectionKeys(t *testing.T) {
+	got := buildMetadataConfigYAML(mkMetadataInstance())
 	for _, want := range []string{
-		"<interval_ms>3600000</interval_ms>",
-		"<time_horizon_sec>86400</time_horizon_sec>",
+		"interval_ms: 3600000",
+		"time_horizon_sec: 86400",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("expected %q in rendered config; got:\n%s", want, got)
 		}
 	}
-	for _, stale := range []string{"<interval_seconds>", "<max_age_seconds>"} {
+	for _, stale := range []string{"interval_seconds", "max_age_seconds"} {
 		if strings.Contains(got, stale) {
 			t.Errorf("stale GC key %q must not be rendered (the server never read it); got:\n%s", stale, got)
 		}
@@ -202,7 +188,7 @@ func mkMetadataInstance() *computev1alpha1.FireboltInstance {
 }
 
 func TestBuildMetadataDeploymentPodSecurityContext(t *testing.T) {
-	dep := buildMetadataDeployment(mkMetadataInstance(), buildMetadataConfigXML(mkMetadataInstance()))
+	dep := buildMetadataDeployment(mkMetadataInstance(), buildMetadataConfigYAML(mkMetadataInstance()))
 
 	psc := dep.Spec.Template.Spec.SecurityContext
 	if psc == nil {
@@ -233,7 +219,7 @@ func TestBuildMetadataDeploymentPodSecurityContext(t *testing.T) {
 }
 
 func TestBuildMetadataDeploymentContainerSecurityContext(t *testing.T) {
-	dep := buildMetadataDeployment(mkMetadataInstance(), buildMetadataConfigXML(mkMetadataInstance()))
+	dep := buildMetadataDeployment(mkMetadataInstance(), buildMetadataConfigYAML(mkMetadataInstance()))
 
 	if got, want := len(dep.Spec.Template.Spec.Containers), 1; got != want {
 		t.Fatalf("containers: got %d, want %d", got, want)
@@ -275,7 +261,7 @@ func TestBuildMetadataDeploymentContainerSecurityContext(t *testing.T) {
 // is backed defensively; without an emptyDir mount there, any runtime
 // write under /tmp would fail on a read-only fs.
 func TestBuildMetadataDeploymentWritableTmpVolume(t *testing.T) {
-	dep := buildMetadataDeployment(mkMetadataInstance(), buildMetadataConfigXML(mkMetadataInstance()))
+	dep := buildMetadataDeployment(mkMetadataInstance(), buildMetadataConfigYAML(mkMetadataInstance()))
 	pod := dep.Spec.Template.Spec
 
 	var tmp *corev1.Volume
@@ -310,7 +296,7 @@ func TestBuildMetadataDeploymentWritableTmpVolume(t *testing.T) {
 // floci incident motivated turning the legacy service-link env block off
 // across every operator-managed PodSpec; this test is the lock-in.
 func TestBuildMetadataDeploymentDisablesServiceLinks(t *testing.T) {
-	dep := buildMetadataDeployment(mkMetadataInstance(), buildMetadataConfigXML(mkMetadataInstance()))
+	dep := buildMetadataDeployment(mkMetadataInstance(), buildMetadataConfigYAML(mkMetadataInstance()))
 	esl := dep.Spec.Template.Spec.EnableServiceLinks
 	if esl == nil || *esl {
 		t.Errorf("EnableServiceLinks: got %+v, want *false", esl)


### PR DESCRIPTION
**Background**

FB-2743 switched the metadata image (`dedicated-pensieve`) to load **YAML config only** — `PensieveServerApplication::initialize()` now calls `LoadYamlConfigFile` via `YamlChangeProvider`, which rejects any document whose root isn't a map. The operator still rendered the metadata ConfigMap as **XML** (`config.xml`), so any metadata image built at/after that change crash-loops on startup:

```
Poco exception in PensieveLiteServerMain: Invalid dedicated-pensieve configuration:
  - error: Configuration root cannot be scalar or sequence.
```

This is the exact incompatibility the `Stable operator smoke test` catches (tracked in FB-2874 / FB-2877): the published operator chart + a post-FB-2743 metadata image ⇒ `firebolt-metadata` `CrashLoopBackOff`, `FireboltInstance` stuck in `Provisioning`.

**Summary**

Render the metadata config as a YAML map matching what `dedicated-pensieve` now expects (same shape as packdb's `helm/dedicated-pensieve/templates/configmap.yaml`):

- `buildMetadataConfigXML` → `buildMetadataConfigYAML`, emitting a `pensieve_lite:` YAML map with the same fields (host/port/log_level, `postgresql.*`, `keepalive`, `garbage_collection` `interval_ms`/`time_horizon_sec`).
- ConfigMap data key `config.xml` → `config.yaml`; container command `--config /configs/config.yaml`.
- User-controlled fields (`spec.id`, postgres host/database/schema) are quoted via `yamlString` (`json.Marshal` — a JSON string literal is a valid YAML scalar), preventing YAML injection; replaces the former `xmlEscape`.
- Tests updated to parse/round-trip YAML.

Rendered output for a sample instance:

```yaml
pensieve_lite:
  default_account_id: "01KP98J0000000000000000000"
  host: 0.0.0.0
  port: 7000
  server_threads: 0
  log_level: information
  metadata_storage:
    postgresql:
      host: "inst-metadata-pg.ns.svc.cluster.local"
      port: 5432
      database: "firebolt_metadata"
      schema: "public"
      keepalive: {enabled: 1, idle_sec: 120, interval_sec: 30, count: 5}
      connect_timeout_sec: 5
    garbage_collection: {enabled: true, interval_ms: 3600000, time_horizon_sec: 86400}
```

**Test Plan**

- `go build ./...` and `go vet ./internal/controller/` clean.
- Metadata unit tests pass (schema selection, injection round-trip, GC keys). The envtest Ginkgo suite needs `bin/k8s` binaries not present locally, so it's unrun here.
- Rendered config verified to have a YAML **map root**, which dedicated-pensieve's `YamlChangeProvider` accepts.

**Follow-up:** the `Stable operator smoke test` installs the *latest published* chart, so a new operator chart release is required for it to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every metadata instance is configured and rolled out via ConfigMap hash; incorrect YAML shape would break provisioning, but behavior is covered by tests and matches the new image contract.
> 
> **Overview**
> **Fixes metadata crash-loops** on images that load YAML-only config (FB-2743): the operator now emits **`config.yaml`** with a `pensieve_lite:` map root instead of **`config.xml`**, and the pensieve container uses `--config /configs/config.yaml`.
> 
> User-controlled CR fields are still sanitized via **`yamlString`** (`json.Marshal` for quoted scalars), replacing **`xmlEscape`**. Unit tests were updated for YAML schema, injection round-trip, and GC keys. **`defaults.latest.env`** bumps engine/metadata tags to `release-5.0.0-pre.0.20260806001005.b7c004a34806`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d38f75b9f33196190766a49237b3651c1c180ee8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->