### PR TITLE
chore(deps): bump packdb engine/metadata to 5.0.0-pre.0.20260808171517.d7585f66d216

### DIFF
--- a/config/images/defaults.latest.env
+++ b/config/images/defaults.latest.env
@@ -21,9 +21,9 @@
 #     test/e2e/e2e_suite_test.go's SynchronizedBeforeSuite.
 
 ENGINE_IMAGE=oci.firebolt.io/firebolt-db/engine
-ENGINE_TAG=release-5.0.0-pre.0.20260806001005.b7c004a34806
+ENGINE_TAG=release-5.0.0-pre.0.20260808171517.d7585f66d216
 METADATA_IMAGE=ghcr.io/firebolt-db/metadata
-METADATA_TAG=release-5.0.0-pre.0.20260806001005.b7c004a34806
+METADATA_TAG=release-5.0.0-pre.0.20260808171517.d7585f66d216
 POSTGRES_IMAGE=postgres:16-alpine
 ENVOY_IMAGE=envoyproxy/envoy
 ENVOY_TAG=v1.37.2


### PR DESCRIPTION
## Summary

Bump default engine/metadata images to packdb `5.0.0-pre.0.20260808171517.d7585f66d216`
— the build the engine/metadata `:latest` GHCR tags were just re-pointed to.

> [!NOTE]
> Opened automatically by packdb's `promote-ghcr-latest` workflow (weekly
> Monday refresh or a manual promotion) right after it re-pointed the
> engine/metadata `:latest` GHCR tags at this build, so `:latest` and this
> repo's pinned tags move together. An unmerged PR is overwritten by the
> next run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the default engine/metadata images shipped with the operator, so an incompatible packdb build could break deployments; gated by unit and E2E tests.
> 
> **Overview**
> Bumps the default **engine** and **metadata** image pins in `config/images/defaults.latest.env` to packdb `release-5.0.0-pre.0.20260808171517.d7585f66d216`, matching the newly promoted GHCR `:latest` tags.
> 
> No operator logic changes—only the embedded default image tags used by the latest build variant, Helm chart, and E2E suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bbbf037b2f6332b6a6b4ff613200dc68b281b27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->