### PR TITLE
ci(test): harden asynchronous E2E checks (#199)

### DIFF
--- a/dev-docs/testing/e2e-testing.md
+++ b/dev-docs/testing/e2e-testing.md
@@ -79,9 +79,9 @@ When adding a wait, reuse an existing helper or timeout constant if it describes
 
 ## Zero-downtime assertions
 
-A zero-downtime test must gather enough requests to make a zero-failure assertion meaningful. Start the background runner before the transition, require a minimum success count, and fail on every observed query error.
+A zero-downtime test must gather enough requests to make a zero-failure assertion meaningful. Start the background runner before the transition, require a minimum success count, and fail on every observed data-plane query error. The runner retries only explicit client-pod failures to resolve the stable Gateway Service name, with a bounded attempt count; those requests never reached the Gateway and measure Kind/CoreDNS availability rather than the Operator's routing contract. Exhausted DNS retries still fail the test.
 
-Do not accept transient failures as expected rollout behavior. The routing contract is layered specifically so blue-green transitions do not leak a 5xx to requests within its supported request-size and gateway-entry constraints.
+Do not accept transient HTTP failures, connection errors, or generic request timeouts as expected rollout behavior. The routing contract is layered specifically so blue-green transitions do not leak a 5xx to requests within its supported request-size and gateway-entry constraints.
 
 ## Crash-recovery coverage
 

--- a/scripts/ci/verify-wake-on-zero.sh
+++ b/scripts/ci/verify-wake-on-zero.sh
@@ -60,6 +60,11 @@ WAKE_QUERY_TIMEOUT="${WAKE_QUERY_TIMEOUT:-240}"
 # bring it back.
 STOP_WAIT_SECONDS="${STOP_WAIT_SECONDS:-180}"
 WAKE_WAIT_SECONDS="${WAKE_WAIT_SECONDS:-240}"
+# Scaling the FireboltEngine to zero only records the desired state. Pod
+# termination and EndpointSlice reconciliation finish asynchronously, so give
+# the data plane its own bounded convergence window before testing the parked
+# engine contract.
+ENDPOINT_WAIT_SECONDS="${ENDPOINT_WAIT_SECONDS:-60}"
 
 # How many health probes to send at the parked engine, how long the probe
 # pod may take to schedule and finish them, and how long the engine must
@@ -199,11 +204,24 @@ fi
 # resolve. That is precisely why Envoy cannot ride this out on its own and
 # why the agent has to hold the request.
 echo "Confirming the stopped engine has no endpoints..."
-endpoints=$(kubectl get endpointslice -n "$NAMESPACE" \
-  -l "kubernetes.io/service-name=${ENGINE_NAME}-service" \
-  -o jsonpath='{range .items[*]}{.endpoints[*].addresses[*]}{" "}{end}' 2>/dev/null || echo "")
+deadline=$(( SECONDS + ENDPOINT_WAIT_SECONDS ))
+endpoints="<not read>"
+while (( SECONDS < deadline )); do
+  if current_endpoints=$(kubectl get endpointslice -n "$NAMESPACE" \
+    -l "kubernetes.io/service-name=${ENGINE_NAME}-service" \
+    -o jsonpath='{range .items[*]}{.endpoints[*].addresses[*]}{" "}{end}' 2>/dev/null); then
+    endpoints="$current_endpoints"
+    if [[ -z "${endpoints// /}" ]]; then
+      break
+    fi
+  else
+    endpoints="<EndpointSlice read failed>"
+  fi
+  sleep 1
+done
 if [[ -n "${endpoints// /}" ]]; then
-  echo "Stopped engine still has endpoints: ${endpoints}"
+  echo "Timed out after ${ENDPOINT_WAIT_SECONDS}s waiting for stopped-engine endpoints to disappear; last result: ${endpoints}"
+  dump_namespace_debug "$NAMESPACE"
   exit 1
 fi
 echo "No endpoints, as expected"

--- a/test/e2e/helpers_retry_test.go
+++ b/test/e2e/helpers_retry_test.go
@@ -1,0 +1,129 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2026 Firebolt Analytics.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestRetryGatewayQueryOnDNSFailure(t *testing.T) {
+	dnsTimeout := errors.New("curl failed: curl: (28) Resolving timed out after 2002 milliseconds")
+	dnsMissing := errors.New("curl failed: curl: (6) Could not resolve host: gateway.test.svc.cluster.local")
+	connectionReset := errors.New("curl failed: recv failure: Connection reset by peer")
+	httpFailure := errors.New("curl failed: the requested URL returned error: 503")
+	genericTimeout := errors.New("curl failed: operation timed out while awaiting response")
+
+	tests := []struct {
+		name      string
+		results   []error
+		wantCalls int
+		wantErr   error
+	}{
+		{
+			name:      "success without retry",
+			results:   []error{nil},
+			wantCalls: 1,
+		},
+		{
+			name:      "resolving timeout is retried",
+			results:   []error{dnsTimeout, nil},
+			wantCalls: 2,
+		},
+		{
+			name:      "missing DNS record is retried",
+			results:   []error{dnsMissing, dnsMissing, nil},
+			wantCalls: 3,
+		},
+		{
+			name:      "DNS retries are bounded",
+			results:   []error{dnsTimeout, dnsMissing, dnsTimeout},
+			wantCalls: 3,
+			wantErr:   dnsTimeout,
+		},
+		{
+			name:      "connection failure is not retried",
+			results:   []error{connectionReset, nil},
+			wantCalls: 1,
+			wantErr:   connectionReset,
+		},
+		{
+			name:      "HTTP failure is not retried",
+			results:   []error{httpFailure, nil},
+			wantCalls: 1,
+			wantErr:   httpFailure,
+		},
+		{
+			name:      "generic request timeout is not retried",
+			results:   []error{genericTimeout, nil},
+			wantCalls: 1,
+			wantErr:   genericTimeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			output, err := retryGatewayQueryOnDNSFailure(context.Background(), func(context.Context) (string, error) {
+				result := tt.results[calls]
+				calls++
+				if result != nil {
+					return "", result
+				}
+				return "ok", nil
+			})
+
+			if calls != tt.wantCalls {
+				t.Fatalf("query calls = %d, want %d", calls, tt.wantCalls)
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantErr == nil && output != "ok" {
+				t.Fatalf("output = %q, want ok", output)
+			}
+		})
+	}
+}
+
+func TestGatewayDNSResolutionFailure(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "could not resolve", err: errors.New("curl: (6) Could not resolve host: gateway"), want: true},
+		{name: "resolving timeout", err: errors.New("curl: (28) Resolving timed out after 2002 milliseconds"), want: true},
+		{name: "connection refused", err: errors.New("curl: (7) Failed to connect: Connection refused"), want: false},
+		{name: "connection reset", err: errors.New("curl: (56) Recv failure: Connection reset by peer"), want: false},
+		{name: "HTTP 503", err: errors.New("curl: (22) The requested URL returned error: 503"), want: false},
+		{name: "generic timeout", err: errors.New("curl: (28) Operation timed out after 33001 milliseconds"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isGatewayDNSResolutionFailure(tt.err); got != tt.want {
+				t.Fatalf("isGatewayDNSResolutionFailure(%v) = %t, want %t", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -2638,7 +2638,9 @@ func (r *GatewayBackgroundQueryRunner) Start(ctx context.Context) {
 }
 
 func (r *GatewayBackgroundQueryRunner) runQuery(ctx context.Context) {
-	output, err := RunQueryViaGateway(ctx, r.podName, r.instanceName, r.engineName, r.query)
+	output, err := retryGatewayQueryOnDNSFailure(ctx, func(ctx context.Context) (string, error) {
+		return RunQueryViaGateway(ctx, r.podName, r.instanceName, r.engineName, r.query)
+	})
 	if err != nil {
 		r.recordFailure("query_error", err.Error())
 		return
@@ -2656,6 +2658,53 @@ func (r *GatewayBackgroundQueryRunner) runQuery(ctx context.Context) {
 	}
 
 	r.successCount.Add(1)
+}
+
+const (
+	gatewayDNSQueryAttempts = 3
+	gatewayDNSRetryDelay    = 100 * time.Millisecond
+)
+
+// retryGatewayQueryOnDNSFailure keeps transient Kind/CoreDNS load out of the
+// zero-downtime signal. The gateway Service name is stable for the lifetime of
+// a test, so failing to resolve that name says nothing about an engine cutover.
+// Keep this allowlist narrow: connection and HTTP failures reached the data
+// plane and must remain immediate test failures.
+func retryGatewayQueryOnDNSFailure(ctx context.Context, query func(context.Context) (string, error)) (string, error) {
+	var (
+		output string
+		err    error
+	)
+	for attempt := 1; attempt <= gatewayDNSQueryAttempts; attempt++ {
+		output, err = query(ctx)
+		if err == nil || !isGatewayDNSResolutionFailure(err) || attempt == gatewayDNSQueryAttempts {
+			return output, err
+		}
+
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		timer := time.NewTimer(gatewayDNSRetryDelay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return "", ctx.Err()
+		case <-timer.C:
+		}
+	}
+
+	return output, err
+}
+
+func isGatewayDNSResolutionFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	detail := strings.ToLower(err.Error())
+	return strings.Contains(detail, "could not resolve host") ||
+		strings.Contains(detail, "resolving timed out")
 }
 
 func (r *GatewayBackgroundQueryRunner) recordFailure(category, detail string) {


### PR DESCRIPTION
**Background**

#199: The Helm wake-on-zero check can observe `spec.replicas=0` before pod termination and EndpointSlice reconciliation remove the serving address.

#206: The E2E background gateway sampler can mistake a transient Kind/CoreDNS lookup failure for an Operator data-plane outage.

**Summary**

- Wait up to 60 seconds for stopped-engine EndpointSlice addresses to disappear before asserting the parked-engine contract; retry transient EndpointSlice reads and dump namespace diagnostics on timeout.
- Retry background gateway queries only for explicit client-side DNS-resolution failures, with at most three attempts separated by 100 ms. HTTP errors, connection failures, and generic request timeouts remain immediate zero-downtime failures.
- Add focused retry-policy tests and document the zero-downtime assertion boundary for contributors.

Both changes are test-harness synchronization only. Production reconciliation and Gateway routing behavior are unchanged.

**Test Plan**

- `bash -n scripts/ci/verify-wake-on-zero.sh`
- `git diff --check`
- `go test -tags=e2e ./test/e2e -run "Test(RetryGatewayQueryOnDNSFailure|GatewayDNSResolutionFailure)$" -count=10`
- `uv run --with pyyaml make build`
- `uv run --with pyyaml make lint` (0 issues)
- [Final E2E run](https://github.com/firebolt-db/firebolt-kubernetes-operator/actions/runs/33496615406) passed both variants and the aggregate E2E gate on `b8c15e9`.
- [Final Helm run](https://github.com/firebolt-db/firebolt-kubernetes-operator/actions/runs/33496615553) passed `Verify wake-on-zero`, `test-helm`, and the aggregate Helm gate on `b8c15e9`.