### PR TITLE
fix(controller): answer /healthz with any query string at the gateway (FB-3826)

### DIFF
--- a/docs/engine/auto-stop-and-wake-up.mdx
+++ b/docs/engine/auto-stop-and-wake-up.mdx
@@ -77,7 +77,7 @@ spec:
 
 Wake-up works only for queries sent through the Instance Gateway. Traffic that bypasses the Gateway is unsupported and cannot wake a stopped Engine because the Engine Service has no endpoints.
 
-The Gateway answers its `/healthz` endpoint itself, before any wake handling, so health checks and uptime monitors pointed at the Gateway never wake a stopped Engine.
+The Gateway answers its `/healthz` endpoint itself, before any wake handling, so health checks and uptime monitors pointed at the Gateway never wake a stopped Engine. A query string on that path is ignored, not routed: `/healthz`, `/healthz?`, and `/healthz?anything=value` are answered identically, and none of them registers wake demand or reaches an Engine. Any other path, including `/healthz/`, is treated as an Engine request, so one that names a stopped Engine wakes it.
 
 Set `wakeAgent.enabled=false` in the Helm values to disable Gateway wake-up. Queries to running Engines are unaffected; a query for a stopped Engine returns `503`.
 

--- a/internal/controller/instance_gateway.go
+++ b/internal/controller/instance_gateway.go
@@ -68,6 +68,14 @@ const (
 	gatewayServicePort   int32 = 80
 	gatewayConfigKey           = "envoy.yaml"
 
+	// gatewayHealthPathMatchRegex is what every health_check filter matches
+	// ":path" against. The query string is part of that header, and route
+	// matching everywhere upstream ignores it, so a bare-path match leaves
+	// "/healthz?engine=<name>" to fall through into the Lua wake path, where
+	// it registers wake demand for the engine it names. Envoy matches a
+	// regex against the whole header value.
+	gatewayHealthPathMatchRegex = `^/healthz(\?.*)?$`
+
 	// gatewayWakeAgentHoldPort is the loopback port the wake-agent serves
 	// its hold endpoint on. Bound to 127.0.0.1 inside the pod, so it is
 	// reachable from Envoy and from nothing else.
@@ -796,7 +804,8 @@ func buildEnvoyConfigYAML(instance *computev1alpha1.FireboltInstance, wakeEnable
                       headers:
                         - name: ":path"
                           string_match:
-                            exact: "/healthz"
+                            safe_regex:
+                              regex: '`+gatewayHealthPathMatchRegex+`'
                   - name: envoy.filters.http.lua
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
@@ -1054,7 +1063,8 @@ func buildEnvoyConfigYAML(instance *computev1alpha1.FireboltInstance, wakeEnable
                       headers:
                         - name: ":path"
                           string_match:
-                            exact: "/healthz"
+                            safe_regex:
+                              regex: '`+gatewayHealthPathMatchRegex+`'
                   - name: envoy.filters.http.router
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -1320,7 +1330,8 @@ func buildFailClosedEnvoyConfigYAML(instance *computev1alpha1.FireboltInstance) 
                       headers:
                         - name: ":path"
                           string_match:
-                            exact: "/healthz"
+                            safe_regex:
+                              regex: '`+gatewayHealthPathMatchRegex+`'
                   - name: envoy.filters.http.router
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/internal/controller/instance_gateway_test.go
+++ b/internal/controller/instance_gateway_test.go
@@ -1638,3 +1638,175 @@ func TestGatewayEnvoyPreStopDrain(t *testing.T) {
 		t.Errorf("Args = %v, want an immediate zero-time drain so kept-alive connections close as their work finishes", envoy.Args)
 	}
 }
+
+// TestBuildEnvoyConfigYAMLHealthPathIgnoresQueryString pins the gateway's
+// health contract: /healthz is answered by the health-check filter whatever
+// query string it carries, and nothing else is. Envoy matches ":path"
+// including the query, so a matcher that only accepts the bare path lets
+// "/healthz?engine=<name>" past the filter and into the Lua wake path, where
+// it registers wake demand — an unauthenticated caller can then wake parked
+// engines at will. Every health-check filter in the config is checked, so the
+// client listener and the always-present stats listener cannot drift apart.
+func TestBuildEnvoyConfigYAMLHealthPathIgnoresQueryString(t *testing.T) {
+	healthPaths := []string{
+		"/healthz",
+		"/healthz?",
+		"/healthz?x=1",
+		"/healthz?engine=eng",
+		"/healthz?a=1&b=2",
+	}
+	otherPaths := []string{
+		"/",
+		"/?engine=eng",
+		"/query?engine=eng",
+		"/healthzz",
+		"/healthz/",
+		"/healthz/?x=1",
+		"/HEALTHZ",
+		"//healthz",
+		"/healthz%3Fx=1",
+	}
+
+	for _, tc := range []struct {
+		name          string
+		instance      *computev1alpha1.FireboltInstance
+		wantListeners []string
+	}{
+		{
+			name: "client and stats listeners",
+			instance: &computev1alpha1.FireboltInstance{
+				ObjectMeta: metav1.ObjectMeta{Name: "inst", Namespace: "ns-1"},
+				Spec: computev1alpha1.FireboltInstanceSpec{
+					Gateway: computev1alpha1.GatewaySpec{MetricsPort: 9090},
+				},
+			},
+			wantListeners: []string{gatewayQueryListenerName, "stats_listener"},
+		},
+		{
+			// Gateway TLS requested but not issued: only the stats listener
+			// is rendered, and its /healthz still carries the liveness probe.
+			name: "fail-closed stats listener",
+			instance: &computev1alpha1.FireboltInstance{
+				ObjectMeta: metav1.ObjectMeta{Name: "inst", Namespace: "ns-1"},
+				Spec: computev1alpha1.FireboltInstanceSpec{
+					Gateway: computev1alpha1.GatewaySpec{MetricsPort: 9090},
+					TLS: &computev1alpha1.TLSSpec{
+						Gateway: &computev1alpha1.TLSListenerSpec{Enabled: true},
+					},
+				},
+			},
+			wantListeners: []string{"stats_listener"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var parsed map[string]any
+			if err := yaml.Unmarshal([]byte(buildEnvoyConfigYAML(tc.instance, true)), &parsed); err != nil {
+				t.Fatalf("emitted envoy config is not valid YAML: %v", err)
+			}
+			matchers := healthCheckPathMatchers(t, parsed)
+			var got []string
+			for _, m := range matchers {
+				got = append(got, m.listener)
+			}
+			slices.Sort(got)
+			want := slices.Clone(tc.wantListeners)
+			slices.Sort(want)
+			if !slices.Equal(got, want) {
+				t.Fatalf("listeners carrying a health-check :path matcher = %v, want %v", got, want)
+			}
+			for _, m := range matchers {
+				listener, matcher := m.listener, m.matcher
+				for _, path := range healthPaths {
+					if !stringMatcherAccepts(t, matcher, path) {
+						t.Errorf("%s: health-check filter does not answer %q, so it falls through to engine routing",
+							listener, path)
+					}
+				}
+				for _, path := range otherPaths {
+					if stringMatcherAccepts(t, matcher, path) {
+						t.Errorf("%s: health-check filter answers %q, which is not the health endpoint",
+							listener, path)
+					}
+				}
+			}
+		})
+	}
+}
+
+// healthPathMatcher is one health_check filter's ":path" string_match and the
+// listener it was rendered on.
+type healthPathMatcher struct {
+	listener string
+	matcher  map[string]any
+}
+
+// healthCheckPathMatchers returns the ":path" string_match of every
+// health_check HTTP filter in the emitted config. One entry per filter, so a
+// listener carrying two of them is visible rather than collapsed.
+func healthCheckPathMatchers(t *testing.T, parsed map[string]any) []healthPathMatcher {
+	t.Helper()
+	var matchers []healthPathMatcher
+	listeners := parsed["static_resources"].(map[string]any)["listeners"].([]any)
+	for _, l := range listeners {
+		lm := l.(map[string]any)
+		name, _ := lm["name"].(string)
+		for _, chain := range lm["filter_chains"].([]any) {
+			for _, f := range chain.(map[string]any)["filters"].([]any) {
+				hcm := f.(map[string]any)["typed_config"].(map[string]any)
+				httpFilters, ok := hcm["http_filters"].([]any)
+				if !ok {
+					continue
+				}
+				for _, hf := range httpFilters {
+					hfm := hf.(map[string]any)
+					if hfm["name"] != "envoy.filters.http.health_check" {
+						continue
+					}
+					headers, ok := hfm["typed_config"].(map[string]any)["headers"].([]any)
+					if !ok || len(headers) != 1 {
+						t.Fatalf("listener %s: health_check filter headers = %v, want exactly one matcher",
+							name, hfm["typed_config"].(map[string]any)["headers"])
+					}
+					header := headers[0].(map[string]any)
+					if header["name"] != ":path" {
+						t.Fatalf("listener %s: health_check matches header %v, want \":path\"", name, header["name"])
+					}
+					sm, ok := header["string_match"].(map[string]any)
+					if !ok {
+						t.Fatalf("listener %s: health_check :path string_match missing or wrong type: %T",
+							name, header["string_match"])
+					}
+					matchers = append(matchers, healthPathMatcher{listener: name, matcher: sm})
+				}
+			}
+		}
+	}
+	return matchers
+}
+
+// stringMatcherAccepts evaluates an Envoy StringMatcher against a value, so
+// the health contract is asserted as behavior rather than as config shape.
+// safe_regex is anchored because Envoy matches a regex against the entire
+// input, while Go's MatchString reports a substring hit.
+func stringMatcherAccepts(t *testing.T, matcher map[string]any, value string) bool {
+	t.Helper()
+	if exact, ok := matcher["exact"].(string); ok {
+		return value == exact
+	}
+	if prefix, ok := matcher["prefix"].(string); ok {
+		return strings.HasPrefix(value, prefix)
+	}
+	if re, ok := matcher["safe_regex"].(map[string]any); ok {
+		rx, ok := re["regex"].(string)
+		if !ok {
+			t.Fatalf("safe_regex.regex missing or wrong type: %T", re["regex"])
+		}
+		compiled, err := regexp.Compile(`\A(?:` + rx + `)\z`)
+		if err != nil {
+			t.Fatalf("safe_regex.regex %q does not compile: %v", rx, err)
+		}
+		return compiled.MatchString(value)
+	}
+	t.Fatalf("unsupported string_match %v", keysOf(matcher))
+	return false
+}

--- a/scripts/ci/verify-wake-on-zero.sh
+++ b/scripts/ci/verify-wake-on-zero.sh
@@ -19,12 +19,12 @@ set -euo pipefail
 # survives.
 #
 # The negative half of the same contract is pinned here too, while the engine
-# is parked: a health probe on the gateway's /healthz is answered by the
-# health-check filter ahead of the wake filter, so it never registers demand
-# and never wakes the engine. Both halves are asserted from outside the pod,
-# against the gateway Service — no filter-config inspection — so a refactor
-# that reorders the filters or moves the health path fails these checks
-# instead of slipping past them.
+# is parked: a health probe on the gateway's /healthz, bare or carrying any
+# query string, is answered by the health-check filter ahead of the wake
+# filter, so it never registers demand and never wakes the engine. Both
+# halves are asserted from outside the pod, against the gateway Service — no
+# filter-config inspection — so a refactor that reorders the filters or moves
+# the health path fails these checks instead of slipping past them.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
@@ -66,7 +66,7 @@ WAKE_WAIT_SECONDS="${WAKE_WAIT_SECONDS:-240}"
 # engine contract.
 ENDPOINT_WAIT_SECONDS="${ENDPOINT_WAIT_SECONDS:-60}"
 
-# How many health probes to send at the parked engine, how long the probe
+# How many probe rounds to send at the parked engine, how long the probe
 # pod may take to schedule and finish them, and how long the engine must
 # still be observed at zero after the last probe. The settle window matters:
 # stamped demand turns into a scale-up only after the operator notices it —
@@ -75,6 +75,8 @@ ENDPOINT_WAIT_SECONDS="${ENDPOINT_WAIT_SECONDS:-60}"
 # the engine is watched well past both after the probes finish. An engine
 # still at zero then proves no probe registered demand.
 HEALTH_PROBE_COUNT="${HEALTH_PROBE_COUNT:-10}"
+# Probe shapes per round; keep in step with the curl calls in the probe loop.
+HEALTH_PROBE_SHAPES=7
 HEALTH_PROBE_TIMEOUT="${HEALTH_PROBE_TIMEOUT:-120}"
 HEALTH_SETTLE_SECONDS="${HEALTH_SETTLE_SECONDS:-20}"
 
@@ -234,10 +236,17 @@ echo "No endpoints, as expected"
 # placed ahead of the wake filter, so a probe is served by Envoy itself and
 # never reaches the wake path. Monitoring depends on that ordering: if a
 # refactor moved the health-check filter behind the wake filter, every probe
-# would stamp demand and no parked engine would ever stay parked. Two probe
-# shapes are sent because they fail differently under a reorder — a bare
-# probe would be rejected for its missing engine selector (non-200), and one
-# naming the engine would wake it (scale-up during the hold).
+# would stamp demand and no parked engine would ever stay parked.
+#
+# Envoy's health matcher reads ":path", which includes the query string, while
+# no route matcher in front of the gateway looks at the query at all — so
+# "/healthz?engine=<name>" arrives here as a health request and must be
+# answered as one. Each path shape is therefore probed twice, once plain and
+# once naming the engine in a header, plus one naming it in the query string.
+# The header is what makes the parked-engine assertion bite: the wake filter
+# rejects a request with no engine selector before it reaches the agent, so a
+# shape sent only plain could fall through the health filter without stamping
+# demand, and only its non-200 response would give the regression away.
 health_url="http://${GATEWAY_SVC}.${NAMESPACE}.svc.cluster.local:80/healthz"
 health_probe_pod="healthz-probe-$$"
 
@@ -247,9 +256,13 @@ echo "Probing ${health_url} while the engine is parked (${HEALTH_PROBE_COUNT} ro
   kubectl run "$health_probe_pod" -n "$NAMESPACE" --rm -i --restart=Never \
     --image="${CURL_IMAGE}" --command -- sh -c "
       for i in \$(seq 1 ${HEALTH_PROBE_COUNT}); do
-        curl -sS -o /dev/null -w '%{http_code}\n' --max-time 5 '${health_url}'
+        for target in '${health_url}' '${health_url}?' '${health_url}?x=1'; do
+          curl -sS -o /dev/null -w '%{http_code}\n' --max-time 5 \"\$target\"
+          curl -sS -o /dev/null -w '%{http_code}\n' --max-time 5 \
+            -H 'X-Firebolt-Engine: ${ENGINE_NAME}' \"\$target\"
+        done
         curl -sS -o /dev/null -w '%{http_code}\n' --max-time 5 \
-          -H 'X-Firebolt-Engine: ${ENGINE_NAME}' '${health_url}'
+          '${health_url}?engine=${ENGINE_NAME}'
         sleep 1
       done"
 ) > /tmp/healthz-probe-output 2>&1 &
@@ -354,10 +367,11 @@ require_engine_parked
 
 # Every probe must have been answered 200 by the gateway itself. A 400 means
 # the probe fell through to engine routing (the health-check filter no longer
-# answers ahead of it); a 404 means the health path moved off /healthz.
-# Either way, every external monitor pointed at the gateway breaks with it.
+# answers ahead of it); a 404 means the health path moved off /healthz; a 000
+# means curl gave up while the wake filter held the probe. Either way, every
+# external monitor pointed at the gateway breaks with it.
 health_statuses=$(grep -Eo '^[0-9]{3}$' /tmp/healthz-probe-output || true)
-health_expected=$(( HEALTH_PROBE_COUNT * 2 ))
+health_expected=$(( HEALTH_PROBE_COUNT * HEALTH_PROBE_SHAPES ))
 if [[ -z "${health_statuses}" ]]; then
   health_got=0
 else

--- a/test/e2e/gateway_healthcheck_test.go
+++ b/test/e2e/gateway_healthcheck_test.go
@@ -218,6 +218,45 @@ var _ = Describe("Envoy Gateway Health Checks", func() {
 			)
 		})
 
+		It("should answer /healthz itself whatever query string the request carries", func() {
+			// Envoy's health-check filter matches ":path", which carries the
+			// query string, while every route matcher in front of the gateway
+			// ignores it. A health matcher that accepted only the bare path
+			// would therefore hand "/healthz?..." to the engine-routing chain
+			// behind it, and a request naming an engine there registers wake
+			// demand. The engine name below that does not exist is the
+			// discriminator: routed, it can only fail, so a 200 proves the
+			// health filter answered.
+			assertHealthAnswered := func(pathAndQuery string) {
+				GinkgoHelper()
+				status, body, err := gatewayHealthResponse(clientPod, instanceName, pathAndQuery)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(status).To(Equal(http.StatusOK),
+					"%s was not answered by the gateway's health filter; response body: %s", pathAndQuery, body)
+			}
+
+			By("Answering the bare health path")
+			assertHealthAnswered("/healthz")
+
+			By("Answering an empty query string")
+			assertHealthAnswered("/healthz?")
+
+			By("Answering an arbitrary query string")
+			assertHealthAnswered("/healthz?x=1")
+
+			By("Answering a query string naming a running engine")
+			assertHealthAnswered("/healthz?engine=" + engineName)
+
+			By("Answering a query string naming an engine that does not exist")
+			assertHealthAnswered("/healthz?engine=absent-engine")
+
+			By("Routing other paths that carry the same query string to the engine")
+			status, body, err := gatewayQueryResponse(clientPod, instanceName, "engine=absent-engine", "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).NotTo(Equal(http.StatusOK),
+				"a query for an absent engine was answered 200, so the health filter is swallowing more than /healthz; response body: %s", body)
+		})
+
 		It("should eject a terminating pod within one health check interval and clear the flag once a replacement is healthy", func() {
 			if !drainEjectionEnabled {
 				Skip("drain ejection requires engine to serve /health/ready on port 3473 " +
@@ -287,22 +326,39 @@ var _ = Describe("Envoy Gateway Health Checks", func() {
 // both the HTTP status and body. Unlike execCurlQuery, it deliberately does not
 // use curl --fail because routing-validation tests need to inspect 400 responses.
 func gatewayQueryResponse(clientPod, instanceName, rawQuery, headerEngine string) (int, string, error) {
-	const statusMarker = "\n__HTTP_STATUS__:"
-
-	serviceName := instanceName + controller.SuffixGateway
-	url := fmt.Sprintf("http://%s.%s.svc.cluster.local:80/?%s", serviceName, testNamespace, rawQuery)
 	curlArgs := []string{
-		"-sS",
-		"--connect-timeout", "2",
-		"--max-time", "15",
-		"-w", statusMarker + "%{http_code}",
 		"-X", "POST",
 		"-H", "Content-Type: text/plain",
 	}
 	if headerEngine != "" {
 		curlArgs = append(curlArgs, "-H", "X-Firebolt-Engine: "+headerEngine)
 	}
-	curlArgs = append(curlArgs, "-d", LightQuery, url)
+	curlArgs = append(curlArgs, "-d", LightQuery)
+	return gatewayCurl(clientPod, instanceName, "/?"+rawQuery, curlArgs)
+}
+
+// gatewayHealthResponse issues a GET at the gateway's health endpoint,
+// pathAndQuery included verbatim so a caller can probe the query-string
+// shapes the health contract has to cover.
+func gatewayHealthResponse(clientPod, instanceName, pathAndQuery string) (int, string, error) {
+	return gatewayCurl(clientPod, instanceName, pathAndQuery, []string{"-X", "GET"})
+}
+
+// gatewayCurl runs curl inside the client pod against the instance gateway
+// Service and returns the response status and body.
+func gatewayCurl(clientPod, instanceName, pathAndQuery string, extraArgs []string) (int, string, error) {
+	const statusMarker = "\n__HTTP_STATUS__:"
+
+	serviceName := instanceName + controller.SuffixGateway
+	url := fmt.Sprintf("http://%s.%s.svc.cluster.local:80%s", serviceName, testNamespace, pathAndQuery)
+	curlArgs := []string{
+		"-sS",
+		"--connect-timeout", "2",
+		"--max-time", "15",
+		"-w", statusMarker + "%{http_code}",
+	}
+	curlArgs = append(curlArgs, extraArgs...)
+	curlArgs = append(curlArgs, url)
 
 	args := kubectlArgs("exec", clientPod, "-n", testNamespace, "--", "curl")
 	args = append(args, curlArgs...)


### PR DESCRIPTION
## Background

An unauthenticated `GET /healthz?engine=<name>` woke a parked engine. Route matching in front of the instance gateway ignores the query string, so the request matched the edge's unauthenticated exact `/healthz` rule and was routed; Envoy's `:path` header carries the query, so the gateway's `exact: "/healthz"` health matcher missed it and the request fell through to the Lua filter, which strips the `engine` parameter, rewrites `:authority`, and calls the wake agent — the call that registers wake demand. Any caller that knows a project hostname could wake engines repeatedly and drive compute cost. Query execution is still refused by the engine, so the exposure is wake and cost amplification, not data access.

This is pre-existing on `main` and not introduced by the edge JWT work: the earlier single-rule route carried the same exact health match. The edge cannot fix it, because Gateway API cannot express "no query string".

## Summary

- Every `health_check` filter in the rendered Envoy config matches `:path` against `^/healthz(\?.*)?$` instead of the bare path: the client listener, the metrics-port stats listener, and the stats listener of the fail-closed config rendered while gateway TLS is pending. The regex comes from one constant so the three cannot drift. `/healthz` and `/healthz?<anything>` are now answered identically and neither reaches the wake path; nothing else is answered as health, so `/healthz/`, `/healthzz` and `//healthz` still route as engine requests.
- Refusing a query-bearing health request was the alternative. It would have kept behaviour dependent on the query string, which is the property this change exists to remove.
- Three levels of coverage:
  - a unit test evaluates each rendered matcher against a path table, so the contract is asserted as behaviour rather than as config shape;
  - an e2e spec probes real Envoy through the gateway Service, including `/healthz?engine=<engine that does not exist>` — routed, that can only fail, so a 200 proves the health filter answered;
  - `verify-wake-on-zero.sh` probes a parked engine with the bare path, `?` and `?x=1`, each sent plain and again naming the engine in `X-Firebolt-Engine`, plus `?engine=<engine>`, while watching `spec.replicas` and `autoStopReason`. The header pairing is what makes that watch bite: the wake filter rejects a request carrying no engine selector before it reaches the agent, so a shape sent only plain could fall through the health filter without stamping demand and only its status code would show it.
- `docs/engine/auto-stop-and-wake-up.mdx` states how a query string on the health path is treated.

## Test Plan

- `make build`, `make lint`, `make test` pass.
- The unit test was confirmed to fail before the matcher changed.
- E2E and Helm suites were not run locally (no cluster or Docker available); `E2E Tests` and `Helm Tests` cover them in CI, the latter running the wake-demand probes.

## Risk and rollout

The rendered config changes, so the gateway ConfigMap hash changes and every FireboltInstance gateway Deployment rolls once when the operator upgrades. That is the normal config-change path: the gateway rolls at `maxUnavailable=0`, and Envoy's preStop drain (`POST /healthcheck/fail`, then an 8s wait) plus the wake agent's longer 12s drain keep held requests intact. Until a gateway pod is replaced it keeps the old behaviour, so the fix lands per instance on that roll.

Both probes are unaffected: they hit the bare `/healthz` on the metrics port, and the preStop drain flips the filter process-wide regardless of what its matcher accepts. The widened surface is exactly the query string, so a monitor already pointed at `/healthz` sees no change, while a client that expected `/healthz?...` to reach an engine now gets a health response instead.

## Reviewer notes

Start at the `health_check` filter in `internal/controller/instance_gateway.go`; the other two copies are identical. The firecelld-side follow-ups (its contract note and its own no-wake matrix) are a separate repo and out of scope here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-relevant gateway behavior change that rewrites Envoy ConfigMap and rolls gateway pods on operator upgrade; functional impact is limited to widening `/healthz` handling to include query strings.
> 
> **Overview**
> Closes a **wake-on-zero abuse** where unauthenticated `GET /healthz?engine=<name>` missed the Envoy health matcher (because `:path` includes the query) and fell through to the Lua wake path, registering demand for parked engines.
> 
> **Gateway Envoy config** now matches all `health_check` filters on `:path` with shared regex `^/healthz(\?.*)?$` instead of exact `/healthz`, across the client listener, metrics stats listener, and fail-closed stats listener. `/healthz` with any query is answered as health only; paths like `/healthz/` still route as engine traffic.
> 
> **Coverage** adds a unit test that evaluates each rendered matcher against a path table, an e2e case that proves `200` on `/healthz?engine=…` without routing, expanded `verify-wake-on-zero.sh` probes (bare path, `?`, `?x=1`, header + query variants) while the engine stays parked, and a doc note in `auto-stop-and-wake-up.mdx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e84196cf2c5297ad04fc86ab3535004b7a9750a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->