### PR TITLE
ci(formal): re-pin tla2tools to the current v1.8.0 build (FB-3983)

### DIFF
--- a/scripts/ci/pinned-tools.tsv
+++ b/scripts/ci/pinned-tools.tsv
@@ -19,8 +19,10 @@
 #   yq         .../checksums (SHA-256 is the column named in checksums_hashes_order)
 #   helm-docs  .../checksums.txt
 # tlaplus publishes no checksums, so tla2tools.jar is pinned from the artifact
-# itself; a mismatch there means the release tag was re-cut and needs a look
-# before the digest is updated.
+# itself. Its v1.8.0 pre-release asset is rebuilt from upstream master on every
+# push, so a mismatch on that row is expected churn rather than a re-cut tag:
+# download the current jar, run `make formal-check formal-check-counterexample
+# formal-verify` against it, and update the digest only if all three pass.
 
 kind       amd64  eb244cbafcc157dff60cf68693c14c9a75c4e6e6fedaf9cd71c58117cb93e3fa  https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64
 kind       arm64  8e1014e87c34901cc422a1445866835d1e666f2a61301c27e722bdeab5a1f7e4  https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-arm64
@@ -28,4 +30,4 @@ yq         amd64  a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9e
 yq         arm64  0e7e1524f68d91b3ff9b089872d185940ab0fa020a5a9052046ef10547023156  https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_arm64
 helm-docs  amd64  a8cf72ada34fad93285ba2a452b38bdc5bd52cc9a571236244ec31022928d6cc  https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz
 helm-docs  arm64  c3787212332386dcd122debef7848feb165aa701467ae3e3442df7638f3ac4e4  https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_arm64.tar.gz
-tla2tools  any    ab323b79802aedc3203b3f9af37c6aca3ed43f4e0225b36f2aa77b26de46c05f  https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar
+tla2tools  any    8836549e83db7f0b3f9fdde679ab56270d18e06198366d217d960738c02b9dbe  https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar


### PR DESCRIPTION
**Background**

FB-3983: the tlaplus v1.8.0 pre-release asset is rebuilt upstream on every push, so the pinned digest references an artifact that no longer exists; any CI cache miss fails closed.

**Summary**

- Update the `tla2tools` digest to the current build.
- Note in the manifest that churn on this row is expected, and which checks gate a new digest.

**Test Plan**

- `fetch-verified.sh tla2tools` succeeds; `internal/ci` manifest tests pass.
- `make formal-check`, the counterexample controls and `make formal-verify` pass; regenerated fixtures byte-identical.
