### PR TITLE
feat(api): report observed ready replicas on FireboltEngine status (FB-3263)

### DIFF
--- a/api/v1alpha1/fireboltengine_status_test.go
+++ b/api/v1alpha1/fireboltengine_status_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2026 Firebolt Analytics.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// A zero readyReplicas must reach the wire. Zero is an observation here —
+// stopped, or nothing serving yet — and a client has to be able to tell it
+// from the field being absent, which means an operator too old to report it.
+// `omitempty` would collapse those two into one, so this guards the tag.
+func TestReadyReplicasSerializesZero(t *testing.T) {
+	encoded, err := json.Marshal(FireboltEngineStatus{ReadyReplicas: 0})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"readyReplicas":0`) {
+		t.Errorf("zero readyReplicas was omitted from %s", encoded)
+	}
+}

--- a/api/v1alpha1/fireboltengine_types.go
+++ b/api/v1alpha1/fireboltengine_types.go
@@ -569,8 +569,14 @@ type FireboltEngineStatus struct {
 	// serving and steps to the new one at cutover, so a roll does not show up
 	// here as capacity briefly dropping away. Pods of a generation that is
 	// coming up or draining are not counted.
+	// Deliberately serialized even at zero, unlike most optional status
+	// fields: zero is a real observation here (stopped, or nothing serving
+	// yet) and must stay distinguishable from the field being absent, which
+	// means an operator too old to report it at all. With omitempty a client
+	// reading the field cannot tell those apart. currentGeneration and
+	// activeGeneration serialize zero for the same reason.
 	// +optional
-	ReadyReplicas int `json:"readyReplicas,omitempty"`
+	ReadyReplicas int `json:"readyReplicas"`
 
 	// Conditions represent the latest available observations of the engine's state.
 	// +optional

--- a/api/v1alpha1/fireboltengine_types.go
+++ b/api/v1alpha1/fireboltengine_types.go
@@ -559,6 +559,14 @@ type FireboltEngineStatus struct {
 	// +optional
 	ObservedEngineServingCertGen int `json:"observedEngineServingCertGen,omitempty"`
 
+	// ReadyReplicas is how many pods of the active generation are running and
+	// passing their readiness probe. It is observed, not desired: it counts
+	// what serves traffic right now, so it trails spec.replicas while a
+	// generation comes up and reads 0 for a stopped engine. Pods of a
+	// draining generation are not counted.
+	// +optional
+	ReadyReplicas int `json:"readyReplicas,omitempty"`
+
 	// Conditions represent the latest available observations of the engine's state.
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`

--- a/api/v1alpha1/fireboltengine_types.go
+++ b/api/v1alpha1/fireboltengine_types.go
@@ -559,11 +559,16 @@ type FireboltEngineStatus struct {
 	// +optional
 	ObservedEngineServingCertGen int `json:"observedEngineServingCertGen,omitempty"`
 
-	// ReadyReplicas is how many pods of the active generation are running and
+	// ReadyReplicas is how many pods of activeGeneration are running and
 	// passing their readiness probe. It is observed, not desired: it counts
 	// what serves traffic right now, so it trails spec.replicas while a
-	// generation comes up and reads 0 for a stopped engine. Pods of a
-	// draining generation are not counted.
+	// generation comes up and reads 0 for a stopped engine or one whose first
+	// generation has not cut over yet.
+	//
+	// During a blue-green rollout it stays with the generation that is still
+	// serving and steps to the new one at cutover, so a roll does not show up
+	// here as capacity briefly dropping away. Pods of a generation that is
+	// coming up or draining are not counted.
 	// +optional
 	ReadyReplicas int `json:"readyReplicas,omitempty"`
 

--- a/config/crd/bases/compute.firebolt.io_fireboltengines.yaml
+++ b/config/crd/bases/compute.firebolt.io_fireboltengines.yaml
@@ -9078,11 +9078,16 @@ spec:
                 type: string
               readyReplicas:
                 description: |-
-                  ReadyReplicas is how many pods of the active generation are running and
+                  ReadyReplicas is how many pods of activeGeneration are running and
                   passing their readiness probe. It is observed, not desired: it counts
                   what serves traffic right now, so it trails spec.replicas while a
-                  generation comes up and reads 0 for a stopped engine. Pods of a
-                  draining generation are not counted.
+                  generation comes up and reads 0 for a stopped engine or one whose first
+                  generation has not cut over yet.
+
+                  During a blue-green rollout it stays with the generation that is still
+                  serving and steps to the new one at cutover, so a roll does not show up
+                  here as capacity briefly dropping away. Pods of a generation that is
+                  coming up or draining are not counted.
                 type: integer
             required:
             - activeGeneration

--- a/config/crd/bases/compute.firebolt.io_fireboltengines.yaml
+++ b/config/crd/bases/compute.firebolt.io_fireboltengines.yaml
@@ -9088,6 +9088,12 @@ spec:
                   serving and steps to the new one at cutover, so a roll does not show up
                   here as capacity briefly dropping away. Pods of a generation that is
                   coming up or draining are not counted.
+                  Deliberately serialized even at zero, unlike most optional status
+                  fields: zero is a real observation here (stopped, or nothing serving
+                  yet) and must stay distinguishable from the field being absent, which
+                  means an operator too old to report it at all. With omitempty a client
+                  reading the field cannot tell those apart. currentGeneration and
+                  activeGeneration serialize zero for the same reason.
                 type: integer
             required:
             - activeGeneration

--- a/config/crd/bases/compute.firebolt.io_fireboltengines.yaml
+++ b/config/crd/bases/compute.firebolt.io_fireboltengines.yaml
@@ -9076,6 +9076,14 @@ spec:
               phase:
                 description: Phase is the current lifecycle phase of the engine.
                 type: string
+              readyReplicas:
+                description: |-
+                  ReadyReplicas is how many pods of the active generation are running and
+                  passing their readiness probe. It is observed, not desired: it counts
+                  what serves traffic right now, so it trails spec.replicas while a
+                  generation comes up and reads 0 for a stopped engine. Pods of a
+                  draining generation are not counted.
+                type: integer
             required:
             - activeGeneration
             - currentGeneration

--- a/docs/crd-reference/engine-crd-reference.mdx
+++ b/docs/crd-reference/engine-crd-reference.mdx
@@ -92,7 +92,7 @@ the full class-side allowlist.
 | `status.currentGeneration` | Latest blue-green generation index allocated for the desired state. Resource creation can follow on the next reconciliation. |
 | `status.activeGeneration` | Generation currently serving traffic. |
 | `status.drainingGeneration` | Generation being drained, if any. |
-| `status.readyReplicas` | Pods of the active generation that are running and passing their readiness probe. Observed, not desired: it trails `spec.replicas` while a generation comes up and reads `0` for a stopped Engine. Draining-generation pods are not counted. |
+| `status.readyReplicas` | Pods of the active generation that are running and passing their readiness probe. Observed, not desired: it trails `spec.replicas` while a generation comes up, and reads `0` for a stopped Engine or one whose first generation has not cut over yet. During a blue-green rollout it stays with the generation still serving and steps to the new one at cutover, so a roll does not appear here as capacity dropping away; pods of a generation coming up or draining are not counted. |
 | `status.lastReconciled` | Time of the most recent reconciliation. |
 | `status.lastActivityTime` | Most recent Engine activity used by auto-stop. |
 | `status.lastScaledAt` | Most recent auto-stop replica change. |

--- a/docs/crd-reference/engine-crd-reference.mdx
+++ b/docs/crd-reference/engine-crd-reference.mdx
@@ -92,6 +92,7 @@ the full class-side allowlist.
 | `status.currentGeneration` | Latest blue-green generation index allocated for the desired state. Resource creation can follow on the next reconciliation. |
 | `status.activeGeneration` | Generation currently serving traffic. |
 | `status.drainingGeneration` | Generation being drained, if any. |
+| `status.readyReplicas` | Pods of the active generation that are running and passing their readiness probe. Observed, not desired: it trails `spec.replicas` while a generation comes up and reads `0` for a stopped Engine. Draining-generation pods are not counted. |
 | `status.lastReconciled` | Time of the most recent reconciliation. |
 | `status.lastActivityTime` | Most recent Engine activity used by auto-stop. |
 | `status.lastScaledAt` | Most recent auto-stop replica change. |

--- a/helm/firebolt-operator-crds/json-schema/fireboltengine_v1alpha1.json
+++ b/helm/firebolt-operator-crds/json-schema/fireboltengine_v1alpha1.json
@@ -7586,7 +7586,7 @@
           "type": "string"
         },
         "readyReplicas": {
-          "description": "ReadyReplicas is how many pods of activeGeneration are running and\npassing their readiness probe. It is observed, not desired: it counts\nwhat serves traffic right now, so it trails spec.replicas while a\ngeneration comes up and reads 0 for a stopped engine or one whose first\ngeneration has not cut over yet.\n\nDuring a blue-green rollout it stays with the generation that is still\nserving and steps to the new one at cutover, so a roll does not show up\nhere as capacity briefly dropping away. Pods of a generation that is\ncoming up or draining are not counted.",
+          "description": "ReadyReplicas is how many pods of activeGeneration are running and\npassing their readiness probe. It is observed, not desired: it counts\nwhat serves traffic right now, so it trails spec.replicas while a\ngeneration comes up and reads 0 for a stopped engine or one whose first\ngeneration has not cut over yet.\n\nDuring a blue-green rollout it stays with the generation that is still\nserving and steps to the new one at cutover, so a roll does not show up\nhere as capacity briefly dropping away. Pods of a generation that is\ncoming up or draining are not counted.\nDeliberately serialized even at zero, unlike most optional status\nfields: zero is a real observation here (stopped, or nothing serving\nyet) and must stay distinguishable from the field being absent, which\nmeans an operator too old to report it at all. With omitempty a client\nreading the field cannot tell those apart. currentGeneration and\nactiveGeneration serialize zero for the same reason.",
           "type": "integer"
         }
       },

--- a/helm/firebolt-operator-crds/json-schema/fireboltengine_v1alpha1.json
+++ b/helm/firebolt-operator-crds/json-schema/fireboltengine_v1alpha1.json
@@ -7586,7 +7586,7 @@
           "type": "string"
         },
         "readyReplicas": {
-          "description": "ReadyReplicas is how many pods of the active generation are running and\npassing their readiness probe. It is observed, not desired: it counts\nwhat serves traffic right now, so it trails spec.replicas while a\ngeneration comes up and reads 0 for a stopped engine. Pods of a\ndraining generation are not counted.",
+          "description": "ReadyReplicas is how many pods of activeGeneration are running and\npassing their readiness probe. It is observed, not desired: it counts\nwhat serves traffic right now, so it trails spec.replicas while a\ngeneration comes up and reads 0 for a stopped engine or one whose first\ngeneration has not cut over yet.\n\nDuring a blue-green rollout it stays with the generation that is still\nserving and steps to the new one at cutover, so a roll does not show up\nhere as capacity briefly dropping away. Pods of a generation that is\ncoming up or draining are not counted.",
           "type": "integer"
         }
       },

--- a/helm/firebolt-operator-crds/json-schema/fireboltengine_v1alpha1.json
+++ b/helm/firebolt-operator-crds/json-schema/fireboltengine_v1alpha1.json
@@ -7584,6 +7584,10 @@
         "phase": {
           "description": "Phase is the current lifecycle phase of the engine.",
           "type": "string"
+        },
+        "readyReplicas": {
+          "description": "ReadyReplicas is how many pods of the active generation are running and\npassing their readiness probe. It is observed, not desired: it counts\nwhat serves traffic right now, so it trails spec.replicas while a\ngeneration comes up and reads 0 for a stopped engine. Pods of a\ndraining generation are not counted.",
+          "type": "integer"
         }
       },
       "required": [

--- a/helm/firebolt-operator-crds/templates/fireboltengines.yaml
+++ b/helm/firebolt-operator-crds/templates/fireboltengines.yaml
@@ -4402,6 +4402,12 @@ spec:
                   serving and steps to the new one at cutover, so a roll does not show up
                   here as capacity briefly dropping away. Pods of a generation that is
                   coming up or draining are not counted.
+                  Deliberately serialized even at zero, unlike most optional status
+                  fields: zero is a real observation here (stopped, or nothing serving
+                  yet) and must stay distinguishable from the field being absent, which
+                  means an operator too old to report it at all. With omitempty a client
+                  reading the field cannot tell those apart. currentGeneration and
+                  activeGeneration serialize zero for the same reason.
                 type: integer
             required:
             - activeGeneration

--- a/helm/firebolt-operator-crds/templates/fireboltengines.yaml
+++ b/helm/firebolt-operator-crds/templates/fireboltengines.yaml
@@ -4392,11 +4392,16 @@ spec:
                 type: string
               readyReplicas:
                 description: |-
-                  ReadyReplicas is how many pods of the active generation are running and
+                  ReadyReplicas is how many pods of activeGeneration are running and
                   passing their readiness probe. It is observed, not desired: it counts
                   what serves traffic right now, so it trails spec.replicas while a
-                  generation comes up and reads 0 for a stopped engine. Pods of a
-                  draining generation are not counted.
+                  generation comes up and reads 0 for a stopped engine or one whose first
+                  generation has not cut over yet.
+
+                  During a blue-green rollout it stays with the generation that is still
+                  serving and steps to the new one at cutover, so a roll does not show up
+                  here as capacity briefly dropping away. Pods of a generation that is
+                  coming up or draining are not counted.
                 type: integer
             required:
             - activeGeneration

--- a/helm/firebolt-operator-crds/templates/fireboltengines.yaml
+++ b/helm/firebolt-operator-crds/templates/fireboltengines.yaml
@@ -4390,6 +4390,14 @@ spec:
               phase:
                 description: Phase is the current lifecycle phase of the engine.
                 type: string
+              readyReplicas:
+                description: |-
+                  ReadyReplicas is how many pods of the active generation are running and
+                  passing their readiness probe. It is observed, not desired: it counts
+                  what serves traffic right now, so it trails spec.replicas while a
+                  generation comes up and reads 0 for a stopped engine. Pods of a
+                  draining generation are not counted.
+                type: integer
             required:
             - activeGeneration
             - currentGeneration

--- a/helm/firebolt-operator/crds/fireboltengines.yaml
+++ b/helm/firebolt-operator/crds/fireboltengines.yaml
@@ -4402,6 +4402,12 @@ spec:
                   serving and steps to the new one at cutover, so a roll does not show up
                   here as capacity briefly dropping away. Pods of a generation that is
                   coming up or draining are not counted.
+                  Deliberately serialized even at zero, unlike most optional status
+                  fields: zero is a real observation here (stopped, or nothing serving
+                  yet) and must stay distinguishable from the field being absent, which
+                  means an operator too old to report it at all. With omitempty a client
+                  reading the field cannot tell those apart. currentGeneration and
+                  activeGeneration serialize zero for the same reason.
                 type: integer
             required:
             - activeGeneration

--- a/helm/firebolt-operator/crds/fireboltengines.yaml
+++ b/helm/firebolt-operator/crds/fireboltengines.yaml
@@ -4392,11 +4392,16 @@ spec:
                 type: string
               readyReplicas:
                 description: |-
-                  ReadyReplicas is how many pods of the active generation are running and
+                  ReadyReplicas is how many pods of activeGeneration are running and
                   passing their readiness probe. It is observed, not desired: it counts
                   what serves traffic right now, so it trails spec.replicas while a
-                  generation comes up and reads 0 for a stopped engine. Pods of a
-                  draining generation are not counted.
+                  generation comes up and reads 0 for a stopped engine or one whose first
+                  generation has not cut over yet.
+
+                  During a blue-green rollout it stays with the generation that is still
+                  serving and steps to the new one at cutover, so a roll does not show up
+                  here as capacity briefly dropping away. Pods of a generation that is
+                  coming up or draining are not counted.
                 type: integer
             required:
             - activeGeneration

--- a/helm/firebolt-operator/crds/fireboltengines.yaml
+++ b/helm/firebolt-operator/crds/fireboltengines.yaml
@@ -4390,6 +4390,14 @@ spec:
               phase:
                 description: Phase is the current lifecycle phase of the engine.
                 type: string
+              readyReplicas:
+                description: |-
+                  ReadyReplicas is how many pods of the active generation are running and
+                  passing their readiness probe. It is observed, not desired: it counts
+                  what serves traffic right now, so it trails spec.replicas while a
+                  generation comes up and reads 0 for a stopped engine. Pods of a
+                  draining generation are not counted.
+                type: integer
             required:
             - activeGeneration
             - currentGeneration

--- a/internal/controller/engine_property_test.go
+++ b/internal/controller/engine_property_test.go
@@ -167,6 +167,13 @@ func (m *engineSim) buildState() EngineState {
 		ClusterService:     m.cache.clusterSvc,
 	}
 
+	if ag := m.status.ActiveGeneration; ag >= 0 && ag != gen {
+		// Mid-rollout getEngineState reads the serving generation separately;
+		// when it coincides with the current one assembleEngineState reuses
+		// that count instead of reading twice.
+		raw.ActiveSTS = m.cache.stses[ag]
+	}
+
 	if m.status.DrainingGeneration != nil {
 		dg := *m.status.DrainingGeneration
 		raw.DrainingSTS = m.cache.stses[dg]

--- a/internal/controller/engine_reconcile.go
+++ b/internal/controller/engine_reconcile.go
@@ -284,10 +284,14 @@ func computeEngineReconcile(
 
 	// Observed, so it is written on every path rather than per phase: the
 	// count belongs to the state this pass read, not to the transition the
-	// pass decided on. assembleEngineState leaves it zero when there is no
-	// active-generation StatefulSet, which is what makes a stopped engine
-	// report 0 instead of its last running value.
-	result.Status.ReadyReplicas = current.CurrentPodReady
+	// pass decided on. It tracks the ACTIVE generation, not the current one —
+	// during a rollout the new generation exists and is filling up while the
+	// old one still serves, and reporting the new one there would show a drop
+	// to zero and a climb back on every roll, for capacity that was never
+	// unavailable. assembleEngineState leaves it zero when nothing is serving,
+	// which is what makes a stopped engine report 0 rather than its last
+	// running value.
+	result.Status.ReadyReplicas = current.ActivePodReady
 
 	now := metav1.Now()
 	result.Status.LastReconciled = &now

--- a/internal/controller/engine_reconcile.go
+++ b/internal/controller/engine_reconcile.go
@@ -282,6 +282,13 @@ func computeEngineReconcile(
 		result.Requeue = true
 	}
 
+	// Observed, so it is written on every path rather than per phase: the
+	// count belongs to the state this pass read, not to the transition the
+	// pass decided on. assembleEngineState leaves it zero when there is no
+	// active-generation StatefulSet, which is what makes a stopped engine
+	// report 0 instead of its last running value.
+	result.Status.ReadyReplicas = current.CurrentPodReady
+
 	now := metav1.Now()
 	result.Status.LastReconciled = &now
 	return result

--- a/internal/controller/engine_reconcile_test.go
+++ b/internal/controller/engine_reconcile_test.go
@@ -3295,11 +3295,93 @@ func TestTLSHash_ReflectsCertPolicy(t *testing.T) {
 	}
 }
 
+// TestAssembleEngineState_ActivePodReadyTracksServingGeneration verifies which
+// generation's ready count reaches status.readyReplicas. Outside a rollout the
+// current-generation count is reused; mid-rollout the count belongs to the
+// generation still serving, never to the one filling up; and nothing serving
+// yet reads zero.
+func TestAssembleEngineState_ActivePodReadyTracksServingGeneration(t *testing.T) {
+	tests := []struct {
+		name       string
+		currentGen int
+		activeGen  int
+		raw        rawEngineResources
+		want       int
+	}{
+		{
+			name:       "steady state reuses the current generation's count",
+			currentGen: 1,
+			activeGen:  1,
+			raw: rawEngineResources{
+				CurrentSTS:      makeSTS(testEngineName, 1, 3),
+				CurrentPodReady: 3,
+			},
+			want: 3,
+		},
+		{
+			name:       "steady state with no StatefulSet reads zero",
+			currentGen: 1,
+			activeGen:  1,
+			raw:        rawEngineResources{CurrentPodReady: 3},
+			want:       0,
+		},
+		{
+			name:       "mid-rollout reports the serving generation, not the one coming up",
+			currentGen: 2,
+			activeGen:  1,
+			raw: rawEngineResources{
+				CurrentSTS:      makeSTS(testEngineName, 2, 3),
+				CurrentPodReady: 1,
+				ActiveSTS:       makeSTS(testEngineName, 1, 3),
+				ActivePodReady:  3,
+			},
+			want: 3,
+		},
+		{
+			name:       "mid-rollout with the serving StatefulSet already gone reads zero",
+			currentGen: 2,
+			activeGen:  1,
+			raw: rawEngineResources{
+				CurrentSTS:      makeSTS(testEngineName, 2, 3),
+				CurrentPodReady: 1,
+			},
+			want: 0,
+		},
+		{
+			name:       "first creation has no serving generation and reads zero",
+			currentGen: 0,
+			activeGen:  -1,
+			raw: rawEngineResources{
+				CurrentSTS:      makeSTS(testEngineName, 0, 3),
+				CurrentPodReady: 2,
+			},
+			want: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			status := &computev1alpha1.FireboltEngineStatus{
+				CurrentGeneration: tc.currentGen,
+				ActiveGeneration:  tc.activeGen,
+			}
+
+			state, err := assembleEngineState(status, tc.raw)
+			if err != nil {
+				t.Fatalf("assembleEngineState: %v", err)
+			}
+
+			if state.ActivePodReady != tc.want {
+				t.Errorf("expected ActivePodReady %d, got %d", tc.want, state.ActivePodReady)
+			}
+		})
+	}
+}
+
 // TestComputeEngineReconcile_ReadyReplicasIsObserved verifies that
-// status.readyReplicas carries the observed active-generation ready count on
+// status.readyReplicas carries the observed serving-generation ready count on
 // every path: the full count when all pods are ready, the partial count while
-// a generation is still coming up, and zero for an engine with no
-// active-generation StatefulSet.
+// a generation is still coming up, and zero when nothing is serving.
 func TestComputeEngineReconcile_ReadyReplicasIsObserved(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -3314,6 +3396,7 @@ func TestComputeEngineReconcile_ReadyReplicasIsObserved(t *testing.T) {
 				CurrentPodsReady:        true,
 				CurrentPodTotal:         3,
 				CurrentPodReady:         3,
+				ActivePodReady:          3,
 				ClusterService:          makeClusterSvc(testEngineName, 1),
 				ClusterServiceTargetGen: 1,
 			},
@@ -3327,13 +3410,14 @@ func TestComputeEngineReconcile_ReadyReplicasIsObserved(t *testing.T) {
 				CurrentPodsReady:        false,
 				CurrentPodTotal:         3,
 				CurrentPodReady:         2,
+				ActivePodReady:          2,
 				ClusterService:          makeClusterSvc(testEngineName, 1),
 				ClusterServiceTargetGen: 1,
 			},
 			want: 2,
 		},
 		{
-			name:    "no active-generation StatefulSet reports zero",
+			name:    "nothing serving reports zero",
 			current: EngineState{ClusterServiceTargetGen: -1},
 			want:    0,
 		},
@@ -3385,5 +3469,36 @@ func TestComputeEngineReconcile_ReadyReplicasZeroWhenStopped(t *testing.T) {
 
 	if result.Status.ReadyReplicas != 0 {
 		t.Errorf("expected readyReplicas 0 for a stopped engine, got %d", result.Status.ReadyReplicas)
+	}
+}
+
+// TestComputeEngineReconcile_ReadyReplicasHoldsThroughRollout verifies that a
+// roll does not read as capacity dropping away: while the new generation is
+// creating, the count stays with the generation still serving rather than
+// following the one filling up.
+func TestComputeEngineReconcile_ReadyReplicasHoldsThroughRollout(t *testing.T) {
+	spec := testSpec()
+	spec.Template = nil
+	status := &computev1alpha1.FireboltEngineStatus{
+		Phase:             computev1alpha1.PhaseCreating,
+		CurrentGeneration: 2,
+		ActiveGeneration:  1,
+		ReadyReplicas:     3,
+	}
+	current := EngineState{
+		CurrentSTS:              makeSTS(testEngineName, 2, 3),
+		CurrentHeadlessSvc:      &corev1.Service{},
+		CurrentConfigMap:        buildConfigMap(spec, testEngineName, testNamespace, 2, testInstanceInfo(), nil),
+		CurrentPodTotal:         1,
+		CurrentPodReady:         1,
+		ActivePodReady:          3,
+		ClusterService:          makeClusterSvc(testEngineName, 1),
+		ClusterServiceTargetGen: 1,
+	}
+
+	result := computeEngineReconcile(spec, status, current, testEngineName, testNamespace, 2, testInstanceInfo(), nil)
+
+	if result.Status.ReadyReplicas != 3 {
+		t.Errorf("expected readyReplicas 3 from the serving generation, got %d", result.Status.ReadyReplicas)
 	}
 }

--- a/internal/controller/engine_reconcile_test.go
+++ b/internal/controller/engine_reconcile_test.go
@@ -3294,3 +3294,96 @@ func TestTLSHash_ReflectsCertPolicy(t *testing.T) {
 		t.Error("tlsHash(nil) must be empty")
 	}
 }
+
+// TestComputeEngineReconcile_ReadyReplicasIsObserved verifies that
+// status.readyReplicas carries the observed active-generation ready count on
+// every path: the full count when all pods are ready, the partial count while
+// a generation is still coming up, and zero for an engine with no
+// active-generation StatefulSet.
+func TestComputeEngineReconcile_ReadyReplicasIsObserved(t *testing.T) {
+	tests := []struct {
+		name    string
+		current EngineState
+		want    int
+	}{
+		{
+			name: "all pods ready",
+			current: EngineState{
+				CurrentSTS:              makeSTS(testEngineName, 1, 3),
+				CurrentHeadlessSvc:      &corev1.Service{},
+				CurrentPodsReady:        true,
+				CurrentPodTotal:         3,
+				CurrentPodReady:         3,
+				ClusterService:          makeClusterSvc(testEngineName, 1),
+				ClusterServiceTargetGen: 1,
+			},
+			want: 3,
+		},
+		{
+			name: "partially ready reports the subset, not the desired count",
+			current: EngineState{
+				CurrentSTS:              makeSTS(testEngineName, 1, 3),
+				CurrentHeadlessSvc:      &corev1.Service{},
+				CurrentPodsReady:        false,
+				CurrentPodTotal:         3,
+				CurrentPodReady:         2,
+				ClusterService:          makeClusterSvc(testEngineName, 1),
+				ClusterServiceTargetGen: 1,
+			},
+			want: 2,
+		},
+		{
+			name:    "no active-generation StatefulSet reports zero",
+			current: EngineState{ClusterServiceTargetGen: -1},
+			want:    0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := testSpec()
+			spec.Template = nil
+			status := &computev1alpha1.FireboltEngineStatus{
+				Phase:             computev1alpha1.PhaseStable,
+				CurrentGeneration: 1,
+				ActiveGeneration:  1,
+			}
+			if tc.current.CurrentConfigMap == nil && tc.current.CurrentSTS != nil {
+				tc.current.CurrentConfigMap = buildConfigMap(spec, testEngineName, testNamespace, 1, testInstanceInfo(), nil)
+			}
+
+			result := computeEngineReconcile(spec, status, tc.current, testEngineName, testNamespace, 1, testInstanceInfo(), nil)
+
+			if result.Status.ReadyReplicas != tc.want {
+				t.Errorf("expected readyReplicas %d, got %d", tc.want, result.Status.ReadyReplicas)
+			}
+		})
+	}
+}
+
+// TestComputeEngineReconcile_ReadyReplicasZeroWhenStopped verifies that a
+// parked engine reports zero rather than the count it last served with.
+func TestComputeEngineReconcile_ReadyReplicasZeroWhenStopped(t *testing.T) {
+	spec := testSpec()
+	spec.Replicas = 0
+	status := &computev1alpha1.FireboltEngineStatus{
+		Phase:             computev1alpha1.PhaseStable,
+		CurrentGeneration: 1,
+		ActiveGeneration:  1,
+		ReadyReplicas:     3,
+	}
+	current := EngineState{
+		CurrentSTS:              makeSTS(testEngineName, 1, 0),
+		CurrentHeadlessSvc:      &corev1.Service{},
+		CurrentConfigMap:        buildConfigMap(spec, testEngineName, testNamespace, 1, testInstanceInfo(), nil),
+		CurrentPodsReady:        true,
+		ClusterService:          makeClusterSvc(testEngineName, 1),
+		ClusterServiceTargetGen: 1,
+	}
+
+	result := computeEngineReconcile(spec, status, current, testEngineName, testNamespace, 3, testInstanceInfo(), nil)
+
+	if result.Status.ReadyReplicas != 0 {
+		t.Errorf("expected readyReplicas 0 for a stopped engine, got %d", result.Status.ReadyReplicas)
+	}
+}

--- a/internal/controller/engine_state.go
+++ b/internal/controller/engine_state.go
@@ -77,6 +77,14 @@ type rawEngineResources struct {
 	CurrentPodTotal    int
 	CurrentPodReady    int
 
+	// ActiveSTS and ActivePodReady describe status.ActiveGeneration, and are
+	// fetched only when it differs from the current generation — mid-rollout,
+	// where the outgoing generation is still the one serving. Otherwise they
+	// are left zero and assembleEngineState reuses the current-generation
+	// count, so the steady state costs no extra reads.
+	ActiveSTS      *appsv1.StatefulSet
+	ActivePodReady int
+
 	DrainingSTS         *appsv1.StatefulSet
 	DrainingConfigMap   *corev1.ConfigMap
 	DrainingHeadlessSvc *corev1.Service
@@ -114,6 +122,19 @@ func assembleEngineState(
 			state.CurrentPodTotal = raw.CurrentPodTotal
 			state.CurrentPodReady = raw.CurrentPodReady
 		}
+	}
+
+	// The serving generation's ready count. Same generation as current outside a
+	// rollout, so the current count is reused rather than read twice; mid-rollout
+	// it is the outgoing generation, fetched separately by the caller. A negative
+	// ActiveGeneration means nothing serves yet (first creation), which leaves the
+	// count at zero.
+	switch activeGen := status.ActiveGeneration; {
+	case activeGen < 0:
+	case activeGen == currentGen:
+		state.ActivePodReady = state.CurrentPodReady
+	case raw.ActiveSTS != nil:
+		state.ActivePodReady = raw.ActivePodReady
 	}
 
 	if drainingGen >= 0 && drainingGen != currentGen {
@@ -176,6 +197,28 @@ func (r *FireboltEngineReconciler) getEngineState(ctx context.Context, engine *c
 				r.checkPodsReady(ctx, engine, currentGen, int(engine.Spec.Replicas))
 			if err != nil {
 				return EngineState{}, fmt.Errorf("checkPodsReady (gen %d): %w", currentGen, err)
+			}
+		}
+	}
+
+	// Mid-rollout the generation serving traffic is not the current one, and its
+	// ready count is what status.readyReplicas reports. Only read it when the two
+	// actually differ: in the steady state assembleEngineState reuses the count
+	// above, so this costs nothing outside a transition. expectedReplicas comes
+	// from this generation's own StatefulSet rather than the spec, which the new
+	// generation may already have changed; only the ready count is consumed here.
+	if activeGen := status.ActiveGeneration; activeGen >= 0 && activeGen != currentGen {
+		if raw.ActiveSTS, err = r.getStatefulSet(ctx, engineName, ns, activeGen); err != nil {
+			return EngineState{}, err
+		}
+		if raw.ActiveSTS != nil {
+			expected := 0
+			if raw.ActiveSTS.Spec.Replicas != nil {
+				expected = int(*raw.ActiveSTS.Spec.Replicas)
+			}
+			if _, _, raw.ActivePodReady, err =
+				r.checkPodsReady(ctx, engine, activeGen, expected); err != nil {
+				return EngineState{}, fmt.Errorf("checkPodsReady (active gen %d): %w", activeGen, err)
 			}
 		}
 	}

--- a/internal/controller/engine_types.go
+++ b/internal/controller/engine_types.go
@@ -35,13 +35,23 @@ type EngineState struct {
 	CurrentHeadlessSvc *corev1.Service
 	CurrentPodsReady   bool
 	// CurrentPodTotal is the number of pods that currently exist for the
-	// active generation (including non-running and non-ready ones). It can
+	// current generation (including non-running and non-ready ones). It can
 	// be less than spec.replicas if the StatefulSet has not finished
 	// creating pods yet.
 	CurrentPodTotal int
 	// CurrentPodReady is the subset of CurrentPodTotal that is in
 	// PodRunning phase with PodReady=True. Always <= CurrentPodTotal.
 	CurrentPodReady int
+
+	// ActivePodReady is the ready-pod count of status.ActiveGeneration — the
+	// generation the cluster Service selects, hence the one serving traffic.
+	// It equals CurrentPodReady outside a rollout, when the current and active
+	// generations are the same. While a new generation comes up the two differ,
+	// and this field stays with the outgoing generation until the cutover, so it
+	// never reports capacity that is not reachable yet. Zero when no generation
+	// is active (first creation) or when the active generation's StatefulSet is
+	// absent.
+	ActivePodReady int
 
 	DrainingSTS         *appsv1.StatefulSet
 	DrainingConfigMap   *corev1.ConfigMap


### PR DESCRIPTION
**Background**

FB-3263: `FireboltEngine` exposes desired replicas but not the number of pods currently serving traffic.

**Summary**

- Add `status.readyReplicas` to the FireboltEngine API, generated CRDs, Helm schemas, and CRD reference.
- Populate the field from the ready-pod count of `activeGeneration`, the generation selected by the cluster Service. During a blue-green rollout, the count remains with the serving generation until cutover instead of following the generation still starting.
- Report partial readiness while a generation comes up and `0` when no generation serves traffic. Reuse the current-generation count outside rollouts; only fetch the active generation separately during a transition.

**Test Plan**

- Added controller unit coverage for steady state, partial readiness, blue-green rollouts, a removed serving StatefulSet, initial creation, and stopped Engines.
- Existing controller and API suites, build, vet, and lint pass.


Model-scope-ok: observational status field only. `result.Status.ReadyReplicas` is assigned unconditionally after every phase decision in `computeEngineReconcile`, adds no phase, gate or transition, and is read by nothing — so `FireboltEngine.tla`'s state space is unchanged. The generation the count is taken from is read in `getEngineState`, which the spec does not model either.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a CRD status field and extra pod-readiness reads during blue-green rollouts, but the value is observational only and does not gate phases or traffic cutover.
> 
> **Overview**
> Exposes **`status.readyReplicas`** on `FireboltEngine`: how many pods of `activeGeneration` are running and ready. It is observed capacity, not desired `spec.replicas`.
> 
> The count stays with the generation still serving during a blue-green rollout and only moves at cutover, so a roll does not look like capacity dropping to zero. It reports partial readiness while a generation comes up, and **`0`** when nothing is serving (stopped, first creation, or missing serving StatefulSet). Zero is serialized without `omitempty` so clients can tell a real zero from an older operator that never reported the field.
> 
> The controller reuses the current-generation ready count in steady state and only fetches the active generation separately mid-rollout. The field is written on every reconcile path after phase logic; it does not change transitions. CRDs, Helm schemas, and the CRD reference are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36a2ef4081c6c2384fbac7a3bbc125623af8f4d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->