### PR TITLE
feat(controller): render a pensieve_duck config document for metadata-ng (FB-3701)

### DIFF
--- a/api/v1alpha1/fireboltinstance_types.go
+++ b/api/v1alpha1/fireboltinstance_types.go
@@ -180,10 +180,12 @@ type PostgresSpec struct {
 	// +kubebuilder:validation:Pattern=`^[A-Za-z0-9_.\-]+$`
 	Database string `json:"database"`
 
-	// Schema is the PostgreSQL schema used by the metadata service.
+	// Schema is the PostgreSQL schema used by the legacy metadata service.
 	// Defaults to "public". Allowed characters are letters, digits, "_",
 	// ".", and "-". XML metacharacters are rejected at admission time to
 	// prevent injection into the rendered metadata config.
+	// Not rendered when spec.metadataNG is true: that service lays its
+	// catalog out across its own schemas inside the configured database.
 	// +kubebuilder:default=public
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63

--- a/config/crd/bases/compute.firebolt.io_fireboltinstances.yaml
+++ b/config/crd/bases/compute.firebolt.io_fireboltinstances.yaml
@@ -9084,10 +9084,12 @@ spec:
                       schema:
                         default: public
                         description: |-
-                          Schema is the PostgreSQL schema used by the metadata service.
+                          Schema is the PostgreSQL schema used by the legacy metadata service.
                           Defaults to "public". Allowed characters are letters, digits, "_",
                           ".", and "-". XML metacharacters are rejected at admission time to
                           prevent injection into the rendered metadata config.
+                          Not rendered when spec.metadataNG is true: that service lays its
+                          catalog out across its own schemas inside the configured database.
                         maxLength: 63
                         minLength: 1
                         pattern: ^[A-Za-z0-9_.\-]+$

--- a/docs/instance/metadata/overview.mdx
+++ b/docs/instance/metadata/overview.mdx
@@ -10,6 +10,8 @@ The metadata service stores and serves engine metadata. It uses PostgreSQL as th
 
 **Experimental:** `spec.metadataNG: true` selects metadata-ng configuration and UID/GID, but does not select the metadata image. Legacy behavior remains the default.
 
+The two services read different configuration documents. The legacy service reads a `pensieve_lite` document; metadata-ng reads a `pensieve_duck` document carrying only the listen address and the PostgreSQL `host`, `port`, and `database`, and rejects any other key at startup. `spec.id` and `spec.metadata.postgres.schema` are not rendered for metadata-ng: the service is isolated by the configured database and lays its catalog out across its own schemas inside it, so a custom `schema` has no effect with `metadataNG: true`.
+
 ## External PostgreSQL TLS
 
 To verify an external PostgreSQL server certificate and hostname, configure

--- a/helm/firebolt-operator-crds/json-schema/fireboltinstance_v1alpha1.json
+++ b/helm/firebolt-operator-crds/json-schema/fireboltinstance_v1alpha1.json
@@ -7598,7 +7598,7 @@
                 },
                 "schema": {
                   "default": "public",
-                  "description": "Schema is the PostgreSQL schema used by the metadata service.\nDefaults to \"public\". Allowed characters are letters, digits, \"_\",\n\".\", and \"-\". XML metacharacters are rejected at admission time to\nprevent injection into the rendered metadata config.",
+                  "description": "Schema is the PostgreSQL schema used by the legacy metadata service.\nDefaults to \"public\". Allowed characters are letters, digits, \"_\",\n\".\", and \"-\". XML metacharacters are rejected at admission time to\nprevent injection into the rendered metadata config.\nNot rendered when spec.metadataNG is true: that service lays its\ncatalog out across its own schemas inside the configured database.",
                   "maxLength": 63,
                   "minLength": 1,
                   "pattern": "^[A-Za-z0-9_.\\-]+$",

--- a/helm/firebolt-operator-crds/templates/fireboltinstances.yaml
+++ b/helm/firebolt-operator-crds/templates/fireboltinstances.yaml
@@ -4337,10 +4337,12 @@ spec:
                       schema:
                         default: public
                         description: |-
-                          Schema is the PostgreSQL schema used by the metadata service.
+                          Schema is the PostgreSQL schema used by the legacy metadata service.
                           Defaults to "public". Allowed characters are letters, digits, "_",
                           ".", and "-". XML metacharacters are rejected at admission time to
                           prevent injection into the rendered metadata config.
+                          Not rendered when spec.metadataNG is true: that service lays its
+                          catalog out across its own schemas inside the configured database.
                         maxLength: 63
                         minLength: 1
                         pattern: ^[A-Za-z0-9_.\-]+$

--- a/helm/firebolt-operator/crds/fireboltinstances.yaml
+++ b/helm/firebolt-operator/crds/fireboltinstances.yaml
@@ -4337,10 +4337,12 @@ spec:
                       schema:
                         default: public
                         description: |-
-                          Schema is the PostgreSQL schema used by the metadata service.
+                          Schema is the PostgreSQL schema used by the legacy metadata service.
                           Defaults to "public". Allowed characters are letters, digits, "_",
                           ".", and "-". XML metacharacters are rejected at admission time to
                           prevent injection into the rendered metadata config.
+                          Not rendered when spec.metadataNG is true: that service lays its
+                          catalog out across its own schemas inside the configured database.
                         maxLength: 63
                         minLength: 1
                         pattern: ^[A-Za-z0-9_.\-]+$

--- a/internal/controller/instance_metadata.go
+++ b/internal/controller/instance_metadata.go
@@ -83,7 +83,8 @@ func buildMetadataConfigYAML(instance *computev1alpha1.FireboltInstance) string 
 	pgDatabase := PostgresDBName
 	// Internal Postgres is bootstrapped with the default "public" schema and is
 	// not user-configurable; only the external-postgres path honors a custom
-	// schema below.
+	// schema below. The schema is rendered for the legacy service only — see
+	// the metadata-ng note further down.
 	pgSchema := PostgresDefaultSchema
 
 	if instance.Spec.Metadata.Postgres != nil {
@@ -108,14 +109,14 @@ func buildMetadataConfigYAML(instance *computev1alpha1.FireboltInstance) string 
 	// configuration. The CRD also applies a Pattern admission check on
 	// host/database/schema as defense-in-depth.
 	//
-	// Both metadata service generations load a YAML map rooted at pensieve_lite.
-	// metadata-ng intentionally omits legacy-only keepalive, garbage-collection,
-	// thread-count, and logging settings. The metadata-ng service either does not
-	// implement them or already uses the equivalent behavior, and warns when the
-	// legacy settings are present.
+	// The two metadata service generations read different documents. metadata-ng
+	// reads a map rooted at pensieve_duck carrying only the keys it acts on — the
+	// listen address and the PostgreSQL endpoint — and rejects any other key at
+	// startup. It does not read `default_account_id` or `postgresql.schema`: the
+	// service is isolated by the configured PostgreSQL database and lays its
+	// catalog out across its own schemas inside it.
 	if instance.Spec.MetadataNG {
-		return fmt.Sprintf(`pensieve_lite:
-  default_account_id: %s
+		return fmt.Sprintf(`pensieve_duck:
   host: 0.0.0.0
   port: %d
   metadata_storage:
@@ -123,14 +124,11 @@ func buildMetadataConfigYAML(instance *computev1alpha1.FireboltInstance) string 
       host: %s
       port: %d
       database: %s
-      schema: %s
 `,
-			yamlString(instance.Spec.ID), MetadataServicePort,
-			yamlString(pgHost), pgPort, yamlString(pgDatabase), yamlString(pgSchema))
+			MetadataServicePort, yamlString(pgHost), pgPort, yamlString(pgDatabase))
 	}
 
-	// The legacy metadata image loads YAML config since FB-2743; the document
-	// root must be a YAML map (a scalar/sequence root is rejected).
+	// The legacy metadata service reads a map rooted at pensieve_lite.
 	return fmt.Sprintf(`pensieve_lite:
   default_account_id: %s
   host: 0.0.0.0

--- a/internal/controller/instance_metadata_test.go
+++ b/internal/controller/instance_metadata_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -519,18 +520,23 @@ func TestBuildMetadataConfigYAML_MetadataNG(t *testing.T) {
 	got := buildMetadataConfigYAML(inst)
 
 	for _, want := range []string{
-		`default_account_id: "acc-1"`,
+		"host: 0.0.0.0",
+		fmt.Sprintf("port: %d", MetadataServicePort),
 		`host: "inst-metadata-pg.ns-1.svc.cluster.local"`,
 		`port: 5432`,
 		`database: "firebolt_metadata"`,
-		`schema: "public"`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("expected %q in metadata-ng config; got:\n%s", want, got)
 		}
 	}
 
+	// metadata-ng rejects any key it does not act on, so none of the legacy
+	// service's keys may appear — not even ones the legacy template renders
+	// from the CR (`default_account_id`, `schema`).
 	for _, legacyOnly := range []string{
+		"default_account_id",
+		"schema",
 		"server_threads",
 		"log_level",
 		"keepalive",
@@ -546,8 +552,53 @@ func TestBuildMetadataConfigYAML_MetadataNG(t *testing.T) {
 	if err := yaml.Unmarshal([]byte(got), &root); err != nil {
 		t.Fatalf("metadata-ng config must be valid YAML: %v\n%s", err, got)
 	}
+	if len(root) != 1 {
+		t.Fatalf("metadata-ng config must have exactly one root key; got %v", root)
+	}
+	if _, ok := root["pensieve_duck"]; !ok {
+		t.Fatalf("metadata-ng config missing pensieve_duck root: %v", root)
+	}
+	if _, ok := root["pensieve_lite"]; ok {
+		t.Fatalf("metadata-ng config must not carry the legacy pensieve_lite root: %v", root)
+	}
+
+	// A custom external schema is a legacy-service concept; it must not leak
+	// into the metadata-ng document even when the CR sets one, while the
+	// endpoint itself still must.
+	external := mkMetadataInstance()
+	external.Spec.MetadataNG = true
+	external.Spec.Metadata.Postgres = &computev1alpha1.PostgresSpec{
+		Host:                 "pg.example.com",
+		Database:             "fb",
+		Schema:               "firebolt_metadata",
+		CredentialsSecretRef: corev1.LocalObjectReference{Name: "creds"},
+	}
+	got = buildMetadataConfigYAML(external)
+	if strings.Contains(got, "schema") || strings.Contains(got, "firebolt_metadata") {
+		t.Errorf("external schema must not be rendered for metadata-ng; got:\n%s", got)
+	}
+	if !strings.Contains(got, `host: "pg.example.com"`) || !strings.Contains(got, `database: "fb"`) {
+		t.Errorf("external endpoint must still be rendered for metadata-ng; got:\n%s", got)
+	}
+}
+
+func TestBuildMetadataConfigYAML_LegacyKeepsPensieveLiteRoot(t *testing.T) {
+	got := buildMetadataConfigYAML(mkMetadataInstance())
+
+	var root map[string]any
+	if err := yaml.Unmarshal([]byte(got), &root); err != nil {
+		t.Fatalf("legacy config must be valid YAML: %v\n%s", err, got)
+	}
 	if _, ok := root["pensieve_lite"]; !ok {
-		t.Fatalf("metadata-ng config missing pensieve_lite root: %v", root)
+		t.Fatalf("legacy config missing pensieve_lite root: %v", root)
+	}
+	if _, ok := root["pensieve_duck"]; ok {
+		t.Fatalf("legacy config must not carry the pensieve_duck root: %v", root)
+	}
+	for _, want := range []string{`default_account_id: "acc-1"`, `schema: "public"`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in legacy config; got:\n%s", want, got)
+		}
 	}
 }
 


### PR DESCRIPTION
**Background**

FB-3701: The metadata-ng service reads a YAML document rooted at `pensieve_duck` and rejects any key it does not act on. The operator rendered the legacy `pensieve_lite` document for it.

**Summary**

With `spec.metadataNG: true`, `buildMetadataConfigYAML` now renders a `pensieve_duck` document carrying the listen address and the PostgreSQL host, port and database. `default_account_id` and `postgresql.schema` are not rendered for metadata-ng, since the service does not read them. The legacy service keeps its `pensieve_lite` document unchanged. CRD field docs and the metadata overview page note the difference.

**Test Plan**

- `TestBuildMetadataConfigYAML_MetadataNG`: single `pensieve_duck` root, endpoint keys present, no legacy-only keys, a custom external `schema` is not rendered.
- `TestBuildMetadataConfigYAML_LegacyKeepsPensieveLiteRoot`: legacy output unchanged.
- `make manifests`, `go vet`, `go test ./internal/controller/`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rendered metadata ConfigMap content for the experimental metadata-ng path; a bad document would block metadata pods from starting, but legacy instances are unaffected.
> 
> **Overview**
> With **`spec.metadataNG: true`**, the operator now emits a **`pensieve_duck`** YAML config instead of the legacy **`pensieve_lite`** document. metadata-ng only gets the listen address and PostgreSQL **host**, **port**, and **database**; **`default_account_id`**, **`postgresql.schema`**, and other legacy-only keys are omitted because the service rejects unknown keys at startup.
> 
> The legacy path is unchanged: it still renders **`pensieve_lite`** with **`spec.id`**, schema, and the full legacy template. CRD field comments, generated CRDs/JSON schema, and the metadata overview doc now describe that **`spec.metadata.postgres.schema`** applies only to legacy metadata and has no effect when metadata-ng is enabled.
> 
> Tests assert the correct root key per mode, absence of legacy keys in metadata-ng output (including when an external schema is set on the CR), and unchanged legacy behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a38119ffc4f5c0cc5fa9df19b5470f978c1baea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->