### PR TITLE
docs: add Tigris and Cloudflare R2 to S3-compatible storage (FB-3391)

### DIFF
--- a/docs/engine/object-storage/s3-compatible.mdx
+++ b/docs/engine/object-storage/s3-compatible.mdx
@@ -76,6 +76,83 @@ CoreWeave Object Storage supports virtual-hosted addressing only, so set `path_s
                 name: coreweave-s3-credentials
 ```
 
+## Tigris
+
+[Tigris](https://www.tigrisdata.com/) exposes a global S3 API endpoint at `https://t3.storage.dev` and supports path-style addressing (the default).
+
+Create a `Secret` from a Tigris access key:
+
+```bash
+kubectl -n firebolt create secret generic tigris-s3-credentials \
+  --from-literal=AWS_ACCESS_KEY_ID=<tigris-access-key-id> \
+  --from-literal=AWS_SECRET_ACCESS_KEY=<tigris-secret>
+```
+
+```yaml
+apiVersion: compute.firebolt.io/v1alpha1
+kind: FireboltEngine
+metadata:
+  name: my-engine
+  namespace: firebolt
+spec:
+  instanceRef: quickstart
+  replicas: 1
+  customEngineConfig:
+    storage:
+      managed_table_storage: s3
+      managed_table_bucket_name: my-firebolt-bucket
+      aws:
+        endpoint: https://t3.storage.dev
+        region: auto
+        path_style_addressing: true # non-AWS S3-compatible store; ignored for AWS S3
+  template:
+    spec:
+      containers:
+        - name: engine
+          envFrom:
+            - secretRef:
+                name: tigris-s3-credentials # AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+```
+
+
+## Cloudflare R2
+
+[Cloudflare R2](https://developers.cloudflare.com/r2/) exposes an account-scoped S3 API endpoint at `https://<account-id>.r2.cloudflarestorage.com` and supports path-style addressing. R2 ignores the signing region, so set `region: auto`.
+
+Create a `Secret` from an R2 API token (S3 credentials):
+
+```bash
+kubectl -n firebolt create secret generic r2-s3-credentials \
+  --from-literal=AWS_ACCESS_KEY_ID=<r2-access-key-id> \
+  --from-literal=AWS_SECRET_ACCESS_KEY=<r2-secret>
+```
+
+```yaml
+apiVersion: compute.firebolt.io/v1alpha1
+kind: FireboltEngine
+metadata:
+  name: my-engine
+  namespace: firebolt
+spec:
+  instanceRef: quickstart
+  replicas: 1
+  customEngineConfig:
+    storage:
+      managed_table_storage: s3
+      managed_table_bucket_name: my-firebolt-bucket
+      aws:
+        endpoint: https://<account-id>.r2.cloudflarestorage.com
+        region: auto
+        path_style_addressing: true
+  template:
+    spec:
+      containers:
+        - name: engine
+          envFrom:
+            - secretRef:
+                name: r2-s3-credentials
+```
+
 ## Verify
 
 Apply the manifest, wait for the engine to reach `Ready`, then run a small write/read (for example `CREATE TABLE` + `INSERT` + `SELECT`). Confirm objects appear under your bucket with the provider's CLI (`aws s3 ls s3://my-firebolt-bucket --endpoint-url <endpoint>`). See the [Quickstart](../../quickstart) for connecting to the engine.


### PR DESCRIPTION
Adds Tigris and Cloudflare R2 to the S3-compatible storage page, following the existing Nebius/CoreWeave pattern. Endpoint and credential mechanism (endpoint in the engine config, credentials via env-var Secret) verified on Firebolt Core; not deployed end-to-end through the operator.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no application, operator, or infrastructure code changes.
> 
> **Overview**
> Extends the **S3-compatible storage** doc with two provider guides—**Tigris** and **Cloudflare R2**—placed after CoreWeave and before **Verify**, using the same pattern as Nebius (Secret + `FireboltEngine` manifest).
> 
> Each section documents the S3 endpoint, path-style addressing, and `kubectl` steps for `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`. Both examples set **`region: auto`** under `storage.aws` (called out for R2 because signing region is ignored). Tigris uses `https://t3.storage.dev`; R2 uses the account-scoped `https://<account-id>.r2.cloudflarestorage.com` endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 349bacb9eb284fffa1a750e6a539bc54f2ee9a3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->