### PR TITLE
chore(deps): bump packdb engine/metadata to 5.0.0-pre.0.20260830212212.426f0e955f24

### DIFF
--- a/config/images/defaults.latest.env
+++ b/config/images/defaults.latest.env
@@ -21,9 +21,9 @@
 #     test/e2e/e2e_suite_test.go's SynchronizedBeforeSuite.
 
 ENGINE_IMAGE=oci.firebolt.io/firebolt-db/engine
-ENGINE_TAG=release-5.0.0-pre.0.20260828194119.d0f954993097
+ENGINE_TAG=release-5.0.0-pre.0.20260830212212.426f0e955f24
 METADATA_IMAGE=ghcr.io/firebolt-db/metadata
-METADATA_TAG=release-5.0.0-pre.0.20260828194119.d0f954993097
+METADATA_TAG=release-5.0.0-pre.0.20260830212212.426f0e955f24
 # Multi-arch manifest-list digest (not a single-platform blob). Refresh with:
 #   docker buildx imagetools inspect postgres:16.15-alpine --format '{{.Manifest.Digest}}'
 POSTGRES_IMAGE=postgres:16.15-alpine@sha256:cf78e76683b9ca8c5733cbbdce6c9262b45b6767934dd0a95e671f9a0fc20685


### PR DESCRIPTION
## Summary

Bump default engine/metadata images to packdb `5.0.0-pre.0.20260830212212.426f0e955f24`
— the build the engine/metadata `:latest` GHCR tags were just re-pointed to.

> [!NOTE]
> Opened automatically by packdb's `promote-ghcr-latest` workflow (weekly
> Monday refresh or a manual promotion) right after it re-pointed the
> engine/metadata `:latest` GHCR tags at this build, so `:latest` and this
> repo's pinned tags move together. An unmerged PR is overwritten by the
> next run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only pin update with no application code changes; residual risk is the new engine/metadata build breaking operator or E2E contract, which the automated PR’s test suite is meant to catch.
> 
> **Overview**
> Updates the **latest** image variant pins in `config/images/defaults.latest.env` so operator builds, the Helm chart, and default E2E runs pull a newer packdb build.
> 
> **`ENGINE_TAG`** and **`METADATA_TAG`** move together from `…20260828194119.d0f954993097` to `…20260830212212.426f0e955f24`, keeping engine and metadata on the same release flavor as required by the autobump convention. No other images or config in this file change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0fd7bc792a993831f89d3cfa2dc25ec12f27b2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->