### PR TITLE
fix(controller): cap engine metrics scrape body at 1MiB (FB-2539)

### DIFF
--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -154,7 +154,9 @@ so the chart's manager RBAC does not include that verb. Setting
 `rbac.apiserverProxyGrant=true` on the Firebolt Operator chart, which
 renders a dedicated `ClusterRole` (or per-namespace `Role` when
 `watchNamespaces` is set) granting only that one verb. Without the
-toggle, the metric scrape surfaces as a 403 from the apiserver.
+toggle, the metric scrape surfaces as a 403 from the apiserver. Either
+transport caps a single engine `/metrics` body at 1 MiB and fails the
+scrape if the body is larger.
 
 Resource maxima on the engine container's `resources` block (set
 under `FireboltEngine.spec.template.spec.containers[name=="engine"]`

--- a/internal/controller/engine_scrape.go
+++ b/internal/controller/engine_scrape.go
@@ -44,6 +44,14 @@ const MetricScrapeModeDefault = computev1alpha1.MetricScrapeModePodIP
 // sync.Mutex during shutdown is the classic case).
 const scrapeTimeout = 10 * time.Second
 
+// maxMetricsResponseBytes caps a single engine /metrics body. Generous for
+// a multi-thousand-line exposition and bounded against a compromised pod
+// that streams an unbounded HTTP 200. Matching maxDemandResponseBytes keeps
+// the two pod-sourced HTTP reads on the same ceiling. Crossing the cap
+// fails the scrape (drain / autostop fail closed) rather than silently
+// truncating, because the two gauges can sit anywhere in the body.
+const maxMetricsResponseBytes = 1 << 20
+
 // refuseRedirects stops pod-IP scrapers from following Location headers.
 // A compromised or spoofed pod can return a 3xx pointing at cloud metadata
 // or other internal endpoints; chasing it would turn the operator process
@@ -162,7 +170,11 @@ func (s *podIPScraper) Scrape(ctx context.Context, pod *corev1.Pod) ([]byte, err
 		return nil, fmt.Errorf("scrape from pod %s returned %s: %s",
 			pod.Name, resp.Status, string(body))
 	}
-	return io.ReadAll(resp.Body)
+	body, err := readCappedMetricsBody(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("scraping metrics from pod %s at %s: %w", pod.Name, url, err)
+	}
+	return body, nil
 }
 
 // apiserverProxyScraper routes the GET through the apiserver pods/proxy
@@ -185,13 +197,23 @@ func (s *apiserverProxyScraper) Scrape(ctx context.Context, pod *corev1.Pod) ([]
 	if s.clientset == nil {
 		return nil, errors.New("clientset not initialized")
 	}
-	return s.clientset.CoreV1().RESTClient().Get().
-		Namespace(pod.Namespace).
-		Resource("pods").
-		Name(fmt.Sprintf("%s:%d", pod.Name, MetricsPort)).
-		SubResource("proxy").
-		Suffix(MetricsPath).
-		DoRaw(ctx)
+	// Streamed and capped rather than DoRaw'd, matching the wake-demand
+	// proxy path. The body comes from a pod anyone with engine-template
+	// write can stand up, so an unbounded read is a memory-pressure lever
+	// on the shared operator process.
+	stream, err := s.clientset.CoreV1().
+		Pods(pod.Namespace).
+		ProxyGet("http", pod.Name, strconv.Itoa(MetricsPort), trimLeadingSlash(MetricsPath), nil).
+		Stream(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("proxy scrape of %s/%s: %w", pod.Namespace, pod.Name, err)
+	}
+	defer func() { _ = stream.Close() }()
+	body, err := readCappedMetricsBody(stream)
+	if err != nil {
+		return nil, fmt.Errorf("proxy scrape of %s/%s: %w", pod.Namespace, pod.Name, err)
+	}
+	return body, nil
 }
 
 // unknownModeScraper is the fail-closed branch: every Scrape call errors.
@@ -212,6 +234,20 @@ func (s *unknownModeScraper) Scrape(_ context.Context, _ *corev1.Pod) ([]byte, e
 		return nil, fmt.Errorf("unsupported MetricScrapeMode %q: %s", s.mode, s.reason)
 	}
 	return nil, fmt.Errorf("unknown MetricScrapeMode %q", s.mode)
+}
+
+// readCappedMetricsBody reads at most maxMetricsResponseBytes+1 from r and
+// errors if the body is larger than the cap. The extra byte distinguishes
+// "exactly at the cap" from "truncated an unbounded stream".
+func readCappedMetricsBody(r io.Reader) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, maxMetricsResponseBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxMetricsResponseBytes {
+		return nil, fmt.Errorf("metrics response exceeds %d bytes", maxMetricsResponseBytes)
+	}
+	return data, nil
 }
 
 // trimLeadingSlash drops one leading '/' so MetricsPath joined onto a

--- a/internal/controller/engine_scrape_test.go
+++ b/internal/controller/engine_scrape_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package controller
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -126,6 +128,88 @@ func TestPodIPScraper_MissingPodIP(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no PodIP") {
 		t.Errorf("error wording: %v", err)
+	}
+}
+
+func TestReadCappedMetricsBody_AtLimit(t *testing.T) {
+	t.Parallel()
+	want := bytes.Repeat([]byte("m"), maxMetricsResponseBytes)
+	got, err := readCappedMetricsBody(bytes.NewReader(want))
+	if err != nil {
+		t.Fatalf("readCappedMetricsBody(limit): %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("body: got %d bytes, want %d", len(got), len(want))
+	}
+}
+
+func TestReadCappedMetricsBody_OverLimit(t *testing.T) {
+	t.Parallel()
+	// Offer more than the cap so a silent truncate would still return
+	// maxMetricsResponseBytes without error. The helper must refuse.
+	src := bytes.Repeat([]byte("m"), maxMetricsResponseBytes+4096)
+	got, err := readCappedMetricsBody(bytes.NewReader(src))
+	if err == nil {
+		t.Fatalf("expected error for oversized body, got %d bytes", len(got))
+	}
+	if !strings.Contains(err.Error(), strconv.Itoa(maxMetricsResponseBytes)) {
+		t.Errorf("error should name the cap, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("oversized read must not return a body, got %d bytes", len(got))
+	}
+}
+
+func TestPodIPScraper_RejectsOversizedBody(t *testing.T) {
+	t.Parallel()
+	gauges := "firebolt_running_queries 0\nfirebolt_suspended_queries 0\n"
+	// Stream well past the cap; the client must stop and error rather
+	// than buffer the whole response.
+	oversize := gauges + strings.Repeat("# pad\n", (maxMetricsResponseBytes/len("# pad\n"))+8)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, oversize)
+	}))
+	t.Cleanup(server.Close)
+
+	host, _ := hostPortFromURL(t, server.URL)
+	scraper := fixedPortPodIPScraper(strings.TrimPrefix(server.URL, "http://"))
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "engine-0", Namespace: "ns"},
+		Status:     corev1.PodStatus{PodIP: host, Phase: corev1.PodRunning},
+	}
+	got, err := scraper.Scrape(context.Background(), pod)
+	if err == nil {
+		t.Fatalf("expected oversized /metrics to fail, got %d bytes", len(got))
+	}
+	if !strings.Contains(err.Error(), strconv.Itoa(maxMetricsResponseBytes)) {
+		t.Errorf("error should name the cap, got %v", err)
+	}
+}
+
+func TestPodIPScraper_AcceptsBodyAtCap(t *testing.T) {
+	t.Parallel()
+	gauges := "firebolt_running_queries 0\nfirebolt_suspended_queries 0\n"
+	if len(gauges) > maxMetricsResponseBytes {
+		t.Fatal("gauge preamble longer than cap")
+	}
+	body := gauges + strings.Repeat("x", maxMetricsResponseBytes-len(gauges))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(server.Close)
+
+	host, _ := hostPortFromURL(t, server.URL)
+	scraper := fixedPortPodIPScraper(strings.TrimPrefix(server.URL, "http://"))
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "engine-0", Namespace: "ns"},
+		Status:     corev1.PodStatus{PodIP: host, Phase: corev1.PodRunning},
+	}
+	got, err := scraper.Scrape(context.Background(), pod)
+	if err != nil {
+		t.Fatalf("scrape at cap: %v", err)
+	}
+	if string(got) != body {
+		t.Fatalf("body: got %d bytes, want %d", len(got), len(body))
 	}
 }
 


### PR DESCRIPTION
**Background**

FB-2539: a buggy, compromised or attacker-supplied engine `/metrics` handler can OOM the shared operator because the success-path scrape read is unbounded.

**Summary**

Both metric-scrape transports now share `readCappedMetricsBody`, which refuses a body larger than 1 MiB (`1 << 20`, the same ceiling as the wake-demand client).

- PodIP still bounds non-200 bodies at 512 bytes and now caps HTTP 200 the same way.
- ApiserverProxy switches from `DoRaw` to `ProxyGet(...).Stream`, matching the wake-demand proxy path, so the cap applies there too.
- Crossing the cap fails the scrape instead of silently truncating. The two drain/autostop gauges can sit anywhere in the exposition, so a prefix would look like "metrics missing." Drain and autostop already fail closed on scrape error (`DrainCheckFailing` / treat the poll as activity).

Timeouts and redirect refusal were already in place and do not bound memory. Going forward, a single engine cannot force the operator process to buffer an arbitrary `/metrics` body.

**Test Plan**

- [x] `go test ./internal/controller/ -count=1 -run 'TestReadCappedMetricsBody|TestPodIPScraper|TestScrapeHTTPClientsRefuseRedirects'`
- [x] `make build && make lint`
- [ ] Confirm a body of exactly 1 MiB still scrapes; 1 MiB + 1 byte errors and names the cap (covered by the new unit tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes memory-bounded behavior on a security-sensitive code path (pod-sourced HTTP); oversized legitimate metrics would now fail drain/autostop scrapes instead of succeeding.
> 
> **Overview**
> **Hardens the operator against unbounded `/metrics` reads** that could OOM the shared controller process when an engine pod returns an oversized HTTP 200.
> 
> Both **PodIP** and **ApiserverProxy** scrapes now share `readCappedMetricsBody`, which allows bodies up to **1 MiB** (`maxMetricsResponseBytes`, aligned with the wake-demand client ceiling) and **fails the scrape** if the response is larger—no silent truncation, since drain/autostop gauges can appear anywhere in the exposition.
> 
> The **apiserver proxy** path switches from `DoRaw` to **streamed** `ProxyGet(...).Stream` plus the same cap, matching the wake-demand proxy pattern. **Security docs** note that either transport enforces this limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17c4dd4a6efc0e5e0c30efe3e978cf8178501d04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->