### PR TITLE
fix: restart metadata after external credential updates (#183)

### DIFF
--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -44,11 +44,11 @@ mounts the referenced Secret directly; credential bytes are not copied into the
 Instance or ConfigMap.
 
 The Instance controller watches credential Secrets that its Instances reference.
-It folds the Secret's `username` and `password` content into one aggregate
-Metadata Service pod-template hash, so a credential change rolls the single
-metadata pod even though the Secret name and rendered configuration remain
-unchanged. Secret metadata-only updates do not change the hash. The annotation
-contains neither credential bytes nor separate per-value digests.
+It folds the Secret's `resourceVersion` into the Metadata Service pod-template
+hash, so a credential change rolls the single metadata pod even though the
+Secret name and rendered configuration remain unchanged. This may also roll the
+pod after a metadata-only Secret update, but keeps credential bytes and their
+digests out of non-Secret objects.
 
 ## Query traffic
 

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -44,10 +44,11 @@ mounts the referenced Secret directly; credential bytes are not copied into the
 Instance or ConfigMap.
 
 The Instance controller watches credential Secrets that its Instances reference.
-It folds the Secret `resourceVersion` into the Metadata Service pod-template
-hash, so an in-place password rotation rolls the single metadata pod even though
-the Secret name and rendered configuration remain unchanged. The hash never
-contains credential bytes.
+It folds the Secret's `username` and `password` content into one aggregate
+Metadata Service pod-template hash, so a credential change rolls the single
+metadata pod even though the Secret name and rendered configuration remain
+unchanged. Secret metadata-only updates do not change the hash. The annotation
+contains neither credential bytes nor separate per-value digests.
 
 ## Query traffic
 

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -35,6 +35,20 @@ The same scheduling window applies to the fail-closed EngineClass and FireboltEn
 
 An Engine may also reference one EngineClass in the same namespace through `spec.engineClassRef`. Settings resolve Engine, then FireboltEnginePreset, then EngineClass, then Firebolt Operator defaults. See [EngineClass configuration inheritance](./engineclass/configuration-inheritance).
 
+### External metadata PostgreSQL
+
+When `FireboltInstance.spec.metadata.postgres` is present, the Firebolt Operator
+does not create the internal PostgreSQL StatefulSet. It renders the supplied
+host, port, database, and schema into the Metadata Service configuration and
+mounts the referenced Secret directly; credential bytes are not copied into the
+Instance or ConfigMap.
+
+The Instance controller watches credential Secrets that its Instances reference.
+It folds the Secret `resourceVersion` into the Metadata Service pod-template
+hash, so an in-place password rotation rolls the single metadata pod even though
+the Secret name and rendered configuration remain unchanged. The hash never
+contains credential bytes.
+
 ## Query traffic
 
 Clients connect to the Instance Gateway and select an Engine with the `X-Firebolt-Engine` header. The Gateway forwards traffic only to ready pods in the Engine's active generation.

--- a/internal/controller/instance_controller.go
+++ b/internal/controller/instance_controller.go
@@ -40,13 +40,18 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	computev1alpha1 "github.com/firebolt-db/firebolt-kubernetes-operator/api/v1alpha1"
 	"github.com/firebolt-db/firebolt-kubernetes-operator/internal/metrics"
 )
 
-const instanceFinalizerName = "compute.firebolt.io/instance-cleanup"
+const (
+	instanceFinalizerName = "compute.firebolt.io/instance-cleanup"
+
+	externalPostgresCredentialsSecretIndexField = "spec.metadata.postgres.credentialsSecretRef.name" //nolint:gosec // field-index path, not a credential
+)
 
 // reasonTemplateRejected is the per-component Ready=False reason
 // surfaced when validatePodTemplates rejects spec.gateway.template or
@@ -922,8 +927,17 @@ func (r *FireboltInstanceReconciler) SetupWithManagerNamed(mgr ctrl.Manager, nam
 	if r.EventRecorder == nil {
 		r.EventRecorder = mgr.GetEventRecorder(name)
 	}
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(),
+		&computev1alpha1.FireboltInstance{},
+		externalPostgresCredentialsSecretIndexField,
+		externalPostgresCredentialsSecretIndexValues,
+	); err != nil {
+		return fmt.Errorf("indexing external postgres credential Secret references: %w", err)
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&computev1alpha1.FireboltInstance{}).
+		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.mapMetadataCredentialsSecretToInstances)).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
@@ -931,4 +945,54 @@ func (r *FireboltInstanceReconciler) SetupWithManagerNamed(mgr ctrl.Manager, nam
 		Owns(&policyv1.PodDisruptionBudget{}).
 		Named(name).
 		Complete(r)
+}
+
+// externalPostgresCredentialsSecretIndexValues indexes only explicit external
+// PostgreSQL credential references. Internal PostgreSQL uses an
+// operator-generated Secret, whose events must remain covered solely by the
+// ordinary owned-resource reconcile path.
+func externalPostgresCredentialsSecretIndexValues(obj client.Object) []string {
+	instance, ok := obj.(*computev1alpha1.FireboltInstance)
+	if !ok || instance.Spec.Metadata.Postgres == nil {
+		return nil
+	}
+	name := instance.Spec.Metadata.Postgres.CredentialsSecretRef.Name
+	if name == "" {
+		return nil
+	}
+	return []string{name}
+}
+
+// mapMetadataCredentialsSecretToInstances makes an external credentials Secret
+// refresh an explicit reconcile input. Secret synchronization controllers do
+// not set the FireboltInstance as owner, so Owns cannot observe these updates.
+// The field index keeps unrelated and internal Secret events from scanning
+// every Instance in the namespace.
+func (r *FireboltInstanceReconciler) mapMetadataCredentialsSecretToInstances(
+	ctx context.Context,
+	obj client.Object,
+) []ctrl.Request {
+	secret, ok := obj.(*corev1.Secret)
+	if !ok {
+		return nil
+	}
+	instances := &computev1alpha1.FireboltInstanceList{}
+	if err := r.List(
+		ctx,
+		instances,
+		client.InNamespace(secret.Namespace),
+		client.MatchingFields{externalPostgresCredentialsSecretIndexField: secret.Name},
+	); err != nil {
+		return nil
+	}
+	requests := make([]ctrl.Request, 0, len(instances.Items))
+	for i := range instances.Items {
+		instance := &instances.Items[i]
+		if instance.Spec.Metadata.Postgres == nil ||
+			instance.Spec.Metadata.Postgres.CredentialsSecretRef.Name != secret.Name {
+			continue
+		}
+		requests = append(requests, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(instance)})
+	}
+	return requests
 }

--- a/internal/controller/instance_metadata.go
+++ b/internal/controller/instance_metadata.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -246,13 +247,9 @@ func (r *FireboltInstanceReconciler) ensureMetadataDeployment(ctx context.Contex
 }
 
 // metadataConfigHash preserves the config-only rollout hash for internal
-// PostgreSQL. For external PostgreSQL it also includes the referenced
-// credentials Secret's ResourceVersion so an in-place password rotation rolls
-// the metadata pod. Pensieve reads the credential files at process start; the
-// rendered YAML and Secret name do not change when a Secret synchronization
-// controller refreshes the same object. ResourceVersion, not credential bytes,
-// is sufficient to detect every write without moving secret material into a
-// pod annotation.
+// PostgreSQL. For external PostgreSQL it hashes the config and both credential
+// values together, so credential changes roll the metadata pod without exposing
+// either value or a per-value digest in the pod annotation.
 func (r *FireboltInstanceReconciler) metadataConfigHash(
 	ctx context.Context,
 	instance *computev1alpha1.FireboltInstance,
@@ -268,7 +265,12 @@ func (r *FireboltInstanceReconciler) metadataConfigHash(
 		return "", fmt.Errorf("reading metadata credentials Secret %s/%s for rollout hash: %w",
 			instance.Namespace, name, err)
 	}
-	return contentHash(configYAML + "\x00" + name + "=" + secret.ResourceVersion), nil
+	return aggregateContentHash(
+		[]byte("metadata-config-and-postgres-credentials-v1"),
+		[]byte(configYAML),
+		secret.Data["username"],
+		secret.Data["password"],
+	), nil
 }
 
 // buildMetadataDeployment returns the desired Deployment object for the
@@ -554,6 +556,18 @@ func (r *FireboltInstanceReconciler) ensureMetadataService(ctx context.Context, 
 // as a pod-template annotation to trigger rollouts on config changes.
 func contentHash(content string) string {
 	h := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(h[:])[:16]
+}
+
+// aggregateContentHash length-prefixes its inputs before hashing them so byte
+// boundaries cannot collide. Only the final aggregate digest is returned.
+func aggregateContentHash(parts ...[]byte) string {
+	var content []byte
+	for _, part := range parts {
+		content = binary.BigEndian.AppendUint64(content, uint64(len(part)))
+		content = append(content, part...)
+	}
+	h := sha256.Sum256(content)
 	return hex.EncodeToString(h[:])[:16]
 }
 

--- a/internal/controller/instance_metadata.go
+++ b/internal/controller/instance_metadata.go
@@ -247,9 +247,9 @@ func (r *FireboltInstanceReconciler) ensureMetadataDeployment(ctx context.Contex
 }
 
 // metadataConfigHash preserves the config-only rollout hash for internal
-// PostgreSQL. For external PostgreSQL it hashes the config and both credential
-// values together, so credential changes roll the metadata pod without exposing
-// either value or a per-value digest in the pod annotation.
+// PostgreSQL. For external PostgreSQL it also hashes the referenced Secret's
+// resource version, so credential changes roll the metadata pod without hashing
+// credential bytes into a non-Secret object.
 func (r *FireboltInstanceReconciler) metadataConfigHash(
 	ctx context.Context,
 	instance *computev1alpha1.FireboltInstance,
@@ -266,10 +266,9 @@ func (r *FireboltInstanceReconciler) metadataConfigHash(
 			instance.Namespace, name, err)
 	}
 	return aggregateContentHash(
-		[]byte("metadata-config-and-postgres-credentials-v1"),
+		[]byte("metadata-config-and-postgres-secret-version-v1"),
 		[]byte(configYAML),
-		secret.Data["username"],
-		secret.Data["password"],
+		[]byte(secret.ResourceVersion),
 	), nil
 }
 

--- a/internal/controller/instance_metadata.go
+++ b/internal/controller/instance_metadata.go
@@ -26,6 +26,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -226,6 +227,12 @@ func (r *FireboltInstanceReconciler) ensureMetadataDeployment(ctx context.Contex
 	desired := buildMetadataDeployment(instance, configYAML)
 	desired.TypeMeta = metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"}
 
+	configHash, err := r.metadataConfigHash(ctx, instance, configYAML)
+	if err != nil {
+		return err
+	}
+	desired.Spec.Template.Annotations[AnnotationConfigHash] = configHash
+
 	if err := controllerutil.SetControllerReference(instance, desired, r.Scheme); err != nil {
 		return err
 	}
@@ -236,6 +243,32 @@ func (r *FireboltInstanceReconciler) ensureMetadataDeployment(ctx context.Contex
 		"replicas", *desired.Spec.Replicas,
 		"image", desired.Spec.Template.Spec.Containers[0].Image)
 	return applySSA(ctx, r.Client, desired)
+}
+
+// metadataConfigHash preserves the config-only rollout hash for internal
+// PostgreSQL. For external PostgreSQL it also includes the referenced
+// credentials Secret's ResourceVersion so an in-place password rotation rolls
+// the metadata pod. Pensieve reads the credential files at process start; the
+// rendered YAML and Secret name do not change when a Secret synchronization
+// controller refreshes the same object. ResourceVersion, not credential bytes,
+// is sufficient to detect every write without moving secret material into a
+// pod annotation.
+func (r *FireboltInstanceReconciler) metadataConfigHash(
+	ctx context.Context,
+	instance *computev1alpha1.FireboltInstance,
+	configYAML string,
+) (string, error) {
+	if instance.Spec.Metadata.Postgres == nil {
+		return contentHash(configYAML), nil
+	}
+
+	name := instance.Spec.Metadata.Postgres.CredentialsSecretRef.Name
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: name}, secret); err != nil {
+		return "", fmt.Errorf("reading metadata credentials Secret %s/%s for rollout hash: %w",
+			instance.Namespace, name, err)
+	}
+	return contentHash(configYAML + "\x00" + name + "=" + secret.ResourceVersion), nil
 }
 
 // buildMetadataDeployment returns the desired Deployment object for the

--- a/internal/controller/instance_metadata_test.go
+++ b/internal/controller/instance_metadata_test.go
@@ -99,7 +99,7 @@ func TestMetadataConfigHashInternalPostgresUsesConfigOnly(t *testing.T) {
 	}
 }
 
-func TestMetadataConfigHashExternalPostgresUsesCredentialContent(t *testing.T) {
+func TestMetadataConfigHashExternalPostgresUsesSecretResourceVersion(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := clientgoscheme.AddToScheme(scheme); err != nil {
 		t.Fatal(err)
@@ -122,12 +122,12 @@ func TestMetadataConfigHashExternalPostgresUsesCredentialContent(t *testing.T) {
 		return hash
 	}
 
-	secret := func(username, password string) *corev1.Secret {
+	secret := func(resourceVersion, username, password string) *corev1.Secret {
 		return &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "external-creds",
 				Namespace:       instance.Namespace,
-				ResourceVersion: "10",
+				ResourceVersion: resourceVersion,
 			},
 			Data: map[string][]byte{
 				"username": []byte(username),
@@ -136,21 +136,17 @@ func TestMetadataConfigHashExternalPostgresUsesCredentialContent(t *testing.T) {
 			},
 		}
 	}
-	base := secret("metadata-user", "password-one")
+	base := secret("10", "metadata-user", "password-one")
 	baseHash := hashForSecret(base)
 
-	sameCredentials := secret("metadata-user", "password-one")
-	sameCredentials.ResourceVersion = "11"
+	sameCredentials := secret("11", "metadata-user", "password-one")
 	sameCredentials.Annotations = map[string]string{"synchronizer.example/version": "2"}
-	sameCredentials.Data["database"] = []byte("also-ignored")
-	if got := hashForSecret(sameCredentials); got != baseHash {
-		t.Fatalf("metadata-only Secret update changed config hash: got %q, want %q", got, baseHash)
+	if got := hashForSecret(sameCredentials); got == baseHash {
+		t.Fatalf("Secret resource-version change did not change metadata config hash: %q", got)
 	}
-	if got := hashForSecret(secret("metadata-user-2", "password-one")); got == baseHash {
-		t.Fatalf("username change did not change metadata config hash: %q", got)
-	}
-	if got := hashForSecret(secret("metadata-user", "password-two")); got == baseHash {
-		t.Fatalf("password change did not change metadata config hash: %q", got)
+	differentCredentialsSameVersion := secret("10", "metadata-user-2", "password-two")
+	if got := hashForSecret(differentCredentialsSameVersion); got != baseHash {
+		t.Fatalf("credential bytes entered metadata config hash: got %q, want %q", got, baseHash)
 	}
 	for _, credential := range []string{"metadata-user", "password-one"} {
 		if strings.Contains(baseHash, credential) || baseHash == contentHash(credential) {

--- a/internal/controller/instance_metadata_test.go
+++ b/internal/controller/instance_metadata_test.go
@@ -21,9 +21,11 @@ import (
 	"strings"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
@@ -97,7 +99,7 @@ func TestMetadataConfigHashInternalPostgresUsesConfigOnly(t *testing.T) {
 	}
 }
 
-func TestMetadataConfigHashExternalPostgresIncludesCredentialsSecretVersion(t *testing.T) {
+func TestMetadataConfigHashExternalPostgresUsesCredentialContent(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := clientgoscheme.AddToScheme(scheme); err != nil {
 		t.Fatal(err)
@@ -108,11 +110,8 @@ func TestMetadataConfigHashExternalPostgresIncludesCredentialsSecretVersion(t *t
 		CredentialsSecretRef: corev1.LocalObjectReference{Name: "external-creds"},
 	}
 	configYAML := buildMetadataConfigYAML(instance)
-	hashForVersion := func(version string) string {
+	hashForSecret := func(secret *corev1.Secret) string {
 		t.Helper()
-		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
-			Name: "external-creds", Namespace: instance.Namespace, ResourceVersion: version,
-		}}
 		reconciler := &FireboltInstanceReconciler{
 			Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build(),
 		}
@@ -123,8 +122,87 @@ func TestMetadataConfigHashExternalPostgresIncludesCredentialsSecretVersion(t *t
 		return hash
 	}
 
-	if before, after := hashForVersion("10"), hashForVersion("11"); before == after {
-		t.Fatalf("metadata config hash did not change across credentials Secret rotation: %q", before)
+	secret := func(username, password string) *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "external-creds",
+				Namespace:       instance.Namespace,
+				ResourceVersion: "10",
+			},
+			Data: map[string][]byte{
+				"username": []byte(username),
+				"password": []byte(password),
+				"database": []byte("ignored"),
+			},
+		}
+	}
+	base := secret("metadata-user", "password-one")
+	baseHash := hashForSecret(base)
+
+	sameCredentials := secret("metadata-user", "password-one")
+	sameCredentials.ResourceVersion = "11"
+	sameCredentials.Annotations = map[string]string{"synchronizer.example/version": "2"}
+	sameCredentials.Data["database"] = []byte("also-ignored")
+	if got := hashForSecret(sameCredentials); got != baseHash {
+		t.Fatalf("metadata-only Secret update changed config hash: got %q, want %q", got, baseHash)
+	}
+	if got := hashForSecret(secret("metadata-user-2", "password-one")); got == baseHash {
+		t.Fatalf("username change did not change metadata config hash: %q", got)
+	}
+	if got := hashForSecret(secret("metadata-user", "password-two")); got == baseHash {
+		t.Fatalf("password change did not change metadata config hash: %q", got)
+	}
+	for _, credential := range []string{"metadata-user", "password-one"} {
+		if strings.Contains(baseHash, credential) || baseHash == contentHash(credential) {
+			t.Fatalf("metadata config hash exposes an individual credential: %q", baseHash)
+		}
+	}
+}
+
+func TestEnsureMetadataDeploymentAppliesComputedConfigHash(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := computev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	instance := mkMetadataInstance()
+	instance.UID = types.UID("instance-uid")
+	instance.Spec.Metadata.Postgres = &computev1alpha1.PostgresSpec{
+		Host: "postgres.example.com", Database: "metadata",
+		CredentialsSecretRef: corev1.LocalObjectReference{Name: "external-creds"},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "external-creds", Namespace: instance.Namespace},
+		Data: map[string][]byte{
+			"username": []byte("metadata-user"),
+			"password": []byte("metadata-password"),
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(instance, secret).Build()
+	reconciler := &FireboltInstanceReconciler{Client: client, Scheme: scheme}
+	configYAML := buildMetadataConfigYAML(instance)
+	want, err := reconciler.metadataConfigHash(context.Background(), instance, configYAML)
+	if err != nil {
+		t.Fatalf("metadataConfigHash: %v", err)
+	}
+
+	if err := reconciler.ensureMetadataDeployment(context.Background(), instance, configYAML); err != nil {
+		t.Fatalf("ensureMetadataDeployment: %v", err)
+	}
+	applied := &appsv1.Deployment{}
+	if err := client.Get(context.Background(), types.NamespacedName{
+		Namespace: instance.Namespace,
+		Name:      instance.Name + SuffixMetadataService,
+	}, applied); err != nil {
+		t.Fatalf("get applied metadata Deployment: %v", err)
+	}
+	if got := applied.Spec.Template.Annotations[AnnotationConfigHash]; got != want {
+		t.Fatalf("applied metadata config hash = %q, want %q", got, want)
+	}
+	if got := len(applied.Spec.Template.Annotations); got != 1 {
+		t.Fatalf("applied metadata Deployment has %d annotations, want one aggregate hash", got)
 	}
 }
 

--- a/internal/controller/instance_metadata_test.go
+++ b/internal/controller/instance_metadata_test.go
@@ -17,11 +17,15 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
 
 	computev1alpha1 "github.com/firebolt-db/firebolt-kubernetes-operator/api/v1alpha1"
@@ -73,6 +77,125 @@ func TestBuildMetadataConfigYAMLSchema(t *testing.T) {
 			got := buildMetadataConfigYAML(inst)
 			if !strings.Contains(got, tc.want) {
 				t.Errorf("expected %q in rendered config; got:\n%s", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestMetadataConfigHashInternalPostgresUsesConfigOnly(t *testing.T) {
+	instance := mkMetadataInstance()
+	configYAML := buildMetadataConfigYAML(instance)
+
+	// Internal PostgreSQL must use only the config hash and never read a Secret.
+	reconciler := &FireboltInstanceReconciler{}
+	got, err := reconciler.metadataConfigHash(context.Background(), instance, configYAML)
+	if err != nil {
+		t.Fatalf("metadataConfigHash: %v", err)
+	}
+	if want := contentHash(configYAML); got != want {
+		t.Fatalf("internal metadata config hash = %q, want config-only hash %q", got, want)
+	}
+}
+
+func TestMetadataConfigHashExternalPostgresIncludesCredentialsSecretVersion(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	instance := mkMetadataInstance()
+	instance.Spec.Metadata.Postgres = &computev1alpha1.PostgresSpec{
+		Host: "postgres.example.com", Database: "metadata",
+		CredentialsSecretRef: corev1.LocalObjectReference{Name: "external-creds"},
+	}
+	configYAML := buildMetadataConfigYAML(instance)
+	hashForVersion := func(version string) string {
+		t.Helper()
+		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Name: "external-creds", Namespace: instance.Namespace, ResourceVersion: version,
+		}}
+		reconciler := &FireboltInstanceReconciler{
+			Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build(),
+		}
+		hash, err := reconciler.metadataConfigHash(context.Background(), instance, configYAML)
+		if err != nil {
+			t.Fatalf("metadataConfigHash: %v", err)
+		}
+		return hash
+	}
+
+	if before, after := hashForVersion("10"), hashForVersion("11"); before == after {
+		t.Fatalf("metadata config hash did not change across credentials Secret rotation: %q", before)
+	}
+}
+
+func TestMetadataCredentialsSecretMapsOnlyExternalReferences(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := computev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	referencing := mkMetadataInstance()
+	referencing.Name = "references-secret"
+	referencing.Spec.Metadata.Postgres = &computev1alpha1.PostgresSpec{
+		Host: "postgres.example.com", Database: "metadata",
+		CredentialsSecretRef: corev1.LocalObjectReference{Name: "external-creds"},
+	}
+	other := mkMetadataInstance()
+	other.Name = "other-instance"
+	other.Spec.Metadata.Postgres = &computev1alpha1.PostgresSpec{
+		Host: "postgres.example.com", Database: "other",
+		CredentialsSecretRef: corev1.LocalObjectReference{Name: "other-creds"},
+	}
+	internal := mkMetadataInstance()
+	internal.Name = "internal-instance"
+	reconciler := &FireboltInstanceReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(referencing, other, internal).
+			WithIndex(
+				&computev1alpha1.FireboltInstance{},
+				externalPostgresCredentialsSecretIndexField,
+				externalPostgresCredentialsSecretIndexValues,
+			).
+			Build(),
+	}
+
+	tests := []struct {
+		name        string
+		secretName  string
+		wantRequest string
+	}{
+		{
+			name:        "referenced external Secret",
+			secretName:  "external-creds",
+			wantRequest: referencing.Name,
+		},
+		{
+			name:       "unrelated Secret",
+			secretName: "unrelated",
+		},
+		{
+			name:       "operator-generated internal credentials Secret",
+			secretName: pgCredentialsSecretName(internal.Name),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			requests := reconciler.mapMetadataCredentialsSecretToInstances(context.Background(), &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: tc.secretName, Namespace: referencing.Namespace},
+			})
+			if tc.wantRequest == "" {
+				if len(requests) != 0 {
+					t.Fatalf("mapped requests = %#v, want none", requests)
+				}
+				return
+			}
+			if len(requests) != 1 || requests[0].Name != tc.wantRequest ||
+				requests[0].Namespace != referencing.Namespace {
+				t.Fatalf("mapped requests = %#v, want only %s/%s",
+					requests, referencing.Namespace, tc.wantRequest)
 			}
 		})
 	}


### PR DESCRIPTION
**Background**

#183: Rotating an external PostgreSQL credentials Secret must refresh the metadata workload.

**Summary**

- Watch referenced credential Secrets and reconcile only the Instances that use them.
- Include the Secret `resourceVersion` in the metadata pod-template hash without hashing credential bytes.
- Preserve config-only hashing for internal PostgreSQL.

A metadata-only Secret update may also trigger a rollout.

**Test Plan**

- Controller unit tests
- Go build and lint