### PR TITLE
fix(metadata): omit default_account_id and schema from the metadata-ng config (FB-3683)

### DIFF
--- a/docs/instance/metadata/overview.mdx
+++ b/docs/instance/metadata/overview.mdx
@@ -10,6 +10,8 @@ The metadata service stores and serves engine metadata. It uses PostgreSQL as th
 
 **Experimental:** `spec.metadataNG: true` selects metadata-ng configuration and UID/GID, but does not select the metadata image. Legacy behavior remains the default.
 
+The metadata-ng configuration carries only the keys that service acts on: the listen address and the PostgreSQL `host`, `port`, and `database`. `spec.id` and `spec.metadata.postgres.schema` are not rendered for it — the service is isolated by the configured database and lays its catalog out across its own schemas inside it — so a custom `schema` has no effect with `metadataNG: true`.
+
 ## External PostgreSQL TLS
 
 To verify an external PostgreSQL server certificate and hostname, configure

--- a/docs/instance/metadata/overview.mdx
+++ b/docs/instance/metadata/overview.mdx
@@ -10,7 +10,7 @@ The metadata service stores and serves engine metadata. It uses PostgreSQL as th
 
 **Experimental:** `spec.metadataNG: true` selects metadata-ng configuration and UID/GID, but does not select the metadata image. Legacy behavior remains the default.
 
-The metadata-ng configuration carries only the keys that service acts on: the listen address and the PostgreSQL `host`, `port`, and `database`. `spec.id` and `spec.metadata.postgres.schema` are not rendered for it — the service is isolated by the configured database and lays its catalog out across its own schemas inside it — so a custom `schema` has no effect with `metadataNG: true`.
+With `metadataNG: true`, `spec.metadata.postgres.schema` is not rendered: the service manages its own schemas inside the configured database.
 
 ## External PostgreSQL TLS
 

--- a/internal/controller/instance_metadata.go
+++ b/internal/controller/instance_metadata.go
@@ -83,7 +83,8 @@ func buildMetadataConfigYAML(instance *computev1alpha1.FireboltInstance) string 
 	pgDatabase := PostgresDBName
 	// Internal Postgres is bootstrapped with the default "public" schema and is
 	// not user-configurable; only the external-postgres path honors a custom
-	// schema below.
+	// schema below. The schema is rendered for the legacy service only — see
+	// the metadata-ng note further down.
 	pgSchema := PostgresDefaultSchema
 
 	if instance.Spec.Metadata.Postgres != nil {
@@ -109,13 +110,17 @@ func buildMetadataConfigYAML(instance *computev1alpha1.FireboltInstance) string 
 	// host/database/schema as defense-in-depth.
 	//
 	// Both metadata service generations load a YAML map rooted at pensieve_lite.
-	// metadata-ng intentionally omits legacy-only keepalive, garbage-collection,
-	// thread-count, and logging settings. The metadata-ng service either does not
-	// implement them or already uses the equivalent behavior, and warns when the
-	// legacy settings are present.
+	// metadata-ng renders only the keys that service acts on: the listen
+	// address and the PostgreSQL endpoint. It intentionally omits the
+	// legacy-only keepalive, garbage-collection, thread-count, and logging
+	// settings, and also `default_account_id` and `postgresql.schema`: the
+	// service is isolated by the configured PostgreSQL database (the engine
+	// supplies its instance identity on each request) and lays its catalog
+	// out across its own fixed schemas inside that database, so neither key
+	// has anything to map onto. Every omitted key is one the service would
+	// otherwise warn about at startup as accepted-but-ignored.
 	if instance.Spec.MetadataNG {
 		return fmt.Sprintf(`pensieve_lite:
-  default_account_id: %s
   host: 0.0.0.0
   port: %d
   metadata_storage:
@@ -123,10 +128,8 @@ func buildMetadataConfigYAML(instance *computev1alpha1.FireboltInstance) string 
       host: %s
       port: %d
       database: %s
-      schema: %s
 `,
-			yamlString(instance.Spec.ID), MetadataServicePort,
-			yamlString(pgHost), pgPort, yamlString(pgDatabase), yamlString(pgSchema))
+			MetadataServicePort, yamlString(pgHost), pgPort, yamlString(pgDatabase))
 	}
 
 	// The legacy metadata image loads YAML config since FB-2743; the document

--- a/internal/controller/instance_metadata.go
+++ b/internal/controller/instance_metadata.go
@@ -83,8 +83,7 @@ func buildMetadataConfigYAML(instance *computev1alpha1.FireboltInstance) string 
 	pgDatabase := PostgresDBName
 	// Internal Postgres is bootstrapped with the default "public" schema and is
 	// not user-configurable; only the external-postgres path honors a custom
-	// schema below. The schema is rendered for the legacy service only — see
-	// the metadata-ng note further down.
+	// schema below. Legacy service only; metadata-ng does not render it.
 	pgSchema := PostgresDefaultSchema
 
 	if instance.Spec.Metadata.Postgres != nil {
@@ -110,15 +109,10 @@ func buildMetadataConfigYAML(instance *computev1alpha1.FireboltInstance) string 
 	// host/database/schema as defense-in-depth.
 	//
 	// Both metadata service generations load a YAML map rooted at pensieve_lite.
-	// metadata-ng renders only the keys that service acts on: the listen
-	// address and the PostgreSQL endpoint. It intentionally omits the
-	// legacy-only keepalive, garbage-collection, thread-count, and logging
-	// settings, and also `default_account_id` and `postgresql.schema`: the
-	// service is isolated by the configured PostgreSQL database (the engine
-	// supplies its instance identity on each request) and lays its catalog
-	// out across its own fixed schemas inside that database, so neither key
-	// has anything to map onto. Every omitted key is one the service would
-	// otherwise warn about at startup as accepted-but-ignored.
+	// metadata-ng renders only the keys it acts on. It omits the legacy-only
+	// keepalive, garbage-collection, thread-count and logging settings, and
+	// default_account_id and postgresql.schema (it is isolated by database and
+	// manages its own schemas). It warns at startup about any of them.
 	if instance.Spec.MetadataNG {
 		return fmt.Sprintf(`pensieve_lite:
   host: 0.0.0.0

--- a/internal/controller/instance_metadata_test.go
+++ b/internal/controller/instance_metadata_test.go
@@ -528,10 +528,7 @@ func TestBuildMetadataConfigYAML_MetadataNG(t *testing.T) {
 		}
 	}
 
-	// Every key here is one the metadata-ng service accepts but does not act
-	// on, and warns about at startup when present. `default_account_id` and
-	// `schema` are the two the legacy template still renders for the legacy
-	// service; the rest are legacy-only tuning knobs.
+	// Keys the metadata-ng service ignores and warns about when present.
 	for _, legacyOnly := range []string{
 		"default_account_id",
 		"schema",
@@ -554,9 +551,7 @@ func TestBuildMetadataConfigYAML_MetadataNG(t *testing.T) {
 		t.Fatalf("metadata-ng config missing pensieve_lite root: %v", root)
 	}
 
-	// A custom external schema is a legacy-service concept; the metadata-ng
-	// service has nothing to map it onto, so it must not leak into the
-	// rendered document even when the CR sets one.
+	// A custom external schema must not leak into the metadata-ng document.
 	external := mkMetadataInstance()
 	external.Spec.MetadataNG = true
 	external.Spec.Metadata.Postgres = &computev1alpha1.PostgresSpec{

--- a/internal/controller/instance_metadata_test.go
+++ b/internal/controller/instance_metadata_test.go
@@ -519,18 +519,22 @@ func TestBuildMetadataConfigYAML_MetadataNG(t *testing.T) {
 	got := buildMetadataConfigYAML(inst)
 
 	for _, want := range []string{
-		`default_account_id: "acc-1"`,
 		`host: "inst-metadata-pg.ns-1.svc.cluster.local"`,
 		`port: 5432`,
 		`database: "firebolt_metadata"`,
-		`schema: "public"`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("expected %q in metadata-ng config; got:\n%s", want, got)
 		}
 	}
 
+	// Every key here is one the metadata-ng service accepts but does not act
+	// on, and warns about at startup when present. `default_account_id` and
+	// `schema` are the two the legacy template still renders for the legacy
+	// service; the rest are legacy-only tuning knobs.
 	for _, legacyOnly := range []string{
+		"default_account_id",
+		"schema",
 		"server_threads",
 		"log_level",
 		"keepalive",
@@ -548,6 +552,25 @@ func TestBuildMetadataConfigYAML_MetadataNG(t *testing.T) {
 	}
 	if _, ok := root["pensieve_lite"]; !ok {
 		t.Fatalf("metadata-ng config missing pensieve_lite root: %v", root)
+	}
+
+	// A custom external schema is a legacy-service concept; the metadata-ng
+	// service has nothing to map it onto, so it must not leak into the
+	// rendered document even when the CR sets one.
+	external := mkMetadataInstance()
+	external.Spec.MetadataNG = true
+	external.Spec.Metadata.Postgres = &computev1alpha1.PostgresSpec{
+		Host:                 "pg.example.com",
+		Database:             "fb",
+		Schema:               "firebolt_metadata",
+		CredentialsSecretRef: corev1.LocalObjectReference{Name: "creds"},
+	}
+	got = buildMetadataConfigYAML(external)
+	if strings.Contains(got, "schema") || strings.Contains(got, "firebolt_metadata") {
+		t.Errorf("external schema must not be rendered for metadata-ng; got:\n%s", got)
+	}
+	if !strings.Contains(got, `host: "pg.example.com"`) || !strings.Contains(got, `database: "fb"`) {
+		t.Errorf("external endpoint must still be rendered for metadata-ng; got:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
**Background**

FB-3683: metadata-ng pods warn at startup about `pensieve_lite.metadata_storage.postgresql.schema` and `pensieve_lite.default_account_id`, two keys the service ignores.

**Summary**

Stop rendering `default_account_id` and `postgresql.schema` when `spec.metadataNG` is true. The legacy template is unchanged. No CRD change. Existing metadata-ng deployments roll once (config hash).

**Test Plan**

- `TestBuildMetadataConfigYAML_MetadataNG`: asserts both keys are absent, including when the CR sets a custom `schema`.
- `go test ./internal/controller/ ./api/...`, `go vet` pass.
- PensieveDuck side: firebolt-analytics/packdb#25415.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-ng-only config template change; legacy path untouched. Existing metadata-ng instances roll once via config hash with no CRD or credential changes.
> 
> **Overview**
> When **`spec.metadataNG: true`**, the operator’s generated `pensieve_lite` config no longer includes **`default_account_id`** or **`metadata_storage.postgresql.schema`**, including when the CR sets a custom external Postgres schema. Legacy metadata config is unchanged.
> 
> Docs note that metadata-ng manages its own schemas in the configured database. Tests lock in the slimmer YAML and that host/database still render for external Postgres.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b43f996daa8aa7d411cfcfe93c240744fe5945d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->