### PR TITLE
fix(gateway): retry only conditions that precede request delivery (FB-3097)

### DIFF
--- a/docs/instance/gateway/gateway-query-routing.mdx
+++ b/docs/instance/gateway/gateway-query-routing.mdx
@@ -37,7 +37,7 @@ Creating, scaling, or rolling an Engine does not restart the Gateway. Engine des
 
 ## Retry behavior
 
-The Gateway retries connection failures, refused streams, resets, and a shutdown response marked `X-Firebolt-Drained`. It does not retry arbitrary HTTP 5xx responses because the Engine might already have applied a request's side effects.
+The Gateway retries connection failures, refused streams, resets that occur before the request is sent, and a shutdown response marked `X-Firebolt-Drained`. It does not retry arbitrary HTTP 5xx responses because the Engine might already have applied a request's side effects.
 
 Requests with bodies up to 2 MiB can be replayed during a retry. Larger request bodies are forwarded without retry buffering, so a cutover-related failure is returned to the client. Split large ingest or multi-statement requests if they must tolerate Engine cutovers.
 

--- a/internal/controller/instance_gateway.go
+++ b/internal/controller/instance_gateway.go
@@ -147,9 +147,9 @@ const (
 	//      replay a request whose full body fits in this buffer. The
 	//      X-Firebolt-Drained retry rule (see retry_policy below) and the
 	//      transport-failure retries (`connect-failure`, `refused-stream`,
-	//      `reset`) ALL share this constraint. A request body larger than
-	//      this limit is dispatched without buffering and any 5xx it
-	//      receives — including a retry-safe shutdown-fence 503 —
+	//      `reset-before-request`) ALL share this constraint. A request
+	//      body larger than this limit is dispatched without buffering and
+	//      any 5xx it receives — including a retry-safe shutdown-fence 503 —
 	//      propagates to the client unretried, breaking the zero-downtime
 	//      contract for that request. The chosen 2 MiB covers typical
 	//      Firebolt SQL plus modest COPY ingest with headroom; jobs that
@@ -993,10 +993,20 @@ func buildEnvoyConfigYAML(instance *computev1alpha1.FireboltInstance, wakeEnable
                             # "gateway-error" here: those match 5xx responses
                             # RETURNED BY THE ENGINE, which may have already
                             # executed side effects (e.g. a DML statement that
-                            # partially mutated state). "5xx" returned by
-                            # Envoy itself (flags=UF/URX, zero upstream bytes)
-                            # falls under connect-failure/reset and is already
-                            # covered.
+                            # partially mutated state).
+                            #
+                            # Nor do we list "reset". A 503 that Envoy itself
+                            # synthesizes for a stream reset AFTER the request
+                            # was sent ("upstream connect error or
+                            # disconnect/reset before headers", flags=UC/UR)
+                            # is intentionally NOT retried: the engine may
+                            # have received the request and started executing
+                            # it. Of Envoy's own local replies only the
+                            # connect-phase ones (flags=UF, zero bytes sent
+                            # upstream) are retried, via connect-failure
+                            # above. Do not add "reset" back to make such
+                            # 503s disappear - it would replay delivered
+                            # requests.
                             #
                             # num_retries is set well above the steady-state
                             # replica count of any one engine. Combined with

--- a/internal/controller/instance_gateway.go
+++ b/internal/controller/instance_gateway.go
@@ -973,8 +973,9 @@ func buildEnvoyConfigYAML(instance *computev1alpha1.FireboltInstance, wakeEnable
                             #   - refused-stream:  HTTP/2 REFUSED_STREAM - the
                             #     peer explicitly told us the stream was not
                             #     processed.
-                            #   - reset:           stream reset before any
-                            #     response bytes - same guarantee as
+                            #   - reset-before-request: the stream was reset
+                            #     before the request was sent, so the engine
+                            #     never received it - same guarantee as
                             #     connect-failure.
                             #   - retriable-headers (X-Firebolt-Drained):
                             #     a 503 emitted by the engine's pre-work
@@ -1013,7 +1014,7 @@ func buildEnvoyConfigYAML(instance *computev1alpha1.FireboltInstance, wakeEnable
                             # per_try_timeout, so legitimate long-running
                             # queries are never cut off mid-flight.
                             retry_policy:
-                              retry_on: connect-failure,refused-stream,reset,retriable-headers
+                              retry_on: connect-failure,refused-stream,reset-before-request,retriable-headers
                               retriable_headers:
                                 - name: X-Firebolt-Drained
                                   present_match: true

--- a/internal/controller/instance_gateway_test.go
+++ b/internal/controller/instance_gateway_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"regexp"
 	"slices"
 	"strings"
@@ -815,18 +816,17 @@ func TestBuildEnvoyConfigYAMLDFPNoSearchDomains(t *testing.T) {
 }
 
 // TestBuildEnvoyConfigYAMLRetryPolicy guards the retry contract:
-//   - We retry on connect-failure / refused-stream / reset (transport-level
-//     failures where the engine could not have observed the request).
+//   - We retry on connect-failure / refused-stream / reset-before-request,
+//     which establish that the engine has not processed the request.
 //   - We retry on retriable-headers, gated by present_match on
 //     X-Firebolt-Drained. The engine's shutdown fence sets that header
 //     before any executor / Storage Manager work runs, so the request is
-//     provably side-effect free; treating those 503s as retriable is the
-//     only way the gateway can return a successful response when a query
-//     lands on a pod between SIGTERM and the EndpointSlice update.
+//     safe to retry when it reaches a draining pod before discovery
+//     withdraws that pod. This does not cover ambiguous connection resets.
 //   - We do NOT retry on bare 5xx; that would risk replaying a write that
 //     the engine partially applied before failing.
-//   - previous_hosts retry-host predicate is preserved; without it the
-//     retry could land on the same draining pod and fail again.
+//   - previous_hosts is configured to prefer an untried endpoint. Host
+//     selection has a bounded attempt count and can reuse a prior endpoint.
 func TestBuildEnvoyConfigYAMLRetryPolicy(t *testing.T) {
 	got := buildEnvoyConfigYAML(&computev1alpha1.FireboltInstance{
 		ObjectMeta: metav1.ObjectMeta{Name: "inst", Namespace: "ns-1"},
@@ -840,49 +840,30 @@ func TestBuildEnvoyConfigYAMLRetryPolicy(t *testing.T) {
 	retry := dfpRouteRetryPolicy(t, parsed)
 
 	retryOn, _ := retry["retry_on"].(string)
-	for _, want := range []string{"connect-failure", "refused-stream", "reset", "retriable-headers"} {
-		if !strings.Contains(retryOn, want) {
-			t.Errorf("retry_on %q is missing %q", retryOn, want)
-		}
-	}
-	for _, banned := range []string{"5xx", "gateway-error"} {
-		if strings.Contains(retryOn, banned) {
-			t.Errorf("retry_on %q must not include %q (would retry side-effecting 5xx)", retryOn, banned)
-		}
+	conditions := strings.Split(retryOn, ",")
+	slices.Sort(conditions)
+	wantConditions := []string{"connect-failure", "refused-stream", "reset-before-request", "retriable-headers"}
+	// Exact tokens exclude general reset and 5xx retries, which can replay
+	// requests the engine has already received or executed.
+	if !slices.Equal(conditions, wantConditions) {
+		t.Errorf("retry_on conditions = %q, want %q", conditions, wantConditions)
 	}
 
-	// retriable_headers must include X-Firebolt-Drained with present_match.
-	headers, ok := retry["retriable_headers"].([]any)
-	if !ok || len(headers) == 0 {
-		t.Fatalf("retriable_headers missing or not a list; got %T = %v", retry["retriable_headers"], retry["retriable_headers"])
-	}
-	foundDrained := false
-	for _, h := range headers {
-		hm, _ := h.(map[string]any)
-		if hm == nil {
-			continue
-		}
-		if name, _ := hm["name"].(string); strings.EqualFold(name, "X-Firebolt-Drained") {
-			if pm, _ := hm["present_match"].(bool); pm {
-				foundDrained = true
-			}
-		}
-	}
-	if !foundDrained {
-		t.Errorf("retriable_headers does not include X-Firebolt-Drained with present_match=true; got %v", headers)
+	// Do not allow additional header matchers or an inverted drained matcher
+	// to broaden retries to responses that may follow query execution.
+	wantHeaders := []any{map[string]any{"name": "X-Firebolt-Drained", "present_match": true}}
+	if !reflect.DeepEqual(retry["retriable_headers"], wantHeaders) {
+		t.Errorf("retriable_headers = %v, want only the pre-work drained marker", retry["retriable_headers"])
 	}
 
-	// previous_hosts predicate must be preserved.
+	// Pin the configured preference, not a promise of unique retry targets.
 	preds, _ := retry["retry_host_predicate"].([]any)
-	hasPrev := false
-	for _, p := range preds {
-		pm, _ := p.(map[string]any)
-		if name, _ := pm["name"].(string); strings.Contains(name, "previous_hosts") {
-			hasPrev = true
-		}
+	if len(preds) != 1 {
+		t.Fatalf("retry_host_predicate = %v, want only previous_hosts", preds)
 	}
-	if !hasPrev {
-		t.Error("retry_host_predicate missing previous_hosts; without it a retry can land on the same draining pod")
+	predicate, _ := preds[0].(map[string]any)
+	if predicate["name"] != "envoy.retry_host_predicates.previous_hosts" {
+		t.Errorf("retry_host_predicate name = %v, want previous_hosts", predicate["name"])
 	}
 }
 

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -1898,17 +1898,33 @@ func execCurlQueryWithDeadline(
 	// local reply ("no healthy upstream", "upstream connect error or
 	// disconnect/reset before headers") identifies itself. Transient 5xx
 	// diagnosis during blue-green depends on seeing it.
-	if m := regexp.MustCompile(`code=(\d{3})`).FindStringSubmatch(stderrBuf.String()); m != nil {
-		if code, convErr := strconv.Atoi(m[1]); convErr == nil && code >= 400 {
-			body := strings.Join(strings.Fields(stdoutBuf.String()), " ")
-			if len(body) > 200 {
-				body = body[:200]
-			}
-			return "", fmt.Errorf("HTTP %d: %s | body: %s",
-				code, strings.TrimSpace(stderrBuf.String()), body)
-		}
+	//
+	// This makes the -w line the ONLY HTTP-error detector, so its absence
+	// must fail closed: if the kubectl exec stream mangled stderr and the
+	// timings line never arrived, treating the run as a success would let a
+	// 503 body pass as a query result and silence the zero-failure specs.
+	stderr := strings.TrimSpace(stderrBuf.String())
+	m := regexp.MustCompile(`timings: code=(\d{3})`).FindStringSubmatch(stderr)
+	if m == nil {
+		return "", fmt.Errorf("curl exited 0 but no timings line on stderr; stderr: %q | body: %s",
+			stderr, bodySnippet(stdoutBuf.String()))
+	}
+	code, _ := strconv.Atoi(m[1]) // \d{3} guarantees a parseable integer
+	if code >= 400 {
+		return "", fmt.Errorf("HTTP %d: %s | body: %s", code, stderr, bodySnippet(stdoutBuf.String()))
 	}
 	return stdoutBuf.String(), nil
+}
+
+// bodySnippet collapses a response body onto one line and truncates it so an
+// error message carries enough of an Envoy local reply to identify it without
+// dumping a whole result set.
+func bodySnippet(body string) string {
+	body = strings.Join(strings.Fields(body), " ")
+	if len(body) > 200 {
+		body = body[:200]
+	}
+	return body
 }
 
 // kubectlArgs prepends --context if KIND_CLUSTER is set.

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -1870,7 +1871,7 @@ func execCurlQueryWithDeadline(
 		"connect=%{time_connect}s starttransfer=%{time_starttransfer}s total=%{time_total}s\n"
 
 	curlArgs := []string{
-		"-sSf",
+		"-sS",
 		"--connect-timeout", "2",
 		"--max-time", strconv.Itoa(maxTimeSeconds),
 		"-w", curlTimingFmt,
@@ -1891,6 +1892,21 @@ func execCurlQueryWithDeadline(
 	cmd.Stderr = &stderrBuf
 	if err := cmd.Run(); err != nil {
 		return "", fmt.Errorf("curl failed (exit %v): %s", err, strings.TrimSpace(stderrBuf.String()))
+	}
+	// HTTP errors are detected here rather than with curl -f, because -f
+	// discards the response body and the body is the only place an Envoy
+	// local reply ("no healthy upstream", "upstream connect error or
+	// disconnect/reset before headers") identifies itself. Transient 5xx
+	// diagnosis during blue-green depends on seeing it.
+	if m := regexp.MustCompile(`code=(\d{3})`).FindStringSubmatch(stderrBuf.String()); m != nil {
+		if code, convErr := strconv.Atoi(m[1]); convErr == nil && code >= 400 {
+			body := strings.Join(strings.Fields(stdoutBuf.String()), " ")
+			if len(body) > 200 {
+				body = body[:200]
+			}
+			return "", fmt.Errorf("HTTP %d: %s | body: %s",
+				code, strings.TrimSpace(stderrBuf.String()), body)
+		}
 	}
 	return stdoutBuf.String(), nil
 }
@@ -1969,6 +1985,10 @@ func ParseQueryResult(output string) (interface{}, error) {
 // categorizeQueryError extracts a short category from an error detail string.
 func categorizeQueryError(detail string) string {
 	switch {
+	case strings.Contains(detail, "no healthy upstream"):
+		return "503 no healthy upstream (envoy local reply)"
+	case strings.Contains(detail, "disconnect/reset before headers"):
+		return "503 upstream reset (envoy local reply)"
 	case strings.Contains(detail, "connection refused"):
 		return "connection refused"
 	case strings.Contains(detail, "timeout"):


### PR DESCRIPTION
The E2E zero-failure assertions require the Engine to finish accepted work on SIGTERM; released Engine images now provide that behavior, and this PR's green E2E gate is the proof. The sampler instrumentation in this PR is what pinned the earlier failures to that gap.

**Background**

FB-3097: the gateway retry policy includes `reset`, which matches stream resets after the request reached the Engine, so Envoy can replay a query whose side effects were already applied.

**Summary**

- Replace `reset` with `reset-before-request`; keep connect-failure, refused-stream and the drained-header condition.
- Pin the exact condition set and drained matcher in `TestBuildEnvoyConfigYAMLRetryPolicy`.
- State the delivered-request boundary in the gateway query-routing doc.

**Test Plan**

- Unit test passes, and fails against the previous `reset` policy.
- Build, vet, lint pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes live gateway retry semantics during engine cutovers; incorrect policy could either replay side-effecting queries or surface more transient 503s when upstream resets occur after delivery.
> 
> **Overview**
> **Narrows gateway Envoy retries** so queries are not replayed after the Engine may have already received them (FB-3097).
> 
> The rendered `retry_on` list replaces **`reset`** with **`reset-before-request`**, keeping connect-failure, refused-stream, and **`X-Firebolt-Drained`** header retries. Inline comments document why broad **`reset`** / **`5xx`** retries are unsafe. Gateway query-routing docs now state that only pre-send resets are retried.
> 
> **Tests:** `TestBuildEnvoyConfigYAMLRetryPolicy` pins the exact retry token set and drained-header matcher. E2E curl helpers drop **`curl -f`**, classify HTTP status from the stderr timings line (and fail if it is missing), and label common Envoy local-reply bodies for blue/green diagnostics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d74d6f67e74de530b5816e10e95af430dbd8740. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


