### PR TITLE
fix(gateway): resolve engine authorities without DNS search-domain expansion (FB-3287)

### DIFF
--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -36,7 +36,7 @@ An Engine may also reference one EngineClass in the same namespace through `spec
 
 Clients connect to the Instance Gateway and select an Engine with the `X-Firebolt-Engine` header. The Gateway forwards traffic only to ready pods in the Engine's active generation.
 
-Internally, each Engine exposes a Service that the Gateway resolves at request time. The Firebolt Operator switches that Service between generations during blue-green rollouts. It is an internal mechanism, not a client entry point: traffic that bypasses the Gateway is unsupported and loses Gateway features, including waking an auto-stopped Engine.
+Internally, each Engine exposes a Service that the Gateway resolves at request time. The Gateway resolves that Service by its fully qualified name and never expands the pod's DNS search domains: the name is already complete, and some environments inject infrastructure search domains whose expansions a DNS-filtering CNI can reject in a way that Envoy's c-ares resolver treats as fatal for the whole lookup. Exact-name resolution applies to every per-Engine sub-cluster the dynamic forward proxy synthesizes. The Firebolt Operator switches the Service between generations during blue-green rollouts. It is an internal mechanism, not a client entry point: traffic that bypasses the Gateway is unsupported and loses Gateway features, including waking an auto-stopped Engine.
 
 See [Gateway overview](./instance/gateway/overview) for connection examples and [Gateway query routing](./instance/gateway/gateway-query-routing) for routing behavior.
 

--- a/docs/instance/gateway/gateway-query-routing.mdx
+++ b/docs/instance/gateway/gateway-query-routing.mdx
@@ -31,6 +31,8 @@ Client -> Gateway Service -> Envoy -> Engine Service -> ready Engine pod
 
 The Engine Service is headless and returns the ready pod IPs for the active generation. The Gateway performs active readiness checks and opens a new upstream connection for each request.
 
+The Gateway resolves the Engine Service by its fully qualified name, `<engine>-service.<namespace>.svc.cluster.local`, and does not expand the pod's DNS search domains. If you enforce DNS-level network policies, allow queries for that name; the Gateway sends no other lookups for Engine routing.
+
 Creating, scaling, or rolling an Engine does not restart the Gateway. Engine destinations are resolved dynamically.
 
 ## Retry behavior

--- a/internal/controller/instance_gateway.go
+++ b/internal/controller/instance_gateway.go
@@ -1158,6 +1158,32 @@ func buildEnvoyConfigYAML(instance *computev1alpha1.FireboltInstance, wakeEnable
           unhealthy_threshold: 1
           http_health_check:
             path: /health/ready
+      # Resolve the authority exactly as written, never through the pod's
+      # resolv.conf search domains. The Lua filter always rewrites
+      # :authority to a fully qualified in-cluster Service name, but that
+      # name's dot count sits below the kubelet ndots default (5), so
+      # without this option c-ares tries every search-domain expansion of
+      # the name before the name itself. Those expansions can never
+      # resolve, and they are not harmless: nodes commonly inject
+      # infrastructure search domains (a cloud VPC's internal zone, for
+      # example) into pod resolv.conf, and when a DNS-filtering CNI
+      # answers such an expansion with REFUSED, c-ares treats it as a
+      # nameserver failure and aborts the whole lookup without ever
+      # asking for the canonical name — glibc and Go resolvers continue
+      # past a refused candidate; c-ares does not. The engine lookup then
+      # fails on every attempt and the gateway answers 503 for queries
+      # even though the absolute name resolves fine. Skipping the search
+      # walk removes that failure class and the wasted queries with it;
+      # it can remove no working path, because the only candidate that
+      # ever resolves is the absolute name. Like transport_socket above,
+      # this is a plain Cluster field that sub_clusters_config copies
+      # verbatim into every synthesized per-authority sub-cluster.
+      typed_dns_resolver_config:
+        name: envoy.network.dns_resolver.cares
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig
+          dns_resolver_options:
+            no_default_search_domain: true
       cluster_type:
         name: envoy.clusters.dynamic_forward_proxy
         typed_config:

--- a/internal/controller/instance_gateway_test.go
+++ b/internal/controller/instance_gateway_test.go
@@ -766,6 +766,54 @@ func TestBuildEnvoyConfigYAMLDFPSubClusterMode(t *testing.T) {
 	}
 }
 
+// TestBuildEnvoyConfigYAMLDFPNoSearchDomains guards that the dynamic
+// forward proxy cluster resolves authorities exactly as written instead
+// of walking the pod's resolv.conf search domains. The Lua filter always
+// rewrites :authority to a fully qualified Service name whose dot count
+// is below the kubelet ndots default, so without this option c-ares
+// tries every search-domain expansion first. None of those expansions
+// can resolve, and on nodes that inject infrastructure search domains a
+// DNS-filtering CNI may answer an expansion with REFUSED — which c-ares
+// treats as a nameserver failure, aborting the lookup before the
+// canonical name is ever asked and turning every gateway query into a
+// 503. The resolver config is a plain Cluster field, so
+// sub_clusters_config copies it into every synthesized per-authority
+// sub-cluster the same way it copies transport_socket.
+func TestBuildEnvoyConfigYAMLDFPNoSearchDomains(t *testing.T) {
+	got := buildEnvoyConfigYAML(&computev1alpha1.FireboltInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "inst", Namespace: "ns-1"},
+	}, false)
+
+	var parsed map[string]any
+	if err := yaml.Unmarshal([]byte(got), &parsed); err != nil {
+		t.Fatalf("emitted envoy config is not valid YAML: %v", err)
+	}
+
+	cluster := parsed["static_resources"].(map[string]any)["clusters"].([]any)[0].(map[string]any)
+	if name, _ := cluster["name"].(string); name != "dynamic_forward_proxy" {
+		t.Fatalf("clusters[0] = %q; expected the dynamic_forward_proxy cluster", name)
+	}
+
+	resolver, ok := cluster["typed_dns_resolver_config"].(map[string]any)
+	if !ok {
+		t.Fatalf("dynamic_forward_proxy cluster missing typed_dns_resolver_config; got cluster keys = %v", keysOf(cluster))
+	}
+	if name, _ := resolver["name"].(string); name != "envoy.network.dns_resolver.cares" {
+		t.Errorf("typed_dns_resolver_config.name = %q; expected the c-ares resolver", name)
+	}
+	typed, ok := resolver["typed_config"].(map[string]any)
+	if !ok {
+		t.Fatalf("typed_dns_resolver_config missing typed_config; got keys = %v", keysOf(resolver))
+	}
+	opts, ok := typed["dns_resolver_options"].(map[string]any)
+	if !ok {
+		t.Fatalf("resolver typed_config missing dns_resolver_options; got keys = %v", keysOf(typed))
+	}
+	if v, _ := opts["no_default_search_domain"].(bool); !v {
+		t.Error("dns_resolver_options.no_default_search_domain is not true; the gateway would walk resolv.conf search domains and a REFUSED expansion aborts the whole c-ares lookup")
+	}
+}
+
 // TestBuildEnvoyConfigYAMLRetryPolicy guards the retry contract:
 //   - We retry on connect-failure / refused-stream / reset (transport-level
 //     failures where the engine could not have observed the request).


### PR DESCRIPTION
## Problem

On clusters whose nodes inject infrastructure search domains into pod `resolv.conf` (for example a cloud VPC's internal zone on EKS), every query through the Instance Gateway returns `503 no healthy upstream`, while direct requests to the same Engine pod succeed.

The Gateway's Lua filter rewrites `:authority` to the Engine's fully qualified Service name, `<engine>-service.<namespace>.svc.cluster.local`. That name has 4 dots and the kubelet ndots default is 5, so Envoy's c-ares resolver search-expands it through every `resolv.conf` search domain before trying it as written. The `cluster.local` expansions get NXDOMAIN and the walk continues — but when a DNS-filtering CNI (for example an L7 DNS network policy) answers an infrastructure-domain expansion with REFUSED, c-ares treats that as a nameserver failure and aborts the whole lookup **without ever asking for the canonical name**. glibc and Go resolvers continue past a refused candidate, which is why `getent` in the same pod resolves fine and only the Gateway breaks.

## Change

Set `typed_dns_resolver_config` (c-ares with `dns_resolver_options.no_default_search_domain: true`) on the `dynamic_forward_proxy` cluster, so the Gateway resolves the authority exactly as written.

- **Placement**: like `transport_socket` directly above it, this is a plain Cluster field that `sub_clusters_config` copies verbatim into every synthesized per-authority STRICT_DNS sub-cluster (Envoy's `createClusterWithConfig` copies the parent config and overrides only name/cluster_type/lb_policy/load_assignment). The DFP cluster is the only DNS consumer in the bootstrap — the `wake_agent` and `admin_stats` clusters are STATIC.
- **Portability**: the only DNS candidate that ever resolves is the absolute name — search-expanding an already-fully-qualified `cluster.local` name yields names that exist in no environment. Disabling expansion therefore removes no working path on any provider or CNI; it only removes doomed queries and this failure class. No new Envoy version floor: `typed_dns_resolver_config` predates the `sub_clusters_config` mode the config already requires, and the operator pins `envoyproxy/envoy:v1.37.2`.
- Docs updated: `docs/architecture.mdx` (Query traffic) and `docs/instance/gateway/gateway-query-routing.mdx` (Traffic path) now state the exact-name resolution contract, including the one lookup DNS-level network policies need to allow.

## Verification

- **Hermetic reproduction with the real `envoyproxy/envoy:v1.37.2` binary** and the exact rendered configs (before/after), against a scripted DNS server (REFUSED for any search-expanded name, A record for the canonical name) and a pod-like `resolv.conf` (`search corp.internal`, `ndots:5`):
  - *Before*: the DNS server observed **only** `eng1-service.ns-1.svc.cluster.local.corp.internal` (12 A + 12 AAAA tries, all REFUSED); the canonical name was never queried; every client attempt returned `503 no healthy upstream`.
  - *After*: the DNS server observed **exactly one name** — the canonical `eng1-service.ns-1.svc.cluster.local` — zero expanded queries, and the first client attempt returned HTTP 200 through the synthesized sub-cluster (which also demonstrates the parent-field inheritance the placement relies on).
- The full rendered bootstrap passes `envoy --mode validate` on v1.37.2 (`configuration OK`).
- New unit test `TestBuildEnvoyConfigYAMLDFPNoSearchDomains` pins the resolver config on the DFP cluster and fails with the config change reverted (verified).
- `make build`, full `make test`, and `make lint` (0 issues) pass.
- Not covered by a committed CI lane on purpose: kind nodes carry no infrastructure search domain, so neither envtest nor the kind e2e can exercise the failure; the unit test pins the config contract permanently and the reproduction above is the behavioral proof.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Envoy DNS for all Gateway→Engine routing and will roll gateway pods via config hash. A bad resolver option would 503 every query, but the change only disables doomed search expansions of already-FQDN names.
> 
> **Overview**
> Stops the Instance Gateway from search-expanding Engine Service names, which was turning every query into `503 no healthy upstream` on clusters that inject extra `resolv.conf` search domains (e.g. a VPC zone) and a DNS-filtering CNI that answers those expansions with REFUSED.
> 
> The Lua filter already rewrites `:authority` to a fully qualified in-cluster name, but that name has fewer than kubelet’s default `ndots:5`, so Envoy’s c-ares resolver tried doomed search-domain expansions first and aborted the whole lookup before asking for the canonical name. The DFP cluster now sets c-ares `no_default_search_domain: true`; `sub_clusters_config` copies that into every per-Engine STRICT_DNS sub-cluster.
> 
> Docs state the exact-name contract (`<engine>-service.<namespace>.svc.cluster.local`) so DNS-level network policies know which lookup to allow. A unit test pins the resolver option on the rendered bootstrap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b29932dae4d595066f2c242157b65b24b0b6d806. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->