### PR TITLE
chore(deps): bump packdb engine/metadata to 5.0.0-pre.0.20260907054900.7676b5def2cd

### DIFF
--- a/config/images/defaults.latest.env
+++ b/config/images/defaults.latest.env
@@ -21,9 +21,9 @@
 #     test/e2e/e2e_suite_test.go's SynchronizedBeforeSuite.
 
 ENGINE_IMAGE=oci.firebolt.io/firebolt-db/engine
-ENGINE_TAG=release-5.0.0-pre.0.20260831081410.a005be0f9030
+ENGINE_TAG=release-5.0.0-pre.0.20260907054900.7676b5def2cd
 METADATA_IMAGE=ghcr.io/firebolt-db/metadata
-METADATA_TAG=release-5.0.0-pre.0.20260831081410.a005be0f9030
+METADATA_TAG=release-5.0.0-pre.0.20260907054900.7676b5def2cd
 # Multi-arch manifest-list digest (not a single-platform blob). Refresh with:
 #   docker buildx imagetools inspect postgres:16.15-alpine --format '{{.Manifest.Digest}}'
 POSTGRES_IMAGE=postgres:16.15-alpine@sha256:cf78e76683b9ca8c5733cbbdce6c9262b45b6767934dd0a95e671f9a0fc20685


### PR DESCRIPTION
## Summary

Bump default engine/metadata images to packdb `5.0.0-pre.0.20260907054900.7676b5def2cd`
— the build the engine/metadata `:latest` GHCR tags were just re-pointed to.

> [!NOTE]
> Opened automatically by packdb's `promote-ghcr-latest` workflow (weekly
> Monday refresh or a manual promotion) right after it re-pointed the
> engine/metadata `:latest` GHCR tags at this build, so `:latest` and this
> repo's pinned tags move together. An unmerged PR is overwritten by the
> next run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin-only change with lockstep engine/metadata tags; behavior risk is covered by the repo’s automated test gate on this bump.
> 
> **Overview**
> Updates the **latest** image variant pins in `config/images/defaults.latest.env` so the operator, Helm chart, and default E2E builds pull a newer packdb **release** build.
> 
> `ENGINE_TAG` and `METADATA_TAG` move together from `release-5.0.0-pre.0.20260831081410.a005be0f9030` to `release-5.0.0-pre.0.20260907054900.7676b5def2cd`, keeping engine and metadata on the same flavor. No other images in that file change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a7ceb6b75971180b2b99b25a945b323eeecd1a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->