### PR TITLE
fix(controller): resolve cluster-scoped engine classes in the spec.id canonicalize check (FB-3978)

### DIFF
--- a/internal/controller/instance_controller.go
+++ b/internal/controller/instance_controller.go
@@ -965,6 +965,14 @@ func (r *FireboltInstanceReconciler) SetupWithManagerNamed(mgr ctrl.Manager, nam
 			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		).
 		Watches(
+			&computev1alpha1.ClusterFireboltEngineClass{},
+			handler.EnqueueRequestsFromMapFunc(r.enqueueInstancesFromClusterEngineClass),
+			// Same reasoning as the namespaced class watch: an engine bound
+			// to the shared SKU catalog takes its image from the cluster
+			// class, and a catalog bump changes no engine generation.
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		).
+		Watches(
 			&computev1alpha1.FireboltEnginePreset{},
 			handler.EnqueueRequestsFromMapFunc(r.enqueueInstancesFromEnginePreset),
 			// Deliberately unfiltered: resolveFireboltEnginePresetInfo is
@@ -1048,6 +1056,39 @@ func (r *FireboltInstanceReconciler) enqueueInstancesFromEngineClass(
 		ref := eng.Spec.EngineClassRef
 		return ref != nil && *ref == obj.GetName()
 	})
+}
+
+// enqueueInstancesFromClusterEngineClass maps a ClusterFireboltEngineClass
+// event to every instance, in any namespace, with a bound engine whose
+// spec.engineClassRef names it. A namespaced FireboltEngineClass of the
+// same name shadows the catalog for its namespace, so some of these
+// requests re-run a gate whose answer does not change; that costs one
+// reconcile, whereas skipping them would need a second lookup per engine.
+func (r *FireboltInstanceReconciler) enqueueInstancesFromClusterEngineClass(
+	ctx context.Context, obj client.Object,
+) []reconcile.Request {
+	engines := &computev1alpha1.FireboltEngineList{}
+	if err := r.List(ctx, engines); err != nil {
+		logf.FromContext(ctx).Error(err, "Failed to list engines for the instance ID canonicalize watch",
+			"clusterEngineClass", obj.GetName())
+		return nil
+	}
+	seen := make(map[types.NamespacedName]struct{}, len(engines.Items))
+	var requests []reconcile.Request
+	for i := range engines.Items {
+		eng := &engines.Items[i]
+		ref := eng.Spec.EngineClassRef
+		if eng.Spec.InstanceRef == "" || ref == nil || *ref != obj.GetName() {
+			continue
+		}
+		key := types.NamespacedName{Name: eng.Spec.InstanceRef, Namespace: eng.Namespace}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		requests = append(requests, reconcile.Request{NamespacedName: key})
+	}
+	return requests
 }
 
 // enqueueInstancesFromEnginePreset maps a FireboltEnginePreset event to

--- a/internal/controller/instance_id_canonical.go
+++ b/internal/controller/instance_id_canonical.go
@@ -217,17 +217,9 @@ func resolvedMetadataImage(instance *computev1alpha1.FireboltInstance) string {
 func (r *FireboltInstanceReconciler) resolvedBoundEngineImage(
 	ctx context.Context, engine *computev1alpha1.FireboltEngine,
 ) (string, error) {
-	var classInfo *FireboltEngineClassInfo
-	if engine.Spec.EngineClassRef != nil && *engine.Spec.EngineClassRef != "" {
-		class := &computev1alpha1.FireboltEngineClass{}
-		key := client.ObjectKey{Namespace: engine.Namespace, Name: *engine.Spec.EngineClassRef}
-		if err := r.Get(ctx, key, class); err != nil {
-			if errors.IsNotFound(err) {
-				return "", fmt.Errorf("cannot resolve engine %q image: FireboltEngineClass %q not found", engine.Name, *engine.Spec.EngineClassRef)
-			}
-			return "", fmt.Errorf("getting FireboltEngineClass %q for engine %q: %w", key.Name, engine.Name, err)
-		}
-		classInfo = newFireboltEngineClassInfo(class)
+	classInfo, err := r.resolvedBoundEngineClassInfo(ctx, engine)
+	if err != nil {
+		return "", err
 	}
 
 	// Resolve the Preset through the same fail-closed path the engine
@@ -244,6 +236,38 @@ func (r *FireboltInstanceReconciler) resolvedBoundEngineImage(
 	classInfo = overlayPresetOnClass(presetInfo, classInfo)
 	image, _ := effectiveEngineImage(&engine.Spec, classInfo)
 	return image, nil
+}
+
+// resolvedBoundEngineClassInfo resolves spec.engineClassRef the way the
+// engine reconciler does: the FireboltEngineClass in the engine's
+// namespace first, then the cluster-scoped ClusterFireboltEngineClass of
+// the same name. Engines bound to the shared SKU catalog have no
+// namespaced class at all, so stopping at the first miss would report
+// ImageResolveFailed for every one of them and never lowercase the id.
+func (r *FireboltInstanceReconciler) resolvedBoundEngineClassInfo(
+	ctx context.Context, engine *computev1alpha1.FireboltEngine,
+) (*FireboltEngineClassInfo, error) {
+	if engine.Spec.EngineClassRef == nil || *engine.Spec.EngineClassRef == "" {
+		return nil, nil
+	}
+	ref := *engine.Spec.EngineClassRef
+	class := &computev1alpha1.FireboltEngineClass{}
+	err := r.Get(ctx, client.ObjectKey{Namespace: engine.Namespace, Name: ref}, class)
+	if err == nil {
+		return newFireboltEngineClassInfo(class), nil
+	}
+	if !errors.IsNotFound(err) {
+		return nil, fmt.Errorf("getting FireboltEngineClass %q for engine %q: %w", ref, engine.Name, err)
+	}
+	cc := &computev1alpha1.ClusterFireboltEngineClass{}
+	if err := r.Get(ctx, client.ObjectKey{Name: ref}, cc); err != nil {
+		if errors.IsNotFound(err) {
+			return nil, fmt.Errorf("cannot resolve engine %q image: FireboltEngineClass %s/%s not found, ClusterFireboltEngineClass %s not found",
+				engine.Name, engine.Namespace, ref, ref)
+		}
+		return nil, fmt.Errorf("getting ClusterFireboltEngineClass %q for engine %q: %w", ref, engine.Name, err)
+	}
+	return newClusterFireboltEngineClassInfo(cc), nil
 }
 
 func imageMeetsCanonicalFloor(image string) bool {

--- a/internal/controller/instance_id_canonical_test.go
+++ b/internal/controller/instance_id_canonical_test.go
@@ -548,6 +548,128 @@ func TestInstanceReconcile_ContinuesWhenBoundEngineClassMissing(t *testing.T) {
 	if cond.Reason != reasonInstanceIDResolveError {
 		t.Errorf("InstanceIDCanonical.Reason = %q, want %q", cond.Reason, reasonInstanceIDResolveError)
 	}
+	if !strings.Contains(cond.Message, "ClusterFireboltEngineClass") {
+		t.Errorf("InstanceIDCanonical.Message = %q, want it to say the cluster-scoped class was tried too", cond.Message)
+	}
+}
+
+// TestInstanceReconcile_CanonicalizesUppercaseULIDWhenBoundEngineOnClusterClass
+// pins the catalog arm of the gate: an engine bound to a
+// ClusterFireboltEngineClass has no namespaced class at all, and the gate
+// must resolve its image through the cluster-scoped object the way the
+// engine reconciler does instead of reporting ImageResolveFailed.
+func TestInstanceReconcile_CanonicalizesUppercaseULIDWhenBoundEngineOnClusterClass(t *testing.T) {
+	orig := computev1alpha1.CanonicalInstanceIDImageFloor
+	computev1alpha1.CanonicalInstanceIDImageFloor = DefaultEngineTag
+	t.Cleanup(func() { computev1alpha1.CanonicalInstanceIDImageFloor = orig })
+
+	sch := instanceTemplateTestScheme(t)
+	inst := readyInstanceWithTemplates()
+	inst.Spec.ID = testUppercaseULID
+	eng := &computev1alpha1.FireboltEngine{
+		ObjectMeta: metav1.ObjectMeta{Name: "eng", Namespace: "default"},
+		Spec: computev1alpha1.FireboltEngineSpec{
+			InstanceRef:    inst.Name,
+			EngineClassRef: ptr("catalog-class"),
+		},
+	}
+	cc := &computev1alpha1.ClusterFireboltEngineClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "catalog-class"},
+		Spec: computev1alpha1.ClusterFireboltEngineClassSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  computev1alpha1.EngineContainerName,
+						Image: "oci.firebolt.io/firebolt-db/engine:" + DefaultEngineTag,
+					}},
+				},
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(sch).
+		WithObjects(inst, eng, cc).
+		WithStatusSubresource(&computev1alpha1.FireboltInstance{}).
+		Build()
+	r := &FireboltInstanceReconciler{
+		Client:          cli,
+		Scheme:          sch,
+		MetricsRecorder: fireboltmetrics.NoOpInstanceRecorder{},
+	}
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKey{Name: inst.Name, Namespace: inst.Namespace}})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if !res.Requeue {
+		t.Error("Requeue = false, want true after spec.id canonicalize Update")
+	}
+
+	updated := &computev1alpha1.FireboltInstance{}
+	if err := cli.Get(context.Background(), client.ObjectKey{Name: inst.Name, Namespace: inst.Namespace}, updated); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if want := strings.ToLower(testUppercaseULID); updated.Spec.ID != want {
+		t.Errorf("spec.id = %q, want lowercase %q when the bound engine resolves to a cluster class at the floor", updated.Spec.ID, want)
+	}
+}
+
+// TestInstanceReconcile_LeavesUppercaseULIDWhenClusterClassBelowFloor pins
+// that the cluster-class arm still compares the resolved image against the
+// floor: a catalog entry pinning an old engine holds the id like a
+// namespaced class would.
+func TestInstanceReconcile_LeavesUppercaseULIDWhenClusterClassBelowFloor(t *testing.T) {
+	orig := computev1alpha1.CanonicalInstanceIDImageFloor
+	computev1alpha1.CanonicalInstanceIDImageFloor = DefaultEngineTag
+	t.Cleanup(func() { computev1alpha1.CanonicalInstanceIDImageFloor = orig })
+
+	sch := instanceTemplateTestScheme(t)
+	inst := readyInstanceWithTemplates()
+	inst.Spec.ID = testUppercaseULID
+	eng := &computev1alpha1.FireboltEngine{
+		ObjectMeta: metav1.ObjectMeta{Name: "eng", Namespace: "default"},
+		Spec: computev1alpha1.FireboltEngineSpec{
+			InstanceRef:    inst.Name,
+			EngineClassRef: ptr("catalog-class"),
+		},
+	}
+	cc := &computev1alpha1.ClusterFireboltEngineClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "catalog-class"},
+		Spec: computev1alpha1.ClusterFireboltEngineClassSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  computev1alpha1.EngineContainerName,
+						Image: "oci.firebolt.io/firebolt-db/engine:release-4.0.0-pre.0.20260101000000.aaaaaaaaaaaa",
+					}},
+				},
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(sch).
+		WithObjects(inst, eng, cc).
+		WithStatusSubresource(&computev1alpha1.FireboltInstance{}).
+		Build()
+	r := &FireboltInstanceReconciler{
+		Client:          cli,
+		Scheme:          sch,
+		MetricsRecorder: fireboltmetrics.NoOpInstanceRecorder{},
+	}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKey{Name: inst.Name, Namespace: inst.Namespace}}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	updated := &computev1alpha1.FireboltInstance{}
+	if err := cli.Get(context.Background(), client.ObjectKey{Name: inst.Name, Namespace: inst.Namespace}, updated); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if updated.Spec.ID != testUppercaseULID {
+		t.Errorf("spec.id = %q, want unchanged uppercase while the cluster class pins an image below the floor", updated.Spec.ID)
+	}
+	cond := apimeta.FindStatusCondition(updated.Status.Conditions, computev1alpha1.InstanceConditionInstanceIDCanonical)
+	if cond == nil || cond.Reason != reasonInstanceIDBelowFloor {
+		t.Fatalf("InstanceIDCanonical = %+v, want Reason %q", cond, reasonInstanceIDBelowFloor)
+	}
 }
 
 func TestInstanceReconcile_DoesNotRewriteCustomID(t *testing.T) {
@@ -648,6 +770,48 @@ func TestEnqueueInstancesFromEngineClass(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "unreferenced", Namespace: "ns"},
 	}); len(reqs) != 0 {
 		t.Errorf("enqueue for unreferenced class = %v, want none", reqs)
+	}
+}
+
+// TestEnqueueInstancesFromClusterEngineClass pins the catalog arm of the
+// watch: one ClusterFireboltEngineClass serves every namespace, so its
+// event fans out to each instance, in any namespace, with a bound engine
+// naming it — one request per instance.
+func TestEnqueueInstancesFromClusterEngineClass(t *testing.T) {
+	sch := instanceTemplateTestScheme(t)
+	other := boundEngine("eng-x", "fi-other", "big")
+	other.Namespace = "elsewhere"
+	cli := fake.NewClientBuilder().
+		WithScheme(sch).
+		WithObjects(
+			boundEngine("eng-a", "fi", "big"),
+			// Second engine on the same instance and class: one request.
+			boundEngine("eng-b", "fi", "big"),
+			other,
+			boundEngine("eng-c", "fi-small", "small"),
+			// Bound to the class but to no instance: nothing to gate.
+			boundEngine("eng-e", "", "big"),
+		).
+		Build()
+	r := &FireboltInstanceReconciler{Client: cli, Scheme: sch, MetricsRecorder: fireboltmetrics.NoOpInstanceRecorder{}}
+
+	reqs := r.enqueueInstancesFromClusterEngineClass(context.Background(), &computev1alpha1.ClusterFireboltEngineClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "big"},
+	})
+	got := requestNames(reqs)
+	if len(reqs) != 2 || len(got) != 2 {
+		t.Fatalf("enqueue = %v, want exactly ns/fi and elsewhere/fi-other", reqs)
+	}
+	for _, want := range []string{"ns/fi", "elsewhere/fi-other"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("enqueue = %v, want %s", reqs, want)
+		}
+	}
+
+	if reqs := r.enqueueInstancesFromClusterEngineClass(context.Background(), &computev1alpha1.ClusterFireboltEngineClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "unreferenced"},
+	}); len(reqs) != 0 {
+		t.Errorf("enqueue for unreferenced cluster class = %v, want none", reqs)
 	}
 }
 


### PR DESCRIPTION
## Problem

The controller lowercases an uppercase `FireboltInstance.spec.id` once the metadata image and every bound engine image meet the canonicalize floor. To find a bound engine's image it resolves the engine's class, but only as a `FireboltEngineClass` in the engine's namespace.

An engine bound to a `ClusterFireboltEngineClass` has no namespaced class. For such an instance the check reports `InstanceIDCanonical=False / ImageResolveFailed: FireboltEngineClass "<name>" not found` on every reconcile and never rewrites the id. Engine builds at or above the floor reject the uppercase spelling at startup, so every new engine generation on that instance crashloops.

## Change

- `resolvedBoundEngineImage` resolves the class namespaced-first, then falls back to the `ClusterFireboltEngineClass` of the same name, the same order the engine reconciler uses. A miss in both scopes still reports `ImageResolveFailed`, now naming both kinds.
- The instance reconciler watches `ClusterFireboltEngineClass` (spec changes only) and enqueues every instance, in any namespace, with a bound engine naming that class. Without it a catalog image bump would not re-run the check until some unrelated instance event.
- No RBAC change: the operator ClusterRole already grants get/list/watch on `clusterfireboltengineclasses` for the engine reconciler.

| Bound engine's class | Before | After |
|---|---|---|
| Namespaced `FireboltEngineClass` | resolved | resolved |
| Cluster-scoped `ClusterFireboltEngineClass` | `ImageResolveFailed`, id stays uppercase | resolved, id lowercased once images meet the floor |
| Neither exists | `ImageResolveFailed` | `ImageResolveFailed`, message names both kinds |

## Testing

- New `TestInstanceReconcile_CanonicalizesUppercaseULIDWhenBoundEngineOnClusterClass`: engine bound to a cluster class at the floor, id is lowercased.
- New `TestInstanceReconcile_LeavesUppercaseULIDWhenClusterClassBelowFloor`: cluster class pinning an old image still holds the id with `ImageBelowFloor`.
- New `TestEnqueueInstancesFromClusterEngineClass`: one request per instance across namespaces, none for an unreferenced class.
- `TestInstanceReconcile_ContinuesWhenBoundEngineClassMissing` now also asserts the message names the cluster-scoped kind.
- `make lint`: 0 issues. `make test`: all packages pass.

For traceability: FB-3978.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes instance ID canonicalization and cluster-wide watches for a correctness bug that caused perpetual ImageResolveFailed and engine crashloops; behavior is aligned with existing engine reconciler resolution but touches core reconcile gating.
> 
> **Overview**
> Fixes **spec.id canonicalization** when bound engines use the shared **cluster SKU catalog** (`ClusterFireboltEngineClass`) instead of a namespaced `FireboltEngineClass`.
> 
> **Image resolution** now mirrors the engine reconciler: `resolvedBoundEngineClassInfo` looks up the namespaced class first, then the cluster-scoped class of the same name. Engines that only reference a catalog class no longer get stuck on `ImageResolveFailed`; missing both kinds still fails with a message that names **both** resource types.
> 
> The instance controller **watches** `ClusterFireboltEngineClass` (spec/generation changes only) and **enqueues** one reconcile per affected instance across namespaces when catalog image pins change—same motivation as the existing namespaced class watch.
> 
> Tests cover successful canonicalization via cluster class, below-floor behavior, cluster-class enqueue fan-out, and the updated resolve-error message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7377115f89a6b1d601e0988afcff8a91c0677374. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->