### PR TITLE
fix(controller): roll gateway on CRL secret updates (FB-2667)

### DIFF
--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -198,7 +198,7 @@ Two things about mutual TLS are worth stating plainly, because the operator cann
 - **Verification is CA-scoped, not identity-scoped.** Any certificate the configured CA signed is accepted. Point `clientCASecretRef` at a CA dedicated to this purpose, not at a broad organizational CA that already signs certificates for unrelated workloads.
 - **Prefer a separate issuer per purpose.** The signing keypair, the Engine listener, the Gateway listener, and the client CA should not all chain to one issuer. The Gateway verifies Engines against the Engine issuer's CA, so anything else able to obtain a certificate from that same issuer for a matching name is, to the Gateway, indistinguishable from an Engine.
 
-`crlSecretRef` on either listener supplies a revocation list the Gateway checks alongside the trust anchor, so a compromised certificate can be rejected before it expires. Certificate lifetimes are bounded by default, which limits how long a leaked key stays usable but does not end it — a CRL is the only way to cut it short.
+`crlSecretRef` on either listener supplies a revocation list the Gateway checks alongside the trust anchor, so a compromised certificate can be rejected before it expires. Certificate lifetimes are bounded by default, which limits how long a leaked key stays usable but does not end it — a CRL is the only way to cut it short. Updating a CRL Secret rolls the Gateway so Envoy reloads the list; Envoy does not hot-reload a `filename`-referenced CRL from the mounted volume alone.
 
 ## What the Firebolt Operator does not enforce
 

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -198,7 +198,7 @@ Two things about mutual TLS are worth stating plainly, because the operator cann
 - **Verification is CA-scoped, not identity-scoped.** Any certificate the configured CA signed is accepted. Point `clientCASecretRef` at a CA dedicated to this purpose, not at a broad organizational CA that already signs certificates for unrelated workloads.
 - **Prefer a separate issuer per purpose.** The signing keypair, the Engine listener, the Gateway listener, and the client CA should not all chain to one issuer. The Gateway verifies Engines against the Engine issuer's CA, so anything else able to obtain a certificate from that same issuer for a matching name is, to the Gateway, indistinguishable from an Engine.
 
-`crlSecretRef` on either listener supplies a revocation list the Gateway checks alongside the trust anchor, so a compromised certificate can be rejected before it expires. Certificate lifetimes are bounded by default, which limits how long a leaked key stays usable but does not end it — a CRL is the only way to cut it short. Updating a CRL Secret rolls the Gateway so Envoy reloads the list; Envoy does not hot-reload a `filename`-referenced CRL from the mounted volume alone.
+`crlSecretRef` on either listener supplies a revocation list the Gateway checks alongside the trust anchor, so a compromised certificate can be rejected before it expires. Certificate lifetimes are bounded by default, which limits how long a leaked key stays usable but does not end it — a CRL is the only way to cut it short. When you update a CRL Secret, the Gateway pods roll within about a minute so Envoy reloads the list at startup. Envoy does not hot-reload a `filename`-referenced CRL from the mounted volume alone.
 
 ## What the Firebolt Operator does not enforce
 

--- a/internal/controller/instance_gateway.go
+++ b/internal/controller/instance_gateway.go
@@ -1351,19 +1351,18 @@ func (r *FireboltInstanceReconciler) ensureGatewayConfigMap(ctx context.Context,
 // The tracked set mirrors the pod-template mounts exactly, keyed off the same
 // predicates the mount logic uses (see effectiveGatewayPodTemplate):
 //   - the downstream server cert (Status.GatewayTLS) and — only once downstream
-//     TLS is READY — the mTLS client-CA, both gated on gatewayDownstreamTLSReady.
-//     During the fail-closed provisioning window (Status.GatewayTLS nil, and a
-//     bring-your-own client-CA that may not exist yet) neither is mounted, so
-//     neither is read: a hard Get on the not-yet-created client-CA here used to
-//     abort the whole gateway roll, so the fail-closed Deployment never came up
-//     and the prior plaintext/one-way-TLS listener stayed up (fail-open).
-//   - the upstream engine-CA anchor (Status.EngineTLS), gated on
-//     engineUpstreamTLSReady exactly like its mount, so an in-place engine-CA
-//     reissue rolls the gateway and Envoy reloads trusted_ca.
-//   - the engine CRL (spec.tls.engine.crlSecretRef), gated on
-//     engineUpstreamTLSReady exactly like its mount.
-//   - the client CRL (spec.tls.gateway.crlSecretRef), gated inside the
-//     downstream-ready + client-CA branch exactly like its mount.
+//     TLS is READY — the mTLS client-CA and its CRL
+//     (spec.tls.gateway.crlSecretRef), all gated on
+//     gatewayDownstreamTLSReady. During the fail-closed provisioning window
+//     (Status.GatewayTLS nil, and a bring-your-own client-CA that may not exist
+//     yet) none is mounted, so none is read: a hard Get on the not-yet-created
+//     client-CA here used to abort the whole gateway roll, so the fail-closed
+//     Deployment never came up and the prior plaintext/one-way-TLS listener
+//     stayed up (fail-open).
+//   - the upstream engine-CA anchor (Status.EngineTLS) and its CRL
+//     (spec.tls.engine.crlSecretRef), gated on engineUpstreamTLSReady exactly
+//     like their mounts, so an in-place engine-CA reissue rolls the gateway and
+//     Envoy reloads trusted_ca.
 //
 // A missing Secret is tolerated (skipped, not an error): it only means the hash
 // omits that entry until the Secret lands, and a later reconcile folds it in.

--- a/internal/controller/instance_gateway.go
+++ b/internal/controller/instance_gateway.go
@@ -1360,6 +1360,10 @@ func (r *FireboltInstanceReconciler) ensureGatewayConfigMap(ctx context.Context,
 //   - the upstream engine-CA anchor (Status.EngineTLS), gated on
 //     engineUpstreamTLSReady exactly like its mount, so an in-place engine-CA
 //     reissue rolls the gateway and Envoy reloads trusted_ca.
+//   - the engine CRL (spec.tls.engine.crlSecretRef), gated on
+//     engineUpstreamTLSReady exactly like its mount.
+//   - the client CRL (spec.tls.gateway.crlSecretRef), gated inside the
+//     downstream-ready + client-CA branch exactly like its mount.
 //
 // A missing Secret is tolerated (skipped, not an error): it only means the hash
 // omits that entry until the Secret lands, and a later reconcile folds it in.
@@ -1371,6 +1375,9 @@ func (r *FireboltInstanceReconciler) gatewayTLSSecretVersions(ctx context.Contex
 		names = append(names, instance.Status.GatewayTLS.SecretName)
 		if ref := gatewayClientCASecretRef(instance); ref != nil {
 			names = append(names, ref.Name)
+			if crl := gatewayCRLSecretRef(instance); crl != nil {
+				names = append(names, crl.Name)
+			}
 		}
 	}
 	if engineUpstreamTLSReady(instance) {
@@ -1380,6 +1387,9 @@ func (r *FireboltInstanceReconciler) gatewayTLSSecretVersions(ctx context.Contex
 		// set changes (a generation added under a rotated CA, or an old CA pruned),
 		// rolling the gateway so Envoy reloads trusted_ca.
 		names = append(names, engineCABundleSecretName(instance.Name))
+		if crl := engineCRLSecretRef(instance); crl != nil {
+			names = append(names, crl.Name)
+		}
 	}
 	var parts []string
 	for _, name := range names {

--- a/internal/controller/instance_gateway_test.go
+++ b/internal/controller/instance_gateway_test.go
@@ -278,6 +278,133 @@ func TestGatewayTLSSecretVersions(t *testing.T) {
 			t.Errorf("gatewayTLSSecretVersions = %q, want the engine-CA bundle folded while re-encrypting", got)
 		}
 	})
+
+	t.Run("engine CRL RV folded while re-encryption is active", func(t *testing.T) {
+		crl := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "engine-crl", Namespace: "ns-1"},
+			Data:       map[string][]byte{"crl.pem": []byte("engine-crl-v1")},
+		}
+		cli := fake.NewClientBuilder().WithScheme(sch).
+			WithObjects(tlsSecret("inst-engine-ca-bundle"), crl).Build()
+		r := &FireboltInstanceReconciler{Client: cli, Scheme: sch}
+		inst := &computev1alpha1.FireboltInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "inst", Namespace: "ns-1"},
+			Spec: computev1alpha1.FireboltInstanceSpec{
+				TLS: &computev1alpha1.TLSSpec{
+					Engine: &computev1alpha1.TLSListenerSpec{
+						Enabled:      true,
+						CRLSecretRef: &corev1.LocalObjectReference{Name: "engine-crl"},
+					},
+				},
+			},
+			Status: computev1alpha1.FireboltInstanceStatus{
+				EngineTLS: &computev1alpha1.EngineTLSStatus{SecretName: "inst-engine-tls", Reencrypting: true},
+			},
+		}
+		before, err := r.gatewayTLSSecretVersions(context.Background(), inst)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(before, "engine-crl=") {
+			t.Fatalf("gatewayTLSSecretVersions = %q, want engine CRL folded", before)
+		}
+
+		var live corev1.Secret
+		if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "ns-1", Name: "engine-crl"}, &live); err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		live.Data["crl.pem"] = []byte("engine-crl-v2")
+		if err := cli.Update(context.Background(), &live); err != nil {
+			t.Fatalf("update: %v", err)
+		}
+		after, err := r.gatewayTLSSecretVersions(context.Background(), inst)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if after == before {
+			t.Error("gatewayTLSSecretVersions did not change after engine CRL rotation; the gateway Deployment would never roll")
+		}
+	})
+
+	t.Run("client CRL RV folded once mTLS is ready", func(t *testing.T) {
+		crl := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "client-crl", Namespace: "ns-1"},
+			Data:       map[string][]byte{"crl.pem": []byte("client-crl-v1")},
+		}
+		cli := fake.NewClientBuilder().WithScheme(sch).
+			WithObjects(tlsSecret("gw-tls"), tlsSecret("client-ca"), crl).Build()
+		r := &FireboltInstanceReconciler{Client: cli, Scheme: sch}
+		inst := gwEnabled()
+		inst.Spec.TLS.Gateway.ClientCASecretRef = &corev1.LocalObjectReference{Name: "client-ca"}
+		inst.Spec.TLS.Gateway.CRLSecretRef = &corev1.LocalObjectReference{Name: "client-crl"}
+		inst.Status.GatewayTLS = &computev1alpha1.GatewayTLSStatus{SecretName: "gw-tls"}
+
+		before, err := r.gatewayTLSSecretVersions(context.Background(), inst)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(before, "client-crl=") {
+			t.Fatalf("gatewayTLSSecretVersions = %q, want client CRL folded", before)
+		}
+
+		var live corev1.Secret
+		if err := cli.Get(context.Background(), types.NamespacedName{Namespace: "ns-1", Name: "client-crl"}, &live); err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		live.Data["crl.pem"] = []byte("client-crl-v2")
+		if err := cli.Update(context.Background(), &live); err != nil {
+			t.Fatalf("update: %v", err)
+		}
+		after, err := r.gatewayTLSSecretVersions(context.Background(), inst)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if after == before {
+			t.Error("gatewayTLSSecretVersions did not change after client CRL rotation; the gateway Deployment would never roll")
+		}
+	})
+
+	t.Run("client CRL omitted when only client-CA is set", func(t *testing.T) {
+		cli := fake.NewClientBuilder().WithScheme(sch).
+			WithObjects(tlsSecret("gw-tls"), tlsSecret("client-ca")).Build()
+		r := &FireboltInstanceReconciler{Client: cli, Scheme: sch}
+		inst := gwEnabled()
+		inst.Spec.TLS.Gateway.ClientCASecretRef = &corev1.LocalObjectReference{Name: "client-ca"}
+		inst.Status.GatewayTLS = &computev1alpha1.GatewayTLSStatus{SecretName: "gw-tls"}
+		got, err := r.gatewayTLSSecretVersions(context.Background(), inst)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if strings.Contains(got, "crl") {
+			t.Errorf("gatewayTLSSecretVersions = %q, must not mention a CRL when none is configured", got)
+		}
+	})
+
+	t.Run("missing engine CRL is tolerated", func(t *testing.T) {
+		cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(tlsSecret("inst-engine-ca-bundle")).Build()
+		r := &FireboltInstanceReconciler{Client: cli, Scheme: sch}
+		inst := &computev1alpha1.FireboltInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "inst", Namespace: "ns-1"},
+			Spec: computev1alpha1.FireboltInstanceSpec{
+				TLS: &computev1alpha1.TLSSpec{
+					Engine: &computev1alpha1.TLSListenerSpec{
+						Enabled:      true,
+						CRLSecretRef: &corev1.LocalObjectReference{Name: "engine-crl"},
+					},
+				},
+			},
+			Status: computev1alpha1.FireboltInstanceStatus{
+				EngineTLS: &computev1alpha1.EngineTLSStatus{SecretName: "inst-engine-tls", Reencrypting: true},
+			},
+		}
+		got, err := r.gatewayTLSSecretVersions(context.Background(), inst)
+		if err != nil {
+			t.Fatalf("missing CRL must not error: %v", err)
+		}
+		if strings.Contains(got, "engine-crl=") {
+			t.Errorf("gatewayTLSSecretVersions = %q, missing CRL must be skipped", got)
+		}
+	})
 }
 
 // TestEngineFleetTLSState covers the gateway may only switch

--- a/internal/controller/instance_gateway_test.go
+++ b/internal/controller/instance_gateway_test.go
@@ -396,10 +396,11 @@ func TestGatewayTLSSecretVersions(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "client-crl", Namespace: "ns-1"},
 			Data:       map[string][]byte{"crl.pem": []byte("client-crl")},
 		}
-		cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(crl).Build()
+		cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(tlsSecret("gw-tls"), crl).Build()
 		r := &FireboltInstanceReconciler{Client: cli, Scheme: sch}
 		inst := gwEnabled()
 		inst.Spec.TLS.Gateway.CRLSecretRef = &corev1.LocalObjectReference{Name: "client-crl"}
+		inst.Status.GatewayTLS = &computev1alpha1.GatewayTLSStatus{SecretName: "gw-tls"}
 		got, err := r.gatewayTLSSecretVersions(context.Background(), inst)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)

--- a/internal/controller/instance_gateway_test.go
+++ b/internal/controller/instance_gateway_test.go
@@ -326,6 +326,33 @@ func TestGatewayTLSSecretVersions(t *testing.T) {
 		}
 	})
 
+	t.Run("engine CRL omitted while upstream TLS is not ready", func(t *testing.T) {
+		crl := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "engine-crl", Namespace: "ns-1"},
+			Data:       map[string][]byte{"crl.pem": []byte("engine-crl")},
+		}
+		cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(crl).Build()
+		r := &FireboltInstanceReconciler{Client: cli, Scheme: sch}
+		inst := &computev1alpha1.FireboltInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "inst", Namespace: "ns-1"},
+			Spec: computev1alpha1.FireboltInstanceSpec{
+				TLS: &computev1alpha1.TLSSpec{
+					Engine: &computev1alpha1.TLSListenerSpec{
+						Enabled:      true,
+						CRLSecretRef: &corev1.LocalObjectReference{Name: "engine-crl"},
+					},
+				},
+			},
+		}
+		got, err := r.gatewayTLSSecretVersions(context.Background(), inst)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if strings.Contains(got, "engine-crl=") {
+			t.Errorf("gatewayTLSSecretVersions = %q, must not fold an engine CRL that the gateway does not mount", got)
+		}
+	})
+
 	t.Run("client CRL RV folded once mTLS is ready", func(t *testing.T) {
 		crl := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "client-crl", Namespace: "ns-1"},
@@ -361,6 +388,24 @@ func TestGatewayTLSSecretVersions(t *testing.T) {
 		}
 		if after == before {
 			t.Error("gatewayTLSSecretVersions did not change after client CRL rotation; the gateway Deployment would never roll")
+		}
+	})
+
+	t.Run("client CRL omitted without a mounted client CA", func(t *testing.T) {
+		crl := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "client-crl", Namespace: "ns-1"},
+			Data:       map[string][]byte{"crl.pem": []byte("client-crl")},
+		}
+		cli := fake.NewClientBuilder().WithScheme(sch).WithObjects(crl).Build()
+		r := &FireboltInstanceReconciler{Client: cli, Scheme: sch}
+		inst := gwEnabled()
+		inst.Spec.TLS.Gateway.CRLSecretRef = &corev1.LocalObjectReference{Name: "client-crl"}
+		got, err := r.gatewayTLSSecretVersions(context.Background(), inst)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if strings.Contains(got, "client-crl=") {
+			t.Errorf("gatewayTLSSecretVersions = %q, must not fold a client CRL that the gateway does not mount", got)
 		}
 	})
 

--- a/scripts/ci/verify-ui-sidecar.sh
+++ b/scripts/ci/verify-ui-sidecar.sh
@@ -33,6 +33,29 @@ FLOCI_BUCKET="${FLOCI_BUCKET:-${ENGINE_NAME}-bucket}"
 FLOCI_ENDPOINT="http://floci.${NAMESPACE}.svc.cluster.local:4566"
 UI_PORT=9100
 
+# run_probe_pod NAME SCRIPT
+# One-shot in-cluster curl probe. Avoid `kubectl run -i --rm`: attaching races a
+# fast-exiting container and often returns only the echo lines (missing the
+# curl body), which falsely fails the workspace contract. Create → wait
+# Succeeded → logs → delete is deterministic.
+run_probe_pod() {
+  local name="$1"
+  local script="$2"
+  kubectl delete pod "$name" -n "$NAMESPACE" --ignore-not-found --wait=true >/dev/null 2>&1 || true
+  kubectl run "$name" -n "$NAMESPACE" --restart=Never \
+    --image="${CURL_IMAGE}" --command -- sh -c "$script" >/dev/null
+  if ! kubectl wait --for=jsonpath='{.status.phase}'=Succeeded "pod/${name}" \
+      -n "$NAMESPACE" --timeout=60s >/dev/null 2>&1; then
+    kubectl logs "$name" -n "$NAMESPACE" 2>/dev/null || true
+    kubectl delete pod "$name" -n "$NAMESPACE" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+    return 1
+  fi
+  kubectl logs "$name" -n "$NAMESPACE"
+  local rc=$?
+  kubectl delete pod "$name" -n "$NAMESPACE" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  return "$rc"
+}
+
 echo "=== verify-ui-sidecar (namespace=${NAMESPACE}) ==="
 kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
 
@@ -107,9 +130,8 @@ pod_ip=$(kubectl get pod "$engine_pod" -n "$NAMESPACE" -o jsonpath='{.status.pod
 echo "Probing the Engine Web UI at ${pod_ip}:${UI_PORT} (index + /config.js)..."
 attempts=6
 for i in $(seq 1 "$attempts"); do
-  if output=$(kubectl run "ui-probe-$i" -n "$NAMESPACE" --rm -i --restart=Never \
-      --image="${CURL_IMAGE}" --quiet -- sh -c \
-      "curl -sf -o /dev/null http://${pod_ip}:${UI_PORT}/ && curl -sf http://${pod_ip}:${UI_PORT}/config.js" 2>/dev/null); then
+  if output=$(run_probe_pod "ui-probe-$i" \
+      "curl -sf -o /dev/null http://${pod_ip}:${UI_PORT}/ && curl -sf http://${pod_ip}:${UI_PORT}/config.js"); then
     if printf '%s' "$output" | grep -q "__FIREBOLT_CORE_CONFIG__"; then
       echo "UI index answers 200 and /config.js carries the runtime config:"
       printf '%s\n' "$output"
@@ -142,9 +164,7 @@ default_database=$(printf '%s' "$output" | sed -n 's/.*defaultDatabase: "\([^"]*
 default_database="${default_database:-firebolt}"
 # `|| true` keeps a no-match grep (exit 1, fatal under `set -euo pipefail`)
 # from killing the script before the empty-chunk check below can report it.
-chunk=$(kubectl run "ui-chunk" -n "$NAMESPACE" --rm -i --restart=Never \
-  --image="${CURL_IMAGE}" --quiet -- sh -c \
-  "curl -sf http://${pod_ip}:${UI_PORT}/" 2>/dev/null \
+chunk=$(run_probe_pod "ui-chunk" "curl -sf http://${pod_ip}:${UI_PORT}/" \
   | grep -o 'assets/index-[A-Za-z0-9_-]*\.js' | head -1 || true)
 if [[ -z "$chunk" ]]; then
   echo "index.html references no hashed bundle chunk (assets/index-*.js)"
@@ -153,10 +173,9 @@ if [[ -z "$chunk" ]]; then
 fi
 
 echo "Replaying the workspace request contract (chunk=${chunk}, database=${default_database})..."
-attempts=3
+attempts=6
 for i in $(seq 1 "$attempts"); do
-  if output=$(kubectl run "ui-contract-$i" -n "$NAMESPACE" --rm -i --restart=Never \
-      --image="${CURL_IMAGE}" --quiet -- sh -c "
+  if output=$(run_probe_pod "ui-contract-$i" "
       set -e
       base=http://${pod_ip}:${UI_PORT}
       echo '-- SPA bundle chunk'
@@ -168,7 +187,7 @@ for i in $(seq 1 "$attempts"); do
       echo '-- workspace query execution (SQL editor shape)'
       curl -sf -X POST \"\${base}/query?output_format=JSON_Compact&database=${default_database}\" \
         -H 'Content-Type: application/json' -H 'Authorization: Bearer lite' \
-        -d 'SELECT 42;'" 2>/dev/null); then
+        -d 'SELECT 42;'"); then
     if printf '%s' "$output" | grep -q '"data"' && printf '%s' "$output" | grep -q '42'; then
       echo "Workspace request contract satisfied; SELECT 42 returned data:"
       printf '%s\n' "$output" | tail -3


### PR DESCRIPTION
**Background**

FB-2667: Gateway CRL Secret updates did not change the gateway config hash, so Envoy kept serving the CRL loaded at process start and certificate revocation stayed ineffective on running pods.

**Summary**

`gatewayTLSSecretVersions` already folds mounted TLS Secret `ResourceVersion`s into the gateway `firebolt.io/config-hash` so in-place rotations roll the Deployment. It omitted the engine and client CRL Secrets (`spec.tls.engine.crlSecretRef` / `spec.tls.gateway.crlSecretRef`), even though those Secrets are mounted and referenced from Envoy as static `crl: filename:` paths that do not hot-reload.

This change folds those CRL Secret RVs into the same helper, gated on the same predicates as the pod mounts (`engineUpstreamTLSReady` for the engine CRL; `gatewayDownstreamTLSReady` + client-CA present for the client CRL). Missing Secrets remain skipped. Updating a CRL Secret now changes the stamped hash and rolls the Gateway so Envoy reloads the list.

Going forward, CRL updates propagate via a normal Gateway rolling update (within about a minute on the instance reconcile cadence). Instances that already have a `crlSecretRef` configured will see one Gateway roll on operator upgrade when the stamped hash gains the CRL entry.

Follow-ups (not in this PR):
- FB-2928: preflight / stall detection when a rolled CRL Secret lacks `crl.pem`
- FB-2929: controller-side fallback when `crlSecretRef` is set without `clientCASecretRef` (webhooks off)

**Test Plan**

- [x] `go test ./internal/controller/ -run TestGatewayTLSSecretVersions -count=1`
- [x] `make build && make lint`
- [x] Unit coverage for engine/client CRL fold + rotation, missing CRL tolerated, and negative gates (no fold when upstream TLS inactive / no client CA)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gateway rollout hashing for TLS/mTLS instances with CRLs; behavior is intentional (revocation propagation) but triggers rolling restarts and affects certificate verification on the data path.
> 
> **Overview**
> Fixes **FB-2667**: updating a CRL Secret did not change the gateway `firebolt.io/config-hash`, so running Envoy pods kept the revocation list loaded at startup and revocation stayed ineffective.
> 
> **`gatewayTLSSecretVersions`** now folds **ResourceVersion** for `spec.tls.engine.crlSecretRef` and `spec.tls.gateway.crlSecretRef` into the same hash used for cert rotations, using the same gates as pod mounts (`engineUpstreamTLSReady` for engine CRL; downstream TLS ready plus client CA for client CRL). Missing CRL Secrets are still skipped.
> 
> **Docs** note that CRL Secret updates trigger a Gateway roll within about a minute and that Envoy does not hot-reload `filename`-referenced CRLs from the volume alone.
> 
> Unit tests cover CRL fold/rotation, omitted CRL when not mounted, and missing CRL tolerance. Expect a one-time Gateway roll on operator upgrade when a `crlSecretRef` was already configured, as the hash gains the CRL entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9988eb95dafaf35597b264e6807b70f8da786d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->