### PR TITLE
feat(metrics)!: name the engine metrics' instance label firebolt_io_instance (FB-3633)

### DIFF
--- a/docs/monitoring.mdx
+++ b/docs/monitoring.mdx
@@ -67,15 +67,15 @@ The Gateway exposes a read-only stats listener on its metrics port. Its Envoy ad
 
 | Metric | Type | Labels | Updated | Description |
 |---|---|---|---|---|
-| `firebolt_engine_status_phase` | Gauge | `namespace`, `name`, `instance`, `phase` | Every reconcile | StateSet-style: 1 for the current phase, 0 for all others. Phases: `stable`, `creating`, `switching`, `draining`, `cleaning`, `stopped`. |
-| `firebolt_engine_status_condition` | Gauge | `namespace`, `name`, `instance`, `type` | Every reconcile | 1 when the condition is True, 0 when False or Unknown. Types: `Ready`, `InstanceReady`. |
-| `firebolt_engine_spec_replicas` | Gauge | `namespace`, `name`, `instance` | Every reconcile | Desired replica count from `spec.replicas`. |
-| `firebolt_engine_active_generation` | Gauge | `namespace`, `name`, `instance` | Every reconcile | Generation number currently serving traffic. |
-| `firebolt_engine_pods_ready` | Gauge | `namespace`, `name`, `instance` | Every reconcile | Number of ready pods in the active generation. |
-| `firebolt_engine_pods_total` | Gauge | `namespace`, `name`, `instance` | Every reconcile | Total pods in the active generation (includes non-ready). |
-| `firebolt_engine_draining_generation` | Gauge | `namespace`, `name`, `instance` | Every reconcile | Generation being drained, or -1 if no drain is in progress. |
-| `firebolt_engine_last_reconciled_timestamp` | Gauge | `namespace`, `name`, `instance` | Successful reconciles | Unix timestamp of the last successful reconcile. |
-| `firebolt_engine_drain_check_errors_total` | Counter | `namespace`, `name`, `instance` | On drain probe failure | Cumulative count of drain probe failures (pod unreachable, metrics missing). |
+| `firebolt_engine_status_phase` | Gauge | `namespace`, `name`, `firebolt_io_instance`, `phase` | Every reconcile | StateSet-style: 1 for the current phase, 0 for all others. Phases: `stable`, `creating`, `switching`, `draining`, `cleaning`, `stopped`. |
+| `firebolt_engine_status_condition` | Gauge | `namespace`, `name`, `firebolt_io_instance`, `type` | Every reconcile | 1 when the condition is True, 0 when False or Unknown. Types: `Ready`, `InstanceReady`. |
+| `firebolt_engine_spec_replicas` | Gauge | `namespace`, `name`, `firebolt_io_instance` | Every reconcile | Desired replica count from `spec.replicas`. |
+| `firebolt_engine_active_generation` | Gauge | `namespace`, `name`, `firebolt_io_instance` | Every reconcile | Generation number currently serving traffic. |
+| `firebolt_engine_pods_ready` | Gauge | `namespace`, `name`, `firebolt_io_instance` | Every reconcile | Number of ready pods in the active generation. |
+| `firebolt_engine_pods_total` | Gauge | `namespace`, `name`, `firebolt_io_instance` | Every reconcile | Total pods in the active generation (includes non-ready). |
+| `firebolt_engine_draining_generation` | Gauge | `namespace`, `name`, `firebolt_io_instance` | Every reconcile | Generation being drained, or -1 if no drain is in progress. |
+| `firebolt_engine_last_reconciled_timestamp` | Gauge | `namespace`, `name`, `firebolt_io_instance` | Successful reconciles | Unix timestamp of the last successful reconcile. |
+| `firebolt_engine_drain_check_errors_total` | Counter | `namespace`, `name`, `firebolt_io_instance` | On drain probe failure | Cumulative count of drain probe failures (pod unreachable, metrics missing). |
 
 ### FireboltInstance metrics
 

--- a/hack/metricsdump/main.go
+++ b/hack/metricsdump/main.go
@@ -1,0 +1,59 @@
+// metricsdump prints the operator's metric exposition for one FireboltInstance
+// and one FireboltEngine, exactly as a scraper would read it from /metrics.
+//
+// Consumers of these metrics (the firebolt-instance-observability chart's
+// recording rules and alerts) test against label sets written by hand, which
+// cannot notice when the operator exposes a label a scraper overwrites. This
+// program gives them a real exposition to scrape instead:
+//
+//	go run ./hack/metricsdump > operator-exposition.prom
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	computev1alpha1 "github.com/firebolt-db/firebolt-kubernetes-operator/api/v1alpha1"
+	"github.com/firebolt-db/firebolt-kubernetes-operator/internal/metrics"
+)
+
+func main() {
+	instance := &computev1alpha1.FireboltInstance{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "firebolt", Name: "prod"},
+		Spec:       computev1alpha1.FireboltInstanceSpec{ID: "01hxxxxdumpinstance0000001"},
+		Status: computev1alpha1.FireboltInstanceStatus{
+			Phase:      "Ready",
+			Conditions: []metav1.Condition{{Type: "Ready", Status: metav1.ConditionTrue}},
+		},
+	}
+	engine := &computev1alpha1.FireboltEngine{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "firebolt", Name: "eng"},
+		Spec:       computev1alpha1.FireboltEngineSpec{InstanceRef: "prod", Replicas: 1},
+		Status: computev1alpha1.FireboltEngineStatus{
+			Phase:            "stable",
+			ActiveGeneration: 1,
+			Conditions:       []metav1.Condition{{Type: "Ready", Status: metav1.ConditionTrue}},
+		},
+	}
+	metrics.NewInstanceRecorder().Record(instance)
+	metrics.NewEngineRecorder().Record(engine, 1, 1)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/metrics", http.NoBody)
+	promhttp.HandlerFor(ctrlmetrics.Registry, promhttp.HandlerOpts{}).ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		fmt.Fprintf(os.Stderr, "metrics handler returned %d\n", rec.Code)
+		os.Exit(1)
+	}
+	if _, err := os.Stdout.Write(rec.Body.Bytes()); err != nil {
+		fmt.Fprintf(os.Stderr, "write exposition: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/internal/metrics/engine_labels_test.go
+++ b/internal/metrics/engine_labels_test.go
@@ -1,0 +1,91 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// Every engine family names the parent instance firebolt_io_instance. The
+// recorders pass label values positionally, so a rename of the label itself
+// is invisible to them and to their tests; this test reads what a scraper
+// would read. `instance` is Prometheus's target label, and a scraper that
+// does not honor exposed labels overwrites it with the target address, which
+// is how the parent instance went missing from every engine series once.
+func TestEngineFamiliesExposeParentInstanceAsFireboltIoInstance(t *testing.T) {
+	engines := map[string]prometheus.Collector{
+		"firebolt_engine_status_phase":              EnginePhase,
+		"firebolt_engine_status_condition":          EngineCondition,
+		"firebolt_engine_spec_replicas":             EngineSpecReplicas,
+		"firebolt_engine_active_generation":         EngineActiveGeneration,
+		"firebolt_engine_pods_ready":                EnginePodsReady,
+		"firebolt_engine_pods_total":                EnginePodsTotal,
+		"firebolt_engine_draining_generation":       EngineDrainingGeneration,
+		"firebolt_engine_last_reconciled_timestamp": EngineLastReconciled,
+		"firebolt_engine_drain_check_errors_total":  EngineDrainCheckErrors,
+	}
+
+	// One series per family, so Gather has something to describe.
+	EnginePhase.WithLabelValues("ns", "eng", "inst", "stable").Set(1)
+	EngineCondition.WithLabelValues("ns", "eng", "inst", "Ready").Set(1)
+	EngineSpecReplicas.WithLabelValues("ns", "eng", "inst").Set(1)
+	EngineActiveGeneration.WithLabelValues("ns", "eng", "inst").Set(1)
+	EnginePodsReady.WithLabelValues("ns", "eng", "inst").Set(1)
+	EnginePodsTotal.WithLabelValues("ns", "eng", "inst").Set(1)
+	EngineDrainingGeneration.WithLabelValues("ns", "eng", "inst").Set(-1)
+	EngineLastReconciled.WithLabelValues("ns", "eng", "inst").SetToCurrentTime()
+	EngineDrainCheckErrors.WithLabelValues("ns", "eng", "inst").Inc()
+
+	reg := prometheus.NewPedanticRegistry()
+	for _, c := range engines {
+		if err := reg.Register(c); err != nil {
+			t.Fatalf("register: %v", err)
+		}
+	}
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+
+	seen := map[string]bool{}
+	for _, fam := range families {
+		if _, ours := engines[fam.GetName()]; !ours {
+			continue
+		}
+		seen[fam.GetName()] = true
+		for _, m := range fam.GetMetric() {
+			names := labelNames(m)
+			if !names["firebolt_io_instance"] {
+				t.Errorf("%s: exported labels %v lack firebolt_io_instance", fam.GetName(), keys(names))
+			}
+			if names["instance"] {
+				t.Errorf("%s: exports a label named instance, which a scraper overwrites with the target address", fam.GetName())
+			}
+			if !names["namespace"] || !names["name"] {
+				t.Errorf("%s: exported labels %v lack namespace or name", fam.GetName(), keys(names))
+			}
+		}
+	}
+	for name := range engines {
+		if !seen[name] {
+			t.Errorf("%s: not gathered", name)
+		}
+	}
+}
+
+func labelNames(m *dto.Metric) map[string]bool {
+	out := map[string]bool{}
+	for _, lp := range m.GetLabel() {
+		out[lp.GetName()] = true
+	}
+	return out
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -16,7 +16,11 @@ import (
 )
 
 // Engine metric label keys.
-var engineLabels = []string{"namespace", "name", "instance"}
+// engineLabels names the parent FireboltInstance as firebolt_io_instance, not
+// instance: Prometheus reserves instance for the scrape target, so a scraper
+// that does not honor exposed labels overwrites it with the target address and
+// every consumer joining engines to their instance matches nothing.
+var engineLabels = []string{"namespace", "name", "firebolt_io_instance"}
 
 // Instance metric label keys.
 var instanceLabels = []string{"namespace", "name"}


### PR DESCRIPTION
The FireboltEngine metrics label their parent instance as `instance`. That is Prometheus's reserved target label, so a scraper that does not honor exposed labels overwrites it with the scrape address, and the OpenTelemetry Prometheus receiver does not keep an `exported_instance` copy the way a Prometheus server would. Under such a scraper, every engine series carries `instance="<ip>:<port>"` and a consumer joining engines to their FireboltInstance matches nothing, while the join's recording rules report healthy with zero samples. A Prometheus server with default settings breaks the same join differently, by renaming the exposed value to `exported_instance`. The label works only where `honor_labels` is on, which is nobody by default.

## Change

`engineLabels` becomes `namespace, name, firebolt_io_instance`. Every engine gauge and counter shares the slice, so the nine families move together and no call site changes: the recorder passes label values positionally. `docs/monitoring.mdx` updates the nine rows. The Envoy gateway series already use `firebolt_io_instance` for the same fact, so the two now agree.

The instance-level families (`firebolt_instance_*`) are untouched; they never carried the label.

## Breaking

Anything that filtered, grouped or joined engine series on `instance` must read `firebolt_io_instance`. The `firebolt-instance-observability` chart is being updated alongside this change; its recording rules, annotations, one dashboard column and its promtool fixtures switch to the new label, and engine series from operators older than this release simply stop joining there rather than joining wrongly.

`go build ./...`, `go test ./internal/metrics/...` and `go vet` pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking label rename affects existing PromQL, dashboards, and alerts that group or join on `instance` for engine metrics; behavior under scrape is materially fixed but consumers must migrate to `firebolt_io_instance`.
> 
> **Overview**
> **Breaking:** All nine `firebolt_engine_*` metric families now label the parent FireboltInstance with `firebolt_io_instance` instead of `instance`, via the shared `engineLabels` slice in `internal/metrics/metrics.go`. Recorders keep passing values positionally, so controller call sites are unchanged; only the exported label name changes.
> 
> This avoids Prometheus’s reserved `instance` target label, which scrapers often overwrite with the scrape address—breaking joins to instance-level series and silently emptying observability recording rules. `docs/monitoring.mdx` updates the engine metrics table to match (Envoy gateway metrics already used `firebolt_io_instance`).
> 
> Adds `TestEngineFamiliesExposeParentInstanceAsFireboltIoInstance` to assert gathered exposition includes `firebolt_io_instance` and never exports `instance`, plus `hack/metricsdump` to dump real `/metrics` output for chart/promtool fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5ce035c039417fc8c5b084978c8337d870a252d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->