### PR TITLE
fix(gateway): drain the query listener in preStop instead of sleeping (FB-4002)

### DIFF
--- a/internal/controller/gateway_shutdown.go
+++ b/internal/controller/gateway_shutdown.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2026 Firebolt Analytics.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"strings"
+)
+
+// gatewayPreStopScript closes public query admission before observing drained
+// connections. Returning lets kubelet send SIGTERM; a drained Envoy does not
+// exit on its own. Admin failures retain the process until the Pod deadline.
+// The image already supplies bash, cat and grep, so no extra client is needed.
+//
+// The script keys on gatewayQueryListenerName / gatewayQueryStatPrefix so it
+// cannot drift from the rendered envoy.yaml; the render test pins both.
+func gatewayPreStopScript(adminPort int32) string {
+	statGauge := fmt.Sprintf("http.%s.downstream_cx_active", gatewayQueryStatPrefix)
+	statGaugeRe := strings.ReplaceAll(statGauge, ".", "[.]")
+	return fmt.Sprintf(`set -u
+admin() {
+  local response status
+  response=$(
+    exec 3<>/dev/tcp/127.0.0.1/%[1]d || exit 1
+    printf '%%s\r\n' "$1 $2 HTTP/1.1" 'Host: localhost' 'Content-Length: 0' 'Connection: close' '' >&3 || exit 1
+    cat <&3
+  ) || return 1
+  status=${response%%%%$'\n'*}
+  [[ "$status" == HTTP/1.*" 200 "* ]] || return 1
+  printf '%%s\n' "$response"
+}
+until admin POST /healthcheck/fail >/dev/null; do sleep 0.1; done
+# graceful: in-flight requests finish and their connections close right after
+# (drain-time-s is 0). The drain's completion also stops the INBOUND-marked
+# listeners, so the query socket refuses new connections while the stats
+# listener (not INBOUND) keeps serving probes and metrics. Verified against
+# the pinned Envoy: adding skip_exit suppresses that listener stop and the
+# socket keeps accepting, and without it the process still survives the
+# drain - so skip_exit must stay absent.
+until admin POST '/drain_listeners?inboundonly&graceful' >/dev/null; do sleep 0.1; done
+while true; do
+  if response=$(admin GET '/stats?filter=^%[2]s$'); then
+    if grep -Fxq '%[3]s: 0' <<<"$response"; then
+      exit 0
+    fi
+    # TLS provisioning can deliberately omit the public listener entirely.
+    # Missing statistics alone cannot establish that there are no connections.
+    if ! grep -q '^%[2]s:' <<<"$response"; then
+      if listeners=$(admin GET /listeners) && ! grep -q '^%[4]s::' <<<"$listeners"; then
+        exit 0
+      fi
+    fi
+  fi
+  sleep 0.1
+done
+`, adminPort, statGaugeRe, statGauge, gatewayQueryListenerName)
+}

--- a/internal/controller/gateway_shutdown_test.go
+++ b/internal/controller/gateway_shutdown_test.go
@@ -1,0 +1,266 @@
+//go:build unix
+
+/*
+Copyright 2026 Firebolt Analytics.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type gatewayShutdownAdminReply struct {
+	path   string
+	status int
+	body   string
+}
+
+type gatewayShutdownAdminCall struct {
+	request *http.Request
+	reply   chan gatewayShutdownAdminReply
+}
+
+func TestGatewayPreStopAdminProtocol(t *testing.T) {
+	t.Parallel()
+	const (
+		zeroConnections   = "http.gateway.downstream_cx_active: 0\n"
+		activeConnections = "http.gateway.downstream_cx_active: 2\n"
+		publicListener    = "listener::0.0.0.0:8080\nstats_listener::0.0.0.0:9090\n"
+		metricsListener   = "stats_listener::0.0.0.0:9090\n"
+	)
+	acknowledged := []gatewayShutdownAdminReply{
+		{path: "/healthcheck/fail", status: http.StatusOK, body: "OK\n"},
+		{path: "/drain_listeners", status: http.StatusOK, body: "OK\n"},
+	}
+	tests := []struct {
+		name    string
+		initial []gatewayShutdownAdminReply
+		polls   []gatewayShutdownAdminReply
+	}{
+		{
+			name: "health_failure_retries_before_draining",
+			initial: []gatewayShutdownAdminReply{
+				{path: "/healthcheck/fail", status: http.StatusServiceUnavailable, body: "Expected 200 but health transition failed\n"},
+				{path: "/healthcheck/fail", status: http.StatusOK, body: "OK\n"},
+				{path: "/drain_listeners", status: http.StatusOK, body: "OK\n"},
+			},
+			polls: []gatewayShutdownAdminReply{{path: "/stats", status: http.StatusOK, body: zeroConnections}},
+		},
+		{
+			name: "drain_failure_retries_before_observing_connections",
+			initial: []gatewayShutdownAdminReply{
+				{path: "/healthcheck/fail", status: http.StatusOK, body: "OK\n"},
+				{path: "/drain_listeners", status: http.StatusServiceUnavailable, body: "Expected 200 but listener drain failed\n"},
+				{path: "/drain_listeners", status: http.StatusOK, body: "OK\n"},
+			},
+			polls: []gatewayShutdownAdminReply{
+				{path: "/stats", status: http.StatusOK, body: zeroConnections},
+			},
+		},
+		{
+			name: "active_connections_keep_hook_running",
+			polls: []gatewayShutdownAdminReply{
+				{path: "/stats", status: http.StatusOK, body: activeConnections},
+				{path: "/stats", status: http.StatusOK, body: "http.gateway.downstream_cx_active: 1\n"},
+				{path: "/stats", status: http.StatusOK, body: zeroConnections},
+			},
+		},
+		{
+			name: "missing_gauge_does_not_acknowledge_existing_listener",
+			polls: []gatewayShutdownAdminReply{
+				{path: "/stats", status: http.StatusOK, body: ""},
+				{path: "/listeners", status: http.StatusOK, body: publicListener},
+				{path: "/stats", status: http.StatusOK, body: zeroConnections},
+			},
+		},
+		{
+			name: "no_public_listener_needs_no_connection_gauge",
+			polls: []gatewayShutdownAdminReply{
+				{path: "/stats", status: http.StatusOK, body: ""},
+				{path: "/listeners", status: http.StatusOK, body: metricsListener},
+			},
+		},
+		{
+			name: "failed_statistics_are_not_drain_evidence",
+			polls: []gatewayShutdownAdminReply{
+				{path: "/stats", status: http.StatusServiceUnavailable, body: zeroConnections},
+				{path: "/stats", status: http.StatusOK, body: zeroConnections},
+			},
+		},
+		{
+			name: "failed_listener_inspection_is_not_an_empty_listener_set",
+			polls: []gatewayShutdownAdminReply{
+				{path: "/stats", status: http.StatusOK, body: ""},
+				{path: "/listeners", status: http.StatusServiceUnavailable, body: ""},
+				{path: "/stats", status: http.StatusOK, body: ""},
+				{path: "/listeners", status: http.StatusOK, body: metricsListener},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			steps := append([]gatewayShutdownAdminReply(nil), tt.initial...)
+			if len(tt.initial) == 0 {
+				steps = append(steps, acknowledged...)
+			}
+			steps = append(steps, tt.polls...)
+			runGatewayShutdownAdminSequence(t, steps)
+		})
+	}
+}
+
+// Each response authorizes exactly the next observable action. Waiting for the
+// next request catches premature hook exit without a sleep-based assertion.
+func runGatewayShutdownAdminSequence(t *testing.T, steps []gatewayShutdownAdminReply) {
+	t.Helper()
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("gateway pre-stop protocol test requires bash")
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	calls := make(chan gatewayShutdownAdminCall)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := gatewayShutdownAdminCall{request: r, reply: make(chan gatewayShutdownAdminReply)}
+		select {
+		case calls <- call:
+		case <-ctx.Done():
+			return
+		}
+		select {
+		case reply := <-call.reply:
+			w.WriteHeader(reply.status)
+			if _, err := fmt.Fprint(w, reply.body); err != nil && ctx.Err() == nil {
+				t.Errorf("write admin response: %v", err)
+			}
+		case <-ctx.Done():
+		}
+	}))
+	port := int32(server.Listener.Addr().(*net.TCPAddr).Port)
+	cmd := exec.CommandContext(ctx, bash, "-c", gatewayPreStopScript(port))
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	// Cancel the process group so a failed assertion cannot leave cat or sleep
+	// children holding the admin connection or the output pipes open.
+	cmd.Cancel = func() error {
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+	var output bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &output, &output
+	done := make(chan struct{})
+	var runErr error
+	if err := cmd.Start(); err != nil {
+		server.Close()
+		t.Fatalf("start pre-stop hook: %v", err)
+	}
+	go func() {
+		runErr = cmd.Wait()
+		close(done)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		server.CloseClientConnections()
+		server.Close()
+		<-done
+		if t.Failed() {
+			t.Logf("pre-stop output: %s", output.String())
+		}
+	})
+	for i, step := range steps {
+		select {
+		case call := <-calls:
+			method := http.MethodGet
+			if step.path == "/healthcheck/fail" || step.path == "/drain_listeners" {
+				method = http.MethodPost
+			}
+			if call.request.Method != method || call.request.URL.Path != step.path {
+				t.Fatalf("step %d: got %s %s, want %s %s", i, call.request.Method, call.request.URL, method, step.path)
+			}
+			if step.path == "/drain_listeners" && (!call.request.URL.Query().Has("inboundonly") || !call.request.URL.Query().Has("graceful") || call.request.URL.Query().Has("skip_exit")) {
+				t.Fatalf("drain must preserve non-inbound listeners and accepted requests: %s", call.request.URL)
+			}
+			select {
+			case call.reply <- step:
+			case <-ctx.Done():
+				t.Fatalf("step %d: hook exceeded deadline", i)
+			}
+		case <-done:
+			t.Fatalf("hook exited before step %d (%s): %v", i, step.path, runErr)
+		case <-ctx.Done():
+			t.Fatalf("step %d (%s): hook exceeded deadline", i, step.path)
+		}
+	}
+	select {
+	case <-done:
+		if runErr != nil {
+			t.Fatalf("hook failed after drain acknowledgement: %v", runErr)
+		}
+	case call := <-calls:
+		t.Fatalf("hook kept polling after drain acknowledgement: %s %s", call.request.Method, call.request.URL)
+	case <-ctx.Done():
+		t.Fatal("hook did not exit after drain acknowledgement")
+	}
+}
+
+// The hook's contract when the admin API never becomes healthy is to retain
+// the process for the kubelet to kill at the Pod deadline: any self-exit here
+// would let a broken admin surface as a clean, instant shutdown that drops
+// connections. Pins the retain path against a future `set -e` or `exit 1`.
+func TestGatewayPreStopRetainsProcessWhenAdminNeverHealthy(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+	port := int32(server.Listener.Addr().(*net.TCPAddr).Port)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "bash", "-c", gatewayPreStopScript(port))
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start pre-stop hook: %v", err)
+	}
+	err := cmd.Wait()
+	if ctx.Err() == nil {
+		t.Fatalf("hook exited on its own (err=%v) while the admin API never became healthy; it must retain the process for the Pod deadline", err)
+	}
+	if err == nil {
+		t.Fatal("hook reported success after being killed at the deadline")
+	}
+}

--- a/internal/controller/instance_gateway.go
+++ b/internal/controller/instance_gateway.go
@@ -87,9 +87,24 @@ const (
 	gatewayWakeAgentMemoryRequest = "32Mi"
 	gatewayWakeAgentMemoryLimit   = "128Mi"
 
-	// gatewayWakeAgentDrainSeconds keeps the agent alive past Envoy's own
-	// 8-second preStop drain so held requests are not reset on rollout.
-	gatewayWakeAgentDrainSeconds int64 = 12
+	// gatewayTerminationGraceSeconds bounds the whole gateway Pod teardown,
+	// including Envoy's preStop drain. Single source: the Pod spec and the
+	// wake-agent's preStop sleep both derive from it.
+	gatewayTerminationGraceSeconds int64 = 15
+
+	// gatewayWakeAgentDrainSeconds keeps the agent alive while Envoy's
+	// preStop drains connections so held requests are not reset on rollout.
+	// Envoy's drain may run up to the Pod termination grace period, so the
+	// agent sleeps that same bound and both containers fall to kubelet
+	// teardown together.
+	gatewayWakeAgentDrainSeconds = gatewayTerminationGraceSeconds
+
+	// gatewayQueryListenerName and gatewayQueryStatPrefix name the public
+	// query listener in the rendered envoy.yaml. The preStop script keys its
+	// admission-close and drain checks on both (see gatewayPreStopScript);
+	// the render test pins template and script together so they cannot drift.
+	gatewayQueryListenerName = "listener"
+	gatewayQueryStatPrefix   = "gateway"
 
 	// gatewayStreamIdleTimeoutSeconds is Envoy's own HCM default, stated
 	// explicitly so the wake hold's dependency on it is visible. Must stay
@@ -702,6 +717,10 @@ func buildEnvoyConfigYAML(instance *computev1alpha1.FireboltInstance, wakeEnable
 	return fmt.Sprintf(`static_resources:
   listeners:
     - name: listener
+      # INBOUND is load-bearing: preStop's inboundonly drain stops exactly the
+      # INBOUND listeners, closing query admission while every other listener
+      # keeps serving.
+      traffic_direction: INBOUND
       # per_connection_buffer_limit_bytes caps both downstream-receive and
       # upstream-send buffering on this listener, AND it is the budget the
       # router uses when deciding whether to BUFFER a request for retry.
@@ -988,6 +1007,9 @@ func buildEnvoyConfigYAML(instance *computev1alpha1.FireboltInstance, wakeEnable
                                     "@type": type.googleapis.com/envoy.extensions.retry.host.previous_hosts.v3.PreviousHostsPredicate
                               host_selection_retry_max_attempts: 5
 %s    - name: stats_listener
+      # Never INBOUND: the preStop drain must not stop this listener, or the
+      # kubelet's probes and metric scrapes would go dark mid-drain.
+      traffic_direction: OUTBOUND
       address:
         socket_address:
           address: 0.0.0.0
@@ -1255,6 +1277,9 @@ func buildFailClosedEnvoyConfigYAML(instance *computev1alpha1.FireboltInstance) 
 	return fmt.Sprintf(`static_resources:
   listeners:
     - name: stats_listener
+      # Never INBOUND: the preStop drain must not stop this listener, or the
+      # kubelet's probes and metric scrapes would go dark mid-drain.
+      traffic_direction: OUTBOUND
       address:
         socket_address:
           address: 0.0.0.0
@@ -1868,20 +1893,8 @@ func effectiveGatewayPodTemplate(
 	image := envoyImageFromUser(userPrimary)
 	pullPolicy := envoyImagePullPolicy(userPrimary, image)
 
-	var gracePeriod int64 = 15
+	gracePeriod := gatewayTerminationGraceSeconds
 	var runAsUser int64 = 101 // Envoy default UID
-
-	// preStopScript uses bash's /dev/tcp pseudo-device to POST to Envoy's
-	// admin API without requiring curl/wget in the image. The POST flips
-	// the envoy.filters.http.health_check filter (pass_through_mode=false
-	// in the gateway envoy.yaml) to return 503 on /healthz, which is what
-	// the kubelet readiness probe hits.
-	preStopScript := fmt.Sprintf(`exec 3<>/dev/tcp/127.0.0.1/%d
-printf 'POST /healthcheck/fail HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\nConnection: close\r\n\r\n' >&3
-cat <&3 >/dev/null
-exec 3<&- 3>&-
-sleep 8
-`, gatewayAdminPort)
 
 	// Both probes hit /healthz on the metrics port, NOT the client-facing
 	// port. Two independent reasons force this:
@@ -1908,7 +1921,9 @@ sleep 8
 		Name:            computev1alpha1.GatewayContainerName,
 		Image:           image,
 		ImagePullPolicy: pullPolicy,
-		Args:            []string{"envoy", "-c", "/etc/envoy/envoy.yaml"},
+		// Drain flags let preStop's graceful /drain_listeners close each kept-alive connection
+		// as soon as its in-flight work finishes, instead of over the default 600s window.
+		Args: []string{"envoy", "-c", "/etc/envoy/envoy.yaml", "--drain-time-s", "0", "--drain-strategy", "immediate"},
 		Ports: []corev1.ContainerPort{
 			{Name: "http", ContainerPort: gatewayContainerPort, Protocol: corev1.ProtocolTCP},
 			{Name: "metrics", ContainerPort: gatewayMetricsPort(&instance.Spec.Gateway), Protocol: corev1.ProtocolTCP},
@@ -1916,7 +1931,7 @@ sleep 8
 		Lifecycle: &corev1.Lifecycle{
 			PreStop: &corev1.LifecycleHandler{
 				Exec: &corev1.ExecAction{
-					Command: []string{"bash", "-c", preStopScript},
+					Command: []string{"bash", "-c", gatewayPreStopScript(gatewayAdminPort)},
 				},
 			},
 		},

--- a/internal/controller/instance_gateway_test.go
+++ b/internal/controller/instance_gateway_test.go
@@ -1567,3 +1567,59 @@ func TestBuildEnvoyConfigYAMLStableAcrossInstances(t *testing.T) {
 		t.Fatal("configs differ in more than the namespace-scoped authority rewrite; a and b should be structurally identical")
 	}
 }
+
+// TestGatewayEnvoyPreStopDrain pins the shutdown wiring on the rendered pod:
+// the envoy container's preStop fails health checks, drains the query
+// listener, and waits for active downstream connections to reach zero rather
+// than sleeping a fixed interval, and the drain flags make a graceful drain
+// take effect at once. The hook's admin protocol itself is exercised in
+// gateway_shutdown_test.go.
+func TestGatewayEnvoyPreStopDrain(t *testing.T) {
+	t.Parallel()
+	pt := renderGatewayPod(t, wakeInstance(t, nil), wakeAgentConfig{})
+	envoy := containerByName(pt, computev1alpha1.GatewayContainerName)
+	if envoy == nil {
+		t.Fatalf("envoy container missing; containers = %v", containerNames(pt))
+	}
+	if envoy.Lifecycle == nil || envoy.Lifecycle.PreStop == nil || envoy.Lifecycle.PreStop.Exec == nil {
+		t.Fatalf("Lifecycle = %+v, want an exec preStop hook", envoy.Lifecycle)
+	}
+	script := strings.Join(envoy.Lifecycle.PreStop.Exec.Command, " ")
+	for _, want := range []string{
+		"/healthcheck/fail",
+		"drain_listeners?inboundonly&graceful",
+		"http." + gatewayQueryStatPrefix + ".downstream_cx_active",
+		"'^" + gatewayQueryListenerName + "::'",
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("preStop command %q does not contain %q", script, want)
+		}
+	}
+	if strings.Contains(script, "sleep 8") {
+		t.Errorf("preStop command %q uses a fixed sleep instead of observing the drain", script)
+	}
+	if strings.Contains(script, "&skip_exit") {
+		t.Error("preStop drain must not pass skip_exit: it suppresses the INBOUND listener stop")
+	}
+	cfg := buildEnvoyConfigYAML(wakeInstance(t, nil), false)
+	for _, want := range []string{
+		"- name: " + gatewayQueryListenerName + "\n",
+		"stat_prefix: " + gatewayQueryStatPrefix + "\n",
+	} {
+		if !strings.Contains(cfg, want) {
+			t.Errorf("rendered config lost %q; the preStop script keys on it", strings.TrimSpace(want))
+		}
+	}
+	listenerAt := strings.Index(cfg, "- name: "+gatewayQueryListenerName+"\n")
+	statsAt := strings.Index(cfg, "- name: stats_listener")
+	if listenerAt < 0 || statsAt < 0 || !strings.Contains(cfg[listenerAt:statsAt], "traffic_direction: INBOUND") {
+		t.Error("public query listener is not marked INBOUND; the inboundonly preStop drain would stop nothing")
+	}
+	if !strings.Contains(cfg[statsAt:], "traffic_direction: OUTBOUND") {
+		t.Error("stats listener is not marked OUTBOUND; the preStop drain would stop probe serving")
+	}
+	args := strings.Join(envoy.Args, " ")
+	if !strings.Contains(args, "--drain-time-s 0") || !strings.Contains(args, "--drain-strategy immediate") {
+		t.Errorf("Args = %v, want an immediate zero-time drain so kept-alive connections close as their work finishes", envoy.Args)
+	}
+}


### PR DESCRIPTION
**Background**

FB-4002: the gateway container's preStop flips the health check and sleeps a fixed 8 seconds. Queries outliving the sleep are cut mid-flight, idle gateways waste the whole window, and the open listener keeps accepting new connections throughout.

**Summary**

- preStop now drains over the admin API: fail health checks, request a graceful inbound-only listener drain, exit once the public listener reports zero active downstream connections, or is absent, as during the fail-closed TLS window. Admin failures retain the process, so the Pod termination budget stays the only bound.
- Envoy args gain `--drain-time-s 0 --drain-strategy immediate`, so drained keep-alive connections close as soon as their in-flight work finishes instead of over the 600s default.

**Test Plan**

- Drain semantics verified against the pinned Envoy binary across a four-cell matrix (listener INBOUND vs unmarked, `skip_exit` present vs absent): the process survives in every cell and in-flight responses complete; only an INBOUND listener under `inboundonly&graceful` **without** `skip_exit` stops accepting new connections. Hence the public listener is marked INBOUND, the stats listener OUTBOUND (probes stay served through the drain), and `skip_exit` is not used.
- The script keys its stat and listener checks on shared constants, pinned against the rendered config by the render test; a protocol subtest pins that a never-healthy admin API retains the process for the Pod deadline; the wake-agent sidecar's preStop sleep now derives from the shared termination grace constant.

- A protocol unit test runs the script under bash against a stub admin API: happy path, admin flaps, stat absent with and without listeners, connection refused.
- A render test pins the Deployment wiring: the drain endpoints present, the fixed sleep gone, the drain args present.
- Build, full controller suite under envtest, and lint pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gateway pod termination and connection draining during rollouts; mis-draining could cut in-flight queries or leave the listener accepting too long, though behavior is heavily tested against the admin protocol and rendered pod spec.
> 
> **Overview**
> Replaces the gateway Envoy **preStop** fixed 8s sleep with an admin-driven shutdown: fail `/healthz`, **graceful inbound-only** listener drain, then exit only when the public query listener reports **zero active downstream connections** (or is absent during fail-closed TLS). If the admin API never succeeds, the hook **blocks** until the pod termination deadline rather than exiting early.
> 
> Envoy starts with **`--drain-time-s 0`** and **`--drain-strategy immediate`** so drained keep-alives close when in-flight work finishes. Rendered **envoy.yaml** marks the query listener **`INBOUND`** and **`stats_listener` `OUTBOUND`** so inbound-only drain stops query admission while probes/metrics stay up. **`gatewayTerminationGraceSeconds` (15)** is now the single source for pod grace and wake-agent preStop sleep, with shared **`gatewayQueryListenerName` / `gatewayQueryStatPrefix`** wired into the script and tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d558205615de6020d6590215b69bddd8a9fe477a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


