### PR TITLE
fix(controller): refuse HTTP redirects on pod-IP scrape clients (FB-2668)

### DIFF
--- a/internal/controller/engine_scrape.go
+++ b/internal/controller/engine_scrape.go
@@ -44,12 +44,24 @@ const MetricScrapeModeDefault = computev1alpha1.MetricScrapeModePodIP
 // sync.Mutex during shutdown is the classic case).
 const scrapeTimeout = 10 * time.Second
 
+// refuseRedirects stops pod-IP scrapers from following Location headers.
+// A compromised or spoofed pod can return a 3xx pointing at cloud metadata
+// or other internal endpoints; chasing it would turn the operator process
+// into a blind SSRF client with the operator's network identity. The
+// scrape endpoints never redirect under normal operation.
+func refuseRedirects(*http.Request, []*http.Request) error {
+	return http.ErrUseLastResponse
+}
+
 // metricsHTTPClient is shared across reconciles so we don't burn
 // ephemeral ports building a client per call. DisableKeepAlives because
 // pod IPs are reused across rollouts and a cached idle conn can land on
-// a different pod than the one we just listed.
+// a different pod than the one we just listed. CheckRedirect refuses
+// every redirect so a spoofed engine pod cannot bounce the scrape at an
+// arbitrary internal URL.
 var metricsHTTPClient = &http.Client{
-	Timeout: scrapeTimeout,
+	Timeout:       scrapeTimeout,
+	CheckRedirect: refuseRedirects,
 	Transport: &http.Transport{
 		DisableKeepAlives:     true,
 		DialContext:           (&net.Dialer{Timeout: 3 * time.Second}).DialContext,

--- a/internal/controller/engine_scrape_test.go
+++ b/internal/controller/engine_scrape_test.go
@@ -18,12 +18,14 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -145,6 +147,72 @@ func TestPodIPScraper_Non200Surfaced(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "503") {
 		t.Errorf("expected 503 in error, got %v", err)
+	}
+}
+
+// Both pod-IP scrape clients must refuse redirects; otherwise a spoofed
+// pod can bounce the operator at cloud metadata or other internal URLs.
+func TestScrapeHTTPClientsRefuseRedirects(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name   string
+		client *http.Client
+	}{
+		{name: "metricsHTTPClient", client: metricsHTTPClient},
+		{name: "wakeDemandHTTPClient", client: wakeDemandHTTPClient},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.client.CheckRedirect == nil {
+				t.Fatal("CheckRedirect is nil; client would follow Go's default of up to 10 redirects")
+			}
+			if err := tc.client.CheckRedirect(&http.Request{}, nil); !errors.Is(err, http.ErrUseLastResponse) {
+				t.Fatalf("CheckRedirect() = %v, want http.ErrUseLastResponse", err)
+			}
+		})
+	}
+}
+
+// A spoofed engine returning 302 to an internal URL must not be chased.
+func TestPodIPScraperDoesNotFollowRedirects(t *testing.T) {
+	t.Parallel()
+
+	var baitHit atomic.Bool
+	bait := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		baitHit.Store(true)
+	}))
+	t.Cleanup(bait.Close)
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, bait.URL+"/latest/meta-data/", http.StatusFound)
+	}))
+	t.Cleanup(redirector.Close)
+
+	host, _ := hostPortFromURL(t, redirector.URL)
+	realAddr := strings.TrimPrefix(redirector.URL, "http://")
+	scraper := &podIPScraper{client: &http.Client{
+		CheckRedirect: metricsHTTPClient.CheckRedirect,
+		Transport: &http.Transport{
+			DisableKeepAlives: true,
+			DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+				d := net.Dialer{}
+				return d.DialContext(ctx, network, realAddr)
+			},
+		},
+	}}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "engine-0", Namespace: "ns"},
+		Status:     corev1.PodStatus{PodIP: host, Phase: corev1.PodRunning},
+	}
+
+	_, err := scraper.Scrape(context.Background(), pod)
+	if err == nil {
+		t.Fatal("Scrape() succeeded against a redirecting metrics endpoint")
+	}
+	if !strings.Contains(err.Error(), "302") {
+		t.Errorf("error should surface the redirect status, got %v", err)
+	}
+	if baitHit.Load() {
+		t.Fatal("metrics scrape client followed a redirect to the bait server")
 	}
 }
 

--- a/internal/controller/wake_demand.go
+++ b/internal/controller/wake_demand.go
@@ -365,9 +365,12 @@ func (t *WakeDemandTracker) gatewayPods(ctx context.Context, namespace string) (
 
 // wakeDemandHTTPClient mirrors metricsHTTPClient's settings and for the
 // same reason: gateway pod IPs are reused across rollouts, so a cached idle
-// connection can land on a pod other than the one just listed.
+// connection can land on a pod other than the one just listed. CheckRedirect
+// refuses every redirect so a spoofed gateway pod cannot bounce the demand
+// scrape at an arbitrary internal URL (same SSRF class as metricsHTTPClient).
 var wakeDemandHTTPClient = &http.Client{
-	Timeout: wakeDemandScrapeTimeout,
+	Timeout:       wakeDemandScrapeTimeout,
+	CheckRedirect: refuseRedirects,
 	Transport: &http.Transport{
 		DisableKeepAlives:     true,
 		DialContext:           (&net.Dialer{Timeout: 2 * time.Second}).DialContext,

--- a/internal/controller/wake_demand_test.go
+++ b/internal/controller/wake_demand_test.go
@@ -22,6 +22,8 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -338,6 +340,38 @@ func TestScrapeAgentRequiresClientsetForProxyMode(t *testing.T) {
 	_, err := tr.scrapeAgent(context.Background(), pod, computev1alpha1.MetricScrapeModeApiserverProxy)
 	if err == nil {
 		t.Fatal("scrapeAgent() succeeded in proxy mode with no clientset")
+	}
+}
+
+// A spoofed gateway returning 302 to an internal URL must not be chased:
+// the operator process carries broader network identity than the pod.
+func TestScrapeAgentDoesNotFollowRedirects(t *testing.T) {
+	t.Parallel()
+
+	var baitHit atomic.Bool
+	bait := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		baitHit.Store(true)
+	}))
+	t.Cleanup(bait.Close)
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, bait.URL+"/latest/meta-data/", http.StatusFound)
+	}))
+	t.Cleanup(redirector.Close)
+
+	host, port := splitHostPort(t, redirector.Listener.Addr().String())
+	tr := &WakeDemandTracker{DemandPort: port}
+	pod := gatewayPod("gw-0", host, corev1.PodRunning)
+
+	_, err := tr.scrapeAgent(context.Background(), pod, computev1alpha1.MetricScrapeModePodIP)
+	if err == nil {
+		t.Fatal("scrapeAgent() succeeded against a redirecting agent")
+	}
+	if !strings.Contains(err.Error(), "302") {
+		t.Errorf("error should surface the redirect status, got %v", err)
+	}
+	if baitHit.Load() {
+		t.Fatal("wake demand client followed a redirect to the bait server")
 	}
 }
 


### PR DESCRIPTION
**Background**

FB-2668: The wake-demand and engine-metrics HTTP clients followed Go's default redirect policy (up to 10 hops), so a spoofed or compromised gateway/engine pod could bounce the operator at cloud metadata or other internal URLs using the operator's network identity (blind SSRF).

**Summary**

- Set `CheckRedirect` on `wakeDemandHTTPClient` and `metricsHTTPClient` to return `http.ErrUseLastResponse`, so pod-IP scrapes never chase `Location` headers.
- Centralize the policy in `refuseRedirects` so both clients share one fail-closed redirect guard.
- Add unit coverage that both clients pin that policy, plus behavioral tests that a 302 to a bait server is not followed and surfaces as a non-200 scrape error.

Going forward, direct pod-IP scrapes treat any redirect as a hard failure. The `/demand` and `/metrics` endpoints are not expected to redirect under normal operation.

**Test Plan**

- [x] `go test ./internal/controller/ -run 'TestScrapeHTTPClientsRefuseRedirects|TestPodIPScraperDoesNotFollowRedirects|TestScrapeAgentDoesNotFollowRedirects'`
- [x] `make build && make lint`
- [ ] CI unit tests / lint on the PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-hardening of operator HTTP clients with narrow behavior change (redirects become hard failures); low blast radius but touches critical scrape paths.
> 
> **Overview**
> Closes an **SSRF** gap where pod-IP HTTP scrapes used Go’s default redirect behavior (up to 10 hops). A malicious or spoofed engine/gateway pod could return a `3xx` `Location` and make the operator fetch internal URLs (e.g. cloud metadata) with the operator’s network identity.
> 
> Adds shared **`refuseRedirects`** (`CheckRedirect` → `http.ErrUseLastResponse`) on **`metricsHTTPClient`** and **`wakeDemandHTTPClient`**, so `/metrics` and `/demand` scrapes fail on redirects instead of following them. Unit tests pin the policy on both clients and assert a `302` to a bait server is not chased and surfaces as a scrape error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71a74f84f474d18dbab5fbbec51ca30b2025ee91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->