### PR TITLE
ci: skip expensive suites on trusted release-please PRs (FB-2987)

### DIFF
--- a/.github/workflows/formal-verification.yaml
+++ b/.github/workflows/formal-verification.yaml
@@ -23,6 +23,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
@@ -34,11 +38,24 @@ jobs:
           # The mutant check has a WIDER scope than TLC: it asserts the
           # state-cover suite still catches a broken reconciler, so it depends
           # on the reconciler itself, not only on the model.
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
+          if [ "${EVENT_NAME}" != "pull_request" ]; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
             echo "mutants=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          # Trusted release-please PRs only rewrite release metadata
+          # (version.txt / CHANGELOG / manifest / chart version fields).
+          # Require same-repo head + the release writer bot so a fork or
+          # hand-rolled branch named like release-please still path-scopes
+          # normally (and fail-open still runs workers when uncertain).
+          if [[ "${HEAD_REF}" == release-please--* && "${HEAD_REPO}" == "${REPO}" && "${PR_AUTHOR}" == "fireboltdb-ci-writer[bot]" ]]; then
+            echo "Trusted release-please branch '${HEAD_REF}'; skipping TLC/mutants workers."
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "mutants=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           files="$(gh api --paginate \
             "repos/${REPO}/compare/${BASE_SHA}...${HEAD_SHA}" \
             --jq '.files[].filename' 2>/dev/null || true)"

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -29,34 +29,59 @@ concurrency:
 
 jobs:
   detect:
-    name: Detect docs-only change
+    name: Detect expensive-test shortcut
     runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
+      release_please: ${{ steps.detect.outputs.release_please }}
+      skip_expensive: ${{ steps.detect.outputs.skip_expensive }}
+      skip_reason: ${{ steps.detect.outputs.skip_reason }}
     steps:
-      - name: Determine whether the PR changed only docs
+      - name: Determine whether the PR can skip Kind tests
         id: detect
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          # The docs-only short-circuit only applies to pull_request events.
-          # A workflow_dispatch run is an explicit request to run the suite,
-          # so always run it (no PR diff exists to inspect anyway).
+          write_outputs() {
+            {
+              echo "docs_only=$1"
+              echo "release_please=$2"
+              echo "skip_expensive=$3"
+              echo "skip_reason=$4"
+            } >> "$GITHUB_OUTPUT"
+          }
+
+          # Shortcuts only apply to pull_request events. workflow_dispatch is
+          # an explicit request to run the suite (no PR diff to inspect).
           if [ "${EVENT_NAME}" != "pull_request" ]; then
             echo "Event '${EVENT_NAME}' is not a pull_request; running full suite."
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            write_outputs false false false ""
             exit 0
           fi
+
+          # Trusted release-please PRs only rewrite release metadata
+          # (version.txt / CHANGELOG / manifest / chart version fields).
+          # Require same-repo head + the release writer bot so a fork or
+          # hand-rolled branch named like release-please still runs Kind.
+          if [[ "${HEAD_REF}" == release-please--* && "${HEAD_REPO}" == "${REPO}" && "${PR_AUTHOR}" == "fireboltdb-ci-writer[bot]" ]]; then
+            echo "Trusted release-please branch '${HEAD_REF}'; skipping Kind-backed worker."
+            write_outputs false true true release_please
+            exit 0
+          fi
+
           # List the PR's changed files via the compare API (no checkout
           # needed). "docs" = markdown anywhere, plus docs/.
-          # Fail-safe: any uncertainty leaves docs_only=false so the full
-          # suite still runs.
+          # Fail-safe: any uncertainty leaves skip_expensive=false so the
+          # full suite still runs.
           files="$(gh api --paginate \
             "repos/${REPO}/compare/${BASE_SHA}...${HEAD_SHA}" \
             --jq '.files[].filename' 2>/dev/null || true)"
@@ -65,15 +90,15 @@ jobs:
           non_docs="$(printf '%s\n' "${files}" \
             | grep -vE '\.mdx?$|^docs/' || true)"
           if [ -n "${files}" ] && [ -z "${non_docs}" ]; then
-            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            write_outputs true false true docs_only
           else
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            write_outputs false false false ""
           fi
 
   test-e2e:
     name: E2E Tests (${{ matrix.variant }})
     needs: detect
-    if: needs.detect.outputs.docs_only != 'true'
+    if: needs.detect.outputs.skip_expensive != 'true'
     runs-on: ubuntu-16core-64gb-600ssd-amd64
     permissions:
       contents: read
@@ -252,11 +277,12 @@ jobs:
 
   # Single stable required-check name for branch protection. Matrix legs
   # (E2E Tests (dev/latest)) are not reliably emitted as per-combination
-  # checks when skipped, so a docs-only PR would leave them Pending and
-  # block the merge. This gate runs `if: always()`, collapses both matrix
-  # legs into one `needs.test-e2e.result`, and fails closed if `detect`
-  # itself failed (which would otherwise skip the heavy job and report a
-  # false success).
+  # checks when skipped, so a docs-only or release-please PR would leave
+  # them Pending and block the merge. This gate runs `if: always()`,
+  # collapses both matrix legs into one `needs.test-e2e.result`, and fails
+  # closed if `detect` itself failed (which would otherwise skip the heavy
+  # job and report a false success). An intentional skip must set
+  # skip_expensive=true.
   e2e-required:
     name: E2E Tests
     needs: [detect, test-e2e]
@@ -267,12 +293,25 @@ jobs:
       - name: Verify gated jobs
         env:
           DETECT: ${{ needs.detect.result }}
+          SKIP_EXPENSIVE: ${{ needs.detect.outputs.skip_expensive }}
+          SKIP_REASON: ${{ needs.detect.outputs.skip_reason }}
           E2E: ${{ needs.test-e2e.result }}
         run: |
           if [ "$DETECT" != "success" ]; then
             echo "::error::detect did not succeed (result=$DETECT)"; exit 1
           fi
           case "$E2E" in
-            success|skipped) echo "gate satisfied (test-e2e=$E2E)";;
-            *) echo "::error::test-e2e result=$E2E"; exit 1;;
+            success)
+              echo "gate satisfied (test-e2e=$E2E)"
+              ;;
+            skipped)
+              if [ "$SKIP_EXPENSIVE" = "true" ]; then
+                echo "gate satisfied (test-e2e=skipped, reason=$SKIP_REASON)"
+              else
+                echo "::error::test-e2e was skipped but skip_expensive=$SKIP_EXPENSIVE"; exit 1
+              fi
+              ;;
+            *)
+              echo "::error::test-e2e result=$E2E"; exit 1
+              ;;
           esac

--- a/.github/workflows/test-helm.yaml
+++ b/.github/workflows/test-helm.yaml
@@ -17,25 +17,50 @@ concurrency:
 
 jobs:
   detect:
-    name: Detect docs-only change
+    name: Detect expensive-test shortcut
     runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
       docs_only: ${{ steps.detect.outputs.docs_only }}
+      release_please: ${{ steps.detect.outputs.release_please }}
+      skip_expensive: ${{ steps.detect.outputs.skip_expensive }}
+      skip_reason: ${{ steps.detect.outputs.skip_reason }}
     steps:
-      - name: Determine whether the PR changed only docs
+      - name: Determine whether the PR can skip Kind tests
         id: detect
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          write_outputs() {
+            {
+              echo "docs_only=$1"
+              echo "release_please=$2"
+              echo "skip_expensive=$3"
+              echo "skip_reason=$4"
+            } >> "$GITHUB_OUTPUT"
+          }
+
+          # Trusted release-please PRs only rewrite release metadata
+          # (version.txt / CHANGELOG / manifest / chart version fields).
+          # Require same-repo head + the release writer bot so a fork or
+          # hand-rolled branch named like release-please still runs Kind.
+          if [[ "${HEAD_REF}" == release-please--* && "${HEAD_REPO}" == "${REPO}" && "${PR_AUTHOR}" == "fireboltdb-ci-writer[bot]" ]]; then
+            echo "Trusted release-please branch '${HEAD_REF}'; skipping Kind-backed worker."
+            write_outputs false true true release_please
+            exit 0
+          fi
+
           # List the PR's changed files via the compare API (no checkout
           # needed). "docs" = markdown anywhere, plus docs/.
-          # Fail-safe: any uncertainty leaves docs_only=false so the full
-          # suite still runs.
+          # Fail-safe: any uncertainty leaves skip_expensive=false so the
+          # full suite still runs.
           files="$(gh api --paginate \
             "repos/${REPO}/compare/${BASE_SHA}...${HEAD_SHA}" \
             --jq '.files[].filename' 2>/dev/null || true)"
@@ -44,15 +69,15 @@ jobs:
           non_docs="$(printf '%s\n' "${files}" \
             | grep -vE '\.mdx?$|^docs/' || true)"
           if [ -n "${files}" ] && [ -z "${non_docs}" ]; then
-            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            write_outputs true false true docs_only
           else
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            write_outputs false false false ""
           fi
 
   test-helm:
     name: test-helm
     needs: detect
-    if: needs.detect.outputs.docs_only != 'true'
+    if: needs.detect.outputs.skip_expensive != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -183,7 +208,8 @@ jobs:
   # is a single job that already reports success when skipped, but this
   # gate closes the `detect` fail-open hole (a failed `detect` would skip
   # the heavy job and report a false success) and gives branch protection
-  # one stable name independent of the worker job.
+  # one stable name independent of the worker job. An intentional skip must
+  # set skip_expensive=true (docs-only or trusted release-please).
   helm-required:
     name: Helm Tests
     needs: [detect, test-helm]
@@ -194,12 +220,25 @@ jobs:
       - name: Verify gated jobs
         env:
           DETECT: ${{ needs.detect.result }}
+          SKIP_EXPENSIVE: ${{ needs.detect.outputs.skip_expensive }}
+          SKIP_REASON: ${{ needs.detect.outputs.skip_reason }}
           HELM: ${{ needs.test-helm.result }}
         run: |
           if [ "$DETECT" != "success" ]; then
             echo "::error::detect did not succeed (result=$DETECT)"; exit 1
           fi
           case "$HELM" in
-            success|skipped) echo "gate satisfied (test-helm=$HELM)";;
-            *) echo "::error::test-helm result=$HELM"; exit 1;;
+            success)
+              echo "gate satisfied (test-helm=$HELM)"
+              ;;
+            skipped)
+              if [ "$SKIP_EXPENSIVE" = "true" ]; then
+                echo "gate satisfied (test-helm=skipped, reason=$SKIP_REASON)"
+              else
+                echo "::error::test-helm was skipped but skip_expensive=$SKIP_EXPENSIVE"; exit 1
+              fi
+              ;;
+            *)
+              echo "::error::test-helm result=$HELM"; exit 1
+              ;;
           esac

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,8 +6,46 @@ on:
 permissions: {}
 
 jobs:
+  detect:
+    name: Detect test shortcut
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      skip_test: ${{ steps.detect.outputs.skip_test }}
+      skip_reason: ${{ steps.detect.outputs.skip_reason }}
+    steps:
+      - name: Determine whether the PR can skip unit tests
+        id: detect
+        env:
+          REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          write_outputs() {
+            {
+              echo "skip_test=$1"
+              echo "skip_reason=$2"
+            } >> "$GITHUB_OUTPUT"
+          }
+
+          # Trusted release-please PRs only rewrite release metadata
+          # (version.txt / CHANGELOG / manifest / chart version fields).
+          # Require same-repo head + the release writer bot so a fork or
+          # hand-rolled branch named like release-please still runs tests.
+          if [[ "${HEAD_REF}" == release-please--* && "${HEAD_REPO}" == "${REPO}" && "${PR_AUTHOR}" == "fireboltdb-ci-writer[bot]" ]]; then
+            echo "Trusted release-please branch '${HEAD_REF}'; skipping unit-test worker."
+            write_outputs true release_please
+            exit 0
+          fi
+
+          write_outputs false ""
+
   test:
     name: Run on Ubuntu (${{ matrix.variant }})
+    needs: detect
+    if: needs.detect.outputs.skip_test != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -57,22 +95,41 @@ jobs:
         env:
           GOPRIVATE: github.com/firebolt-db/*
 
-  # Single stable required-check name for branch protection. The unit
-  # matrix legs (Run on Ubuntu (dev/latest)) were never required directly;
-  # this gate exposes one stable name. The unit suite always runs (no
-  # `detect`), so the gate simply requires `test` to have succeeded.
+  # Single stable required-check name for branch protection. Matrix legs
+  # (Run on Ubuntu (dev/latest)) are not reliably emitted as per-combination
+  # checks when skipped, so a trusted release-please PR would leave them
+  # Pending and block the merge. This gate runs `if: always()`, collapses
+  # both matrix legs into one `needs.test.result`, and fails closed if
+  # `detect` itself failed. An intentional skip must set skip_test=true.
   unit-tests:
     name: Unit Tests
-    needs: [test]
+    needs: [detect, test]
     if: always()
     runs-on: ubuntu-latest
     permissions: {}
     steps:
       - name: Verify gated jobs
         env:
+          DETECT: ${{ needs.detect.result }}
+          SKIP_TEST: ${{ needs.detect.outputs.skip_test }}
+          SKIP_REASON: ${{ needs.detect.outputs.skip_reason }}
           TEST: ${{ needs.test.result }}
         run: |
-          if [ "$TEST" != "success" ]; then
-            echo "::error::test result=$TEST"; exit 1
+          if [ "$DETECT" != "success" ]; then
+            echo "::error::detect did not succeed (result=$DETECT)"; exit 1
           fi
-          echo "gate satisfied (test=$TEST)"
+          case "$TEST" in
+            success)
+              echo "gate satisfied (test=$TEST)"
+              ;;
+            skipped)
+              if [ "$SKIP_TEST" = "true" ]; then
+                echo "gate satisfied (test=skipped, reason=$SKIP_REASON)"
+              else
+                echo "::error::test was skipped but skip_test=$SKIP_TEST"; exit 1
+              fi
+              ;;
+            *)
+              echo "::error::test result=$TEST"; exit 1
+              ;;
+          esac

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,9 +273,15 @@ Every third-party binary that CI or the Makefile downloads (`kind`, `yq`, `helm-
 
 ### Required checks / rollup gates
 
-GitHub branch protection requires checks by **job `name`** (not workflow name). A check counts as passing when it is `success`, `skipped`, or `neutral` — but **where** the skip happens matters: a workflow skipped by an `on:` filter stays *Pending* (blocks the PR), whereas a job skipped by a job-level `if:` reports *Success*. Matrix-leg names are also not reliably emitted when the leg is skipped. To keep path/branch-conditional workflows compatible with required checks (docs-only PRs must not block forever, but real failures must still fail closed), each conditional or matrix workflow exposes **one stable required-check name backed by a rollup gate job**.
+GitHub branch protection requires checks by **job `name`** (not workflow name). A check counts as passing when it is `success`, `skipped`, or `neutral` — but **where** the skip happens matters: a workflow skipped by an `on:` filter stays *Pending* (blocks the PR), whereas a job skipped by a job-level `if:` reports *Success*. Matrix-leg names are also not reliably emitted when the leg is skipped. To keep path/branch-conditional workflows compatible with required checks (docs-only and trusted release-please PRs must not block forever, but real failures must still fail closed), each conditional or matrix workflow exposes **one stable required-check name backed by a rollup gate job**.
 
-Gate convention: the gate job runs `if: always()`, `needs` the `detect` job plus the heavy/worker job, has `permissions: {}`, uses inline `run:` only (no new pinned action — keeps the action-lint/zizmor surface unchanged), and passes only when `detect` succeeded **and** the gated job is `success` or (intentionally) `skipped`. A failed `detect` fails the gate closed (a skipped heavy job would otherwise count as a false success). `needs.<job>.result` collapses all matrix legs into one result.
+Gate convention: the gate job runs `if: always()`, `needs` the `detect` job plus the heavy/worker job, has `permissions: {}`, uses inline `run:` only (no new pinned action — keeps the action-lint/zizmor surface unchanged), and passes only when `detect` succeeded **and** the gated job is `success` or (intentionally) `skipped` with the matching skip output set. A failed `detect` fails the gate closed (a skipped heavy job would otherwise count as a false success). `needs.<job>.result` collapses all matrix legs into one result.
+
+**Trusted release-please shortcut.** Release-please PRs only rewrite release metadata (`version.txt`, `CHANGELOG.md`, `.release-please-manifest.json`, chart `version` / `appVersion`). Their code was already gated on the feature PRs that landed on `main`, so the expensive workers skip on those PRs while the rollup gates stay green:
+
+- Predicate (must match all three): `github.head_ref` starts with `release-please--`, head repo is this repository (not a fork), and `github.event.pull_request.user.login` is `fireboltdb-ci-writer[bot]`.
+- Applied in `test-e2e.yaml`, `test-helm.yaml`, `test.yaml`, and `formal-verification.yaml` (sets `relevant`/`mutants` false so TLC and Mutants skip). Do **not** skip via workflow-level `on:` / branch filters — that leaves required checks Pending.
+- Forks or hand-rolled branches named like `release-please--*` still run the full suites (fail closed). `formal-verification.yaml` push-to-`main` is unchanged and still always runs TLC/mutants.
 
 Canonical required-check names (each is a gate job except Lint / PR Title):
 


### PR DESCRIPTION
**Background**

FB-2987: Release-please PRs only bump release metadata, but still burn Kind e2e, helm-test, unit tests, and formal workers; that CI adds no merge signal beyond the feature PRs that already landed the code.

**Summary**

Skip the expensive workers on **trusted** release-please pull requests while keeping the required rollup gates green:

- `test-e2e.yaml` / `test-helm.yaml`: extend the existing docs-only detect into an expensive-test shortcut that also recognizes trusted release-please PRs (`skip_expensive` + `skip_reason`).
- `test.yaml`: add a detect job that skips the unit-test matrix on the same predicate; `Unit Tests` gate accepts intentional skips only.
- `formal-verification.yaml`: trusted release-please PRs force `relevant=false` / `mutants=false` so TLC and Mutants stand down (push-to-`main` still always runs).
- Rollup gates now require the matching skip output when a worker is `skipped`, so an accidental skip fails closed.
- Trust predicate: `head_ref` starts with `release-please--`, head repo is this repository, author is `fireboltdb-ci-writer[bot]`.

Going forward, release-please PRs still report `E2E Tests`, `Helm Tests`, `Unit Tests`, and `TLC model checker` as success without starting the heavy jobs. Forks or hand-rolled `release-please--*` branches keep running the full suites.

**Test Plan**

- [x] Local bash checks of the trust predicate (trusted bot/same-repo → skip; fork, wrong author, or non-release-please branch → run)
- [x] Confirmed live release-please author/login is `fireboltdb-ci-writer[bot]` (e.g. #118 / #130 / #131)
- [ ] On this PR: Actions Lint & Scan / workflow jobs pass; normal (non-release-please) PR still runs e2e/helm/unit/formal path detect as before
- [ ] After merge: next release-please PR shows Kind/unit/TLC workers skipped with gates green (`reason=release_please`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes required-check skip/gate logic across four workflows; a bad trust predicate or gate condition could skip suites incorrectly or block merges. Mitigated by a three-part trust check and fail-closed gate behavior.
> 
> **Overview**
> Skips expensive CI workers on **trusted release-please PRs** (metadata-only bumps) while keeping required rollup gates green.
> 
> Extends the e2e/helm docs-only detect into a shared `skip_expensive` shortcut, adds a unit-test detect job, and forces formal `relevant`/`mutants` false for the same trust predicate: `release-please--*` branch, same-repo head, and author `fireboltdb-ci-writer[bot]`. Forks or hand-rolled lookalikes still run full suites.
> 
> Rollup gates now accept a skipped worker **only** when the matching skip output is set, so accidental skips fail closed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83708731f3382cebf2166af4467475fdc4bc3b5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->