### PR TITLE
chore(deps): bump packdb engine/metadata to 5.0.0-pre.0.20260822175432.75d37cc26c66

### DIFF
--- a/config/images/defaults.latest.env
+++ b/config/images/defaults.latest.env
@@ -21,9 +21,9 @@
 #     test/e2e/e2e_suite_test.go's SynchronizedBeforeSuite.
 
 ENGINE_IMAGE=oci.firebolt.io/firebolt-db/engine
-ENGINE_TAG=release-5.0.0-pre.0.20260815074041.524de236b514
+ENGINE_TAG=release-5.0.0-pre.0.20260822175432.75d37cc26c66
 METADATA_IMAGE=ghcr.io/firebolt-db/metadata
-METADATA_TAG=release-5.0.0-pre.0.20260815074041.524de236b514
+METADATA_TAG=release-5.0.0-pre.0.20260822175432.75d37cc26c66
 POSTGRES_IMAGE=postgres:16-alpine
 ENVOY_IMAGE=envoyproxy/envoy
 ENVOY_TAG=v1.37.2


### PR DESCRIPTION
## Summary

Bump default engine/metadata images to packdb `5.0.0-pre.0.20260822175432.75d37cc26c66`
— the build the engine/metadata `:latest` GHCR tags were just re-pointed to.

> [!NOTE]
> Opened automatically by packdb's `promote-ghcr-latest` workflow (weekly
> Monday refresh or a manual promotion) right after it re-pointed the
> engine/metadata `:latest` GHCR tags at this build, so `:latest` and this
> repo's pinned tags move together. An unmerged PR is overwritten by the
> next run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the operator’s default engine and metadata images, so a bad packdb build can break clusters and E2E. Scope is two tag pins only.
> 
> **Overview**
> Pins the default **latest** engine and metadata images to packdb `release-5.0.0-pre.0.20260822175432.75d37cc26c66` in `config/images/defaults.latest.env`, matching the newly promoted GHCR `:latest` tags.
> 
> No other image or operator logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 557dea26fc06ece9c5ac3be66d97ce9183165275. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->