### PR TITLE
test(helm): tolerate API blips and reap the probe pod in the health watch (FB-3200)

### DIFF
--- a/scripts/ci/verify-wake-on-zero.sh
+++ b/scripts/ci/verify-wake-on-zero.sh
@@ -237,6 +237,16 @@ echo "Probing ${health_url} while the engine is parked (${HEALTH_PROBE_COUNT} ro
 ) > /tmp/healthz-probe-output 2>&1 &
 health_probe_pid=$!
 
+# Stops the probe pod on a failure path. Killing $health_probe_pid only
+# stops the local kubectl client; --rm cleanup is client-side, so the pod
+# would keep probing until its loop ends, muddying dump_namespace_debug and
+# any rerun in the same namespace.
+stop_health_probe() {
+  kill "$health_probe_pid" 2>/dev/null || true
+  kubectl delete pod "$health_probe_pod" -n "$NAMESPACE" \
+    --ignore-not-found --wait=false >/dev/null 2>&1 || true
+}
+
 # Fails the phase when the engine leaves its parked state. Watching is not
 # window-based but synchronized with the probe pod's lifetime: the watch runs
 # for as long as the probes do (however long the pod takes to schedule), and
@@ -245,16 +255,38 @@ health_probe_pid=$!
 # could stop watching while late probes were still being sent, and a demand
 # stamped then would wake the engine unobserved — and hand the wake phase
 # below an already-running engine.
+#
+# A kubectl error must not read as a wake: a failed read falls back to
+# empty, and empty != "0". Retry a few times before failing closed under an
+# unreadable-engine message, the same tolerance the park wait above gets by
+# looping over empty reads. Only the replicas read gates the retry — the
+# reason read is diagnostic, and an empty reason matches nothing.
 require_engine_parked() {
-  replicas=$(kubectl get fireboltengine "$ENGINE_NAME" -n "$NAMESPACE" \
-    -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "")
-  reason=$(kubectl get fireboltengine "$ENGINE_NAME" -n "$NAMESPACE" \
-    -o jsonpath='{.status.autoStopReason}' 2>/dev/null || echo "")
+  local attempt replicas reason
+  for attempt in 1 2 3; do
+    replicas=$(kubectl get fireboltengine "$ENGINE_NAME" -n "$NAMESPACE" \
+      -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "")
+    reason=$(kubectl get fireboltengine "$ENGINE_NAME" -n "$NAMESPACE" \
+      -o jsonpath='{.status.autoStopReason}' 2>/dev/null || echo "")
+    if [[ -n "${replicas}" ]]; then
+      break
+    fi
+    sleep 2
+  done
+  if [[ -z "${replicas}" ]]; then
+    echo "Could not read the engine after ${attempt} attempts while watching for a"
+    echo "probe-driven wake. Failing closed: an unwatched window cannot prove the"
+    echo "probes did not wake the engine. This is an API read problem, not a"
+    echo "filter-order regression."
+    stop_health_probe
+    dump_namespace_debug "$NAMESPACE"
+    exit 1
+  fi
   if [[ "${replicas}" != "0" || "${reason}" == "WakeRequested" ]]; then
-    echo "A health probe woke the parked engine (replicas=${replicas:-?}, autoStopReason=${reason:-<none>})."
+    echo "A health probe woke the parked engine (replicas=${replicas}, autoStopReason=${reason:-<none>})."
     echo "A probe on /healthz must be answered ahead of the wake filter and must"
     echo "never register demand."
-    kill "$health_probe_pid" 2>/dev/null || true
+    stop_health_probe
     kubectl logs "$gateway_pod" -n "$NAMESPACE" -c wake-agent --tail=80 || true
     dump_namespace_debug "$NAMESPACE"
     exit 1
@@ -267,7 +299,7 @@ while kill -0 "$health_probe_pid" 2>/dev/null; do
   if (( SECONDS >= probe_deadline )); then
     echo "Health probes did not complete within ${HEALTH_PROBE_TIMEOUT}s:"
     cat /tmp/healthz-probe-output
-    kill "$health_probe_pid" 2>/dev/null || true
+    stop_health_probe
     dump_namespace_debug "$NAMESPACE"
     exit 1
   fi
@@ -278,9 +310,16 @@ done
 if ! wait "$health_probe_pid"; then
   echo "The health-probe pod failed:"
   cat /tmp/healthz-probe-output
+  stop_health_probe
   dump_namespace_debug "$NAMESPACE"
   exit 1
 fi
+
+# A completed client does not prove the pod is gone: kubectl run --rm deletes
+# the pod in a deferred call whose error is discarded. Delete it best-effort
+# now, before validating the responses, so no exit below can leak it.
+kubectl delete pod "$health_probe_pod" -n "$NAMESPACE" \
+  --ignore-not-found --wait=false >/dev/null 2>&1 || true
 
 echo "Probes done; the engine must stay at zero for another ${HEALTH_SETTLE_SECONDS}s..."
 settle_deadline=$(( SECONDS + HEALTH_SETTLE_SECONDS ))


### PR DESCRIPTION
**Background**

FB-3200: post-merge review of #155 found two hardening gaps in the new health-probe phase of `verify-wake-on-zero.sh`. Neither can produce a false pass (both paths fail closed), but one is a flake source with a misleading diagnosis and the other leaks a pod on failure.

**Summary**

Two fixes, both confined to the health-probe phase:

1. **A transient API error no longer reads as "a probe woke the engine".** The parked-check fell back to an empty read on any `kubectl get` error, and empty `!= "0"` took the wake-failure path. A brief API-server blip anywhere in the roughly two-minute watch and settle window failed the required job while pointing triage at the filter order. The replicas read now retries up to three times, and a persistently unreadable engine fails closed under its own message that names the API read as the problem. The wake detection itself is unchanged: any successful read that is not `0` still fails immediately.

2. **No exit in the phase can leak the probe pod any more.** Killing the backgrounded `kubectl run` client never deleted the pod (`--rm` cleanup is client-side), so on a failure the pod kept probing until its loop ended, muddying `dump_namespace_debug` output and reruns in the same namespace. Even a client that completes normally does not prove deletion, because kubectl discards the deferred delete call's error. Failure paths while the client is alive now kill it and delete the pod by name; after a successful wait the pod is deleted best-effort before the responses are validated.

Out of scope: the wake phase's own probe pod has the same leak-on-failure trait. It predates #155 and is left as is.

**Test Plan**

- A stubbed harness drove the phase through ten scenarios: pass, a single API blip (tolerated, passes), API persistently down (fails with the unreadable-engine message), wake during probes, wake during settle, wake at the terminal check, non-200 response, short output, probe-pod failure, and probe timeout. Each behaves as intended.
- `bash -n` and shellcheck are clean.
- The full path runs in CI's `Helm Tests` job via `make helm-test-wake`.

**Follow-ups**

- Give the wake phase's probe pod the same failure-path cleanup, if wanted.
