### PR TITLE
docs: advertise the Gateway as the only query entry point (FB-2154)

### DIFF
--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -34,9 +34,9 @@ An Engine may also reference one EngineClass in the same namespace through `spec
 
 ## Query traffic
 
-Clients normally connect to the Instance Gateway and select an Engine with the `X-Firebolt-Engine` header. The Gateway forwards traffic only to ready pods in the Engine's active generation.
+Clients connect to the Instance Gateway and select an Engine with the `X-Firebolt-Engine` header. The Gateway forwards traffic only to ready pods in the Engine's active generation.
 
-You can also connect directly to an Engine Service. Direct connections bypass Gateway features, including waking an auto-stopped Engine.
+Internally, each Engine exposes a Service that the Gateway resolves at request time. The Firebolt Operator switches that Service between generations during blue-green rollouts. It is an internal mechanism, not a client entry point: traffic that bypasses the Gateway is unsupported and loses Gateway features, including waking an auto-stopped Engine.
 
 See [Gateway overview](./instance/gateway/overview) for connection examples and [Gateway query routing](./instance/gateway/gateway-query-routing) for routing behavior.
 

--- a/docs/engine/auto-stop-and-wake-up.mdx
+++ b/docs/engine/auto-stop-and-wake-up.mdx
@@ -75,7 +75,7 @@ spec:
     enabled: false
 ```
 
-Direct connections to the Engine Service cannot wake a stopped Engine because the Service has no endpoints. Route through the Instance Gateway when you rely on wake-up.
+Wake-up works only for queries sent through the Instance Gateway. Traffic that bypasses the Gateway is unsupported and cannot wake a stopped Engine because the Engine Service has no endpoints.
 
 Set `wakeAgent.enabled=false` in the Helm values to disable Gateway wake-up. Queries to running Engines are unaffected; a query for a stopped Engine returns `503`.
 

--- a/docs/engine/engine-scaling.mdx
+++ b/docs/engine/engine-scaling.mdx
@@ -39,7 +39,7 @@ kubectl patch fireng my-engine -n firebolt \
   --type merge -p '{"spec":{"replicas":2}}'
 ```
 
-If you use auto-stop and want a query to resume a stopped Engine automatically, send traffic through the Instance Gateway. Direct Engine Service traffic cannot wake an Engine with no endpoints.
+If you use auto-stop and want a query to resume a stopped Engine automatically, send traffic through the Instance Gateway. Traffic that bypasses the Gateway cannot wake an Engine with no endpoints.
 
 ## Update an Engine image
 

--- a/docs/instance/gateway/gateway-query-routing.mdx
+++ b/docs/instance/gateway/gateway-query-routing.mdx
@@ -49,6 +49,6 @@ During an Engine cutover or scale-down:
 4. The Gateway retries that request on another ready pod.
 5. Queries accepted before shutdown continue until they finish or the Engine's termination window expires.
 
-The zero-downtime contract applies to traffic through the Gateway and to request bodies within the 2 MiB retry limit. Direct Engine Service connections bypass Gateway retry behavior.
+The zero-downtime contract applies to traffic through the Gateway and to request bodies within the 2 MiB retry limit. Traffic that bypasses the Gateway is unsupported and receives none of these guarantees.
 
 See [Engine rollouts](../../engine/engine-rollouts) for drain controls and [Gateway sizing](./gateway-sizing) for memory and concurrency planning.

--- a/docs/instance/gateway/overview.mdx
+++ b/docs/instance/gateway/overview.mdx
@@ -16,9 +16,9 @@ removes the routing-only query parameter before forwarding the request to the En
 
 ## Connect to engines
 
-### Instance gateway (recommended)
+### Instance gateway
 
-The recommended entry point is the instance gateway. The Envoy proxy routes requests based on the target engine name and handles retries during blue-green transitions. Pass the engine with the `X-Firebolt-Engine` header (raw HTTP clients) or the `engine` query parameter (the bundled `firebolt` CLI).
+The Instance Gateway is the entry point for engine queries. The Envoy proxy routes requests based on the target engine name and handles retries during blue-green transitions. Pass the engine with the `X-Firebolt-Engine` header (raw HTTP clients) or the `engine` query parameter (the bundled `firebolt` CLI).
 
 ```text
 POST http://<instance-name>-gateway.<namespace>.svc.cluster.local/
@@ -38,15 +38,6 @@ firebolt client \
   -c "SELECT 42" \
   --no-interactive
 ```
-
-### Per-engine service
-
-Each engine also exposes a headless Service at `<engine>-service.<namespace>.svc.cluster.local:3473`. Use this when your client implements its own connection-level load balancing and DNS re-resolution.
-
-With this entry point the caller is responsible for:
-
-- Periodically re-resolving the Service hostname so that newly ready pods are picked up and draining pods are dropped.
-- Treating a request on a single endpoint that fails with a transport error as "pick another endpoint", not "retry this request".
 
 ### Configuration
 


### PR DESCRIPTION
**Background**

FB-2154: Documentation advertised the per-engine Service as a supported client entry point, although it provides no wake-up, retry, or routing guarantees.

**Summary**

- Remove the per-engine Service connection path from the Gateway overview.
- Document the Engine Service as an internal Gateway mechanism across the architecture, routing, scaling, and auto-stop pages. Clients must send queries through the Instance Gateway; bypassing it is unsupported and receives no Gateway guarantees.

**Test Plan**

Docs-only change; reviewed the updated pages to confirm that no text presents direct Engine Service access as a supported connection path and that cross-references still resolve.
