### PR TITLE
fix(gateway): advertise ALPN on the TLS listener (FB-4003)

### DIFF
--- a/internal/controller/instance_gateway.go
+++ b/internal/controller/instance_gateway.go
@@ -677,6 +677,7 @@ func buildListenerDownstreamTLSTransportSocket(instance *computev1alpha1.Firebol
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
               common_tls_context:
+                alpn_protocols: [h2, http/1.1]
                 tls_params:
                   tls_minimum_protocol_version: %s
                 tls_certificates:

--- a/internal/controller/instance_gateway_test.go
+++ b/internal/controller/instance_gateway_test.go
@@ -1261,6 +1261,11 @@ func TestBuildEnvoyConfigYAML_GatewayTLSDisabled_NoTransportSocket(t *testing.T)
 	if _, present := fc["transport_socket"]; present {
 		t.Errorf("client-facing listener has transport_socket with gateway TLS disabled: %v", fc["transport_socket"])
 	}
+	// ALPN is a TLS-only concept: it lives inside the DownstreamTlsContext,
+	// so a plaintext config must not mention it anywhere.
+	if strings.Contains(got, "alpn_protocols") {
+		t.Error("plaintext config mentions alpn_protocols; got:\n" + got)
+	}
 }
 
 // TestBuildEnvoyConfigYAML_GatewayTLSDisabled_ByteIdenticalAcrossReconciles
@@ -1335,7 +1340,8 @@ func listenerNames(t *testing.T, parsed map[string]any) []string {
 
 // TestBuildEnvoyConfigYAML_GatewayTLSReady_TransportSocketConfigured pins
 // down the downstream TLS shape once gateway TLS is ready: a
-// DownstreamTlsContext presenting the mounted certificate/key pair.
+// DownstreamTlsContext presenting the mounted certificate/key pair and
+// advertising h2/http1.1 through ALPN.
 func TestBuildEnvoyConfigYAML_GatewayTLSReady_TransportSocketConfigured(t *testing.T) {
 	got := buildEnvoyConfigYAML(&computev1alpha1.FireboltInstance{
 		ObjectMeta: metav1.ObjectMeta{Name: "inst", Namespace: "ns-1"},
@@ -1370,6 +1376,15 @@ func TestBuildEnvoyConfigYAML_GatewayTLSReady_TransportSocketConfigured(t *testi
 	commonTLS, ok := typedConfig["common_tls_context"].(map[string]any)
 	if !ok {
 		t.Fatalf("typed_config.common_tls_context missing or wrong type: %T", typedConfig["common_tls_context"])
+	}
+	// ALPN must offer h2 before http/1.1 so TLS clients can negotiate
+	// HTTP/2 while HTTP/1.1-only clients still connect.
+	alpn, ok := commonTLS["alpn_protocols"].([]any)
+	if !ok {
+		t.Fatalf("common_tls_context.alpn_protocols missing or wrong type: %T", commonTLS["alpn_protocols"])
+	}
+	if want := []any{"h2", "http/1.1"}; !slices.Equal(alpn, want) {
+		t.Errorf("alpn_protocols = %v, want %v", alpn, want)
 	}
 	certs, ok := commonTLS["tls_certificates"].([]any)
 	if !ok || len(certs) != 1 {


### PR DESCRIPTION
**Background**

FB-4003: the gateway's client-facing TLS listener advertises no ALPN, so TLS clients can never negotiate HTTP/2.

**Summary**

- Advertise `h2, http/1.1` on the DownstreamTlsContext. The connection manager's codec is AUTO, so Envoy selects the codec from the negotiated protocol. Plaintext listeners are unchanged.

**Test Plan**

- The TLS config-shape test pins `alpn_protocols` as exactly h2 then http/1.1; the plaintext test pins its absence. Mutating the order fails the test.
- Build, full controller suite under envtest, and lint pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to gateway TLS Envoy config generation; plaintext and non-TLS instances are unchanged, with tests pinning ALPN presence and order.
> 
> **Overview**
> Fixes **FB-4003** by advertising **ALPN** on the gateway’s client-facing TLS listener so clients can negotiate **HTTP/2** over TLS.
> 
> When gateway downstream TLS is active, the generated Envoy `DownstreamTlsContext` now sets `alpn_protocols: [h2, http/1.1]` (h2 first, then HTTP/1.1). **Plaintext** listeners are unchanged—no `transport_socket`, and emitted YAML must not mention `alpn_protocols`.
> 
> Tests lock in the TLS shape (`alpn_protocols` exactly `h2` then `http/1.1`) and assert ALPN is absent when gateway TLS is disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f7f924ea7eadeb1a9182e28dfd762c808802a0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->