### PR TITLE
feat(controller): let engines use their pod Google identity for gs:// (FB-2939)

### DIFF
--- a/docs/engine/object-storage/google-cloud-storage.mdx
+++ b/docs/engine/object-storage/google-cloud-storage.mdx
@@ -150,9 +150,21 @@ An intermediary service account gives external access a stable identity instead.
 The engine selects the external credential path based on what you configure:
 
 - **Intermediary service account set.** The engine impersonates the intermediary service account for external access. The service account is the stable identity you grant access to external data.
-- **Intermediary service account not set.** The engine uses its own pod identity for external access.
+- **Intermediary service account not set.** The engine uses its own pod identity for external access, provided that `storage.gcp.allow_engine_identity` permits it. The Firebolt Operator sets it for every engine it deploys, because you run the engine and its pod identity is your own; the engine itself refuses that identity until a deployment permits it, because it cannot tell whose identity it runs as. Set `customEngineConfig.storage.gcp.allow_engine_identity: false` to keep external access off the pod identity: a credential-less `gs://` read is then sent unauthenticated and reaches publicly readable objects only, and a write fails with an error that asks for credentials. When an intermediary service account is set, that account is the principal, so the setting has no effect.
+- **The query supplies credentials.** A `gs://` location that carries `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (a Google Cloud Storage HMAC key) authenticates with that key through the S3-compatible XML API, bypassing both the pod identity and the intermediary service account.
+- **No Google identity at all.** Nothing provides Application Default Credentials to the engine pods: they run on a cluster outside Google Cloud, or on GKE without Workload Identity and without `GOOGLE_APPLICATION_CREDENTIALS`. A credential-less `gs://` read is then sent unauthenticated and reaches publicly readable objects only. Writing needs an identity and fails.
 
 Access to the managed `storage` bucket always uses the engine pod's own identity. The intermediary service account applies only to external locations.
+
+### Where Application Default Credentials come from
+
+The pod identity is whatever Application Default Credentials resolve to inside the engine container. Google's libraries look for them in a fixed order, and the first match wins:
+
+1. `GOOGLE_APPLICATION_CREDENTIALS`, if it is set. The file it names is used as given, whether that is a mounted service account key or a credential configuration file for Workload Identity Federation.
+2. `$HOME/.config/gcloud/application_default_credentials.json`, if that file exists. This is where `gcloud auth application-default login` writes, so it is normally present only on a workstation.
+3. The instance metadata server, which is what Workload Identity Federation for GKE provides.
+
+Step 2 takes precedence over step 3, so an engine whose `HOME` holds a `gcloud` login authenticates as that person instead of as the pod identity. To pin the source, set `GOOGLE_APPLICATION_CREDENTIALS` on the engine container, or set `HOME` to a directory that only the engine writes to. The engine logs the source it resolved once per process, as `Using Google Cloud identity from <source>`.
 
 ### Configure the intermediary service account
 
@@ -178,4 +190,4 @@ spec:
         intermediary_service_account_id: projects/my-project/serviceAccounts/firebolt-intermediary@my-project.iam.gserviceaccount.com
 ```
 
-The `storage.gcp` block is valid only when `type` is `gcs`.
+The `storage.gcp` connection settings apply to managed tables when `managed_table_storage` is `gcs`. `allow_engine_identity` is the exception: it governs external `gs://` locations, so it applies whatever backs managed tables, and the Firebolt Operator renders it for every engine.

--- a/internal/controller/engine_reconcile.go
+++ b/internal/controller/engine_reconcile.go
@@ -794,6 +794,21 @@ func buildConfigMap(spec *computev1alpha1.FireboltEngineSpec, engineName, namesp
 		"logging": map[string]interface{}{
 			"format": "json",
 		},
+		// A credential-less external gs:// location authenticates as the engine
+		// pod's own Google identity. The engine refuses that unless a deployment
+		// permits it, because it cannot tell whose identity it runs as. An engine
+		// this operator deploys runs under a ServiceAccount its own operator
+		// created, so the identity is theirs to use, and they should not have to
+		// ask for it. Set only here, so a user's
+		// customEngineConfig.storage.gcp.allow_engine_identity: false still wins in
+		// the merge below. Emitted whatever backs managed tables: the key governs
+		// external locations only, and the engine puts no `gcp` block behind
+		// managed_table_storage.
+		"storage": map[string]interface{}{
+			"gcp": map[string]interface{}{
+				"allow_engine_identity": true,
+			},
+		},
 	}
 	if instanceInfo.TLS != nil {
 		coreConfig["endpoints"] = renderEndpointsConfig()

--- a/internal/controller/engine_reconcile_test.go
+++ b/internal/controller/engine_reconcile_test.go
@@ -2978,6 +2978,43 @@ func TestBuildConfigMap_NoCustomConfig_DefaultsApplied(t *testing.T) {
 	}
 }
 
+// TestBuildConfigMap_AllowsGcpEngineIdentity pins the one storage key the
+// operator renders on its users' behalf. The engine refuses a credential-less
+// external gs:// request unless a deployment permits it, because it cannot tell
+// whose Google identity it runs as. An engine this operator deploys runs under a
+// ServiceAccount its own operator created, so the identity is theirs, and they
+// should not have to name it to use their own buckets. Rendered for every engine,
+// whatever backs managed tables, because the key governs external locations only.
+func TestBuildConfigMap_AllowsGcpEngineIdentity(t *testing.T) {
+	root := renderConfig(t, "")
+	gcp := nestedMap(t, nestedMap(t, root, "storage"), "gcp")
+	if gcp["allow_engine_identity"] != true {
+		t.Errorf("storage.gcp.allow_engine_identity = %v, want true", gcp["allow_engine_identity"])
+	}
+}
+
+// TestBuildConfigMap_UserRefusesGcpEngineIdentity is the other half: the value
+// above is a default the user can take back, which is what the self-managed docs
+// promise. It must survive the merge as `false`, not be restored to the
+// operator's `true`, and it must not take the sibling storage keys with it.
+func TestBuildConfigMap_UserRefusesGcpEngineIdentity(t *testing.T) {
+	custom := `{"storage": {"managed_table_storage": "gcs", "gcp": {"allow_engine_identity": false, ` +
+		`"intermediary_service_account_id": "projects/p/serviceAccounts/i@p.iam"}}}`
+	root := renderConfig(t, custom)
+	storage := nestedMap(t, root, "storage")
+	if storage["managed_table_storage"] != "gcs" {
+		t.Errorf("storage.managed_table_storage = %v, want gcs", storage["managed_table_storage"])
+	}
+	gcp := nestedMap(t, storage, "gcp")
+	if gcp["allow_engine_identity"] != false {
+		t.Errorf("storage.gcp.allow_engine_identity = %v, want false", gcp["allow_engine_identity"])
+	}
+	if gcp["intermediary_service_account_id"] != "projects/p/serviceAccounts/i@p.iam" {
+		t.Errorf("storage.gcp.intermediary_service_account_id = %v, want it preserved",
+			gcp["intermediary_service_account_id"])
+	}
+}
+
 func TestBuildConfigMap_NestedSectionOverridesUserDefaults(t *testing.T) {
 	custom := `{"logging": {"format": "text", "level": "debug"}}`
 	root := renderConfig(t, custom)

--- a/internal/controller/schema_conformance_test.go
+++ b/internal/controller/schema_conformance_test.go
@@ -28,7 +28,11 @@ import (
 
 // testdata/packdb-application-config.schema.json is a point-in-time copy of
 // packdb's src/Core/Application/application-config.schema.json, captured at
-// packdb commit 2127bc79a9dc3238c0a1c04edcc830eca06da596 (2026-07-01). This
+// packdb commit 2127bc79a9dc3238c0a1c04edcc830eca06da596 (2026-07-01), plus
+// storage.gcp.allow_engine_identity, a key buildConfigMap renders that the
+// captured copy predates. The copy is stale in other respects too, so keys are
+// added to it one at a time rather than by recapture, which keeps a diff here
+// scoped to the key it is about. This
 // file is the auth/TLS work's most exhaustive check on rendered auth config: it is
 // additionalProperties:false at every level, so validating buildConfigMap's
 // full output against it catches any unknown/misplaced key — the class of

--- a/internal/controller/testdata/packdb-application-config.schema.json
+++ b/internal/controller/testdata/packdb-application-config.schema.json
@@ -413,7 +413,7 @@
           "properties": {
             "admin": {
               "additionalProperties": false,
-              "description": "The Instance admin — required when auth is enabled.",
+              "description": "The Instance admin \u2014 required when auth is enabled.",
               "properties": {
                 "name": {
                   "default": "firebolt",
@@ -814,6 +814,11 @@
         "gcp": {
           "additionalProperties": false,
           "properties": {
+            "allow_engine_identity": {
+              "default": false,
+              "description": "Permit an external `gs://` request that carries no `CREDENTIALS` to authenticate as the engine's own Google identity. When off, such a request is sent unauthenticated: a read reaches publicly readable objects only and a write is refused. Ignored where `intermediary_service_account_id` is set, and never applies to managed-table storage.",
+              "type": "boolean"
+            },
             "intermediary_service_account_id": {
               "type": "string"
             }


### PR DESCRIPTION
**Background**

FB-2939: a credential-less external `gs://` location authenticates as the engine
pod's own Google identity. The engine refuses to do that unless a deployment
permits it through `storage.gcp.allow_engine_identity`, because the engine cannot
tell whose identity it runs as: on a shared service that identity belongs to the
service and not to the caller of the query, so the engine's own default is off.

The engine-side change is firebolt-analytics/packdb#24760.

**Summary**

An engine the Firebolt Operator deploys runs under a ServiceAccount its own
operator created, so the identity is theirs, and they should not have to name a
setting to reach their own buckets. This is the layer that knows a deployment is
self-managed, so this is where the answer belongs.

- `buildConfigMap` renders `storage.gcp.allow_engine_identity: true` in the
  canonical document. The `customEngineConfig` merge runs on top of it, so
  `customEngineConfig.storage.gcp.allow_engine_identity: false` still takes it
  back. `storage` is not an operator-owned path, so nothing strips it.
- Rendered for every engine, whatever backs managed tables. The key governs
  external locations only, and the engine puts no `gcp` block behind
  `managed_table_storage` (`StorageConfig::Validate` states that the three cloud
  blocks may coexist), so there is nothing to gate it on.
- The vendored packdb schema gains the key. It is `additionalProperties: false`
  at every level and would otherwise reject the rendered document. Topped up
  rather than recaptured, so the diff stays scoped to the key under review.
- The GCS page says who signs an external request in each case, where the pod's
  Application Default Credentials come from and in what order they are tried,
  and that the managed bucket is rejected as an external location.

**Draft until the engine image carries the key.** An engine whose config parser
predates packdb#24760 rejects an unknown configuration entry outright:
`ChangeParser` reports "Configuration entry does not exist." and `Load()` throws,
which aborts startup. So this must not merge before `appVersion` pins an engine
image that includes the packdb change. Today it pins `v0.8.2`.

**Test Plan**

- `TestBuildConfigMap_AllowsGcpEngineIdentity` pins the rendered default;
  `TestBuildConfigMap_UserRefusesGcpEngineIdentity` pins that a user's `false`
  survives the merge and does not take the sibling `storage` keys with it.
- `TestBuildConfigMap_ConformsToPackdbSchema` covers the rendered document
  against the vendored schema, which is what the schema top-up is for.
- Not run locally: no Go toolchain on the authoring machine, so `go test` and
  `go vet` have not been executed. CI is the first real check on this diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default Google identity used for external gs:// access on every engine. Must ship only with an engine image that already understands `storage.gcp.allow_engine_identity`, or startup will fail on unknown config.
> 
> **Overview**
> Operator-deployed engines now get `storage.gcp.allow_engine_identity: true` in the rendered config so credential-less external `gs://` reads can use the pod’s Google identity. Users can still set `customEngineConfig.storage.gcp.allow_engine_identity: false`; that merge wins and other `storage` keys are left intact.
> 
> The flag is emitted for every engine (not only GCS-backed managed tables) because it applies only to external locations. The vendored packdb schema is topped up so closed-schema validation still accepts the rendered document.
> 
> GCS docs now spell out the credential chain (intermediary SA, pod identity, HMAC keys, no ADC) and where Application Default Credentials come from. **Do not merge until `appVersion` pins an engine image that includes packdb’s `allow_engine_identity` parser**—older engines reject the unknown key and fail to start.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa67da1b19c2df0a0cce80e1e4fd65440b1bbc45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->