### PR TITLE
fix(gateway): probe routability through Envoy before releasing held wake queries (FB-3986)

### DIFF
--- a/cmd/wakeagent.go
+++ b/cmd/wakeagent.go
@@ -59,6 +59,7 @@ func runWakeAgent(args []string) error {
 		fallbackCap     int
 		holdTimeout     time.Duration
 		demandRetention time.Duration
+		routeProbeURL   string
 	)
 
 	fs.StringVar(&namespace, "namespace", os.Getenv("POD_NAMESPACE"),
@@ -83,6 +84,10 @@ func runWakeAgent(args []string) error {
 		"How long a request is held before the agent gives up and returns 503.")
 	fs.DurationVar(&demandRetention, "demand-retention", wakeagent.DefaultDemandRetention,
 		"How long an engine's demand stamp survives without being refreshed.")
+	fs.StringVar(&routeProbeURL, "route-probe-url", wakeagent.DefaultRouteProbeURL,
+		"URL of Envoy's loopback routing-probe listener, probed with the engine's "+
+			"authority as Host before a held request is released. Set to an empty string "+
+			"to skip the probe and release held requests on endpoint readiness alone.")
 
 	zapOpts := zap.Options{Development: false}
 	zapOpts.BindFlags(fs)
@@ -116,6 +121,7 @@ func runWakeAgent(args []string) error {
 		FallbackCap:           fallbackCap,
 		HoldTimeout:           holdTimeout,
 		DemandRetention:       demandRetention,
+		RouteProbeURL:         routeProbeURL,
 	})
 
 	return agent.Run(ctrl.SetupSignalHandler())

--- a/docs/engine/auto-stop-and-wake-up.mdx
+++ b/docs/engine/auto-stop-and-wake-up.mdx
@@ -62,7 +62,7 @@ With Helm value `wakeAgent.enabled=true` (the default) and the Firebolt Operator
 
 1. The Gateway holds the request while the Engine has no ready endpoints.
 2. The Firebolt Operator sets the Engine to `activeReplicas`.
-3. The held request proceeds after Engine endpoints become ready.
+3. The held request proceeds after Engine endpoints become ready and the Gateway's Envoy confirms, through a local probe of the Engine's `/health/ready`, that it can route to them.
 
 The first query pays the full Engine cold-start time, which can take tens of seconds when images or volumes must be prepared. Set the client timeout accordingly. If the Gateway reaches its held-request capacity, additional requests receive `503` with `Retry-After` while wake-up continues.
 

--- a/internal/controller/instance_gateway.go
+++ b/internal/controller/instance_gateway.go
@@ -79,6 +79,16 @@ const (
 	// engines to scale back up.
 	gatewayWakeAgentDemandPort int32 = 9903
 
+	// gatewayWakeAgentRouteProbePort is the loopback port of the
+	// routing_probe listener: Envoy forwards a GET /health/ready received
+	// here to the dynamic_forward_proxy cluster at the authority the
+	// request's Host header names. The wake agent probes it before
+	// releasing a held request, so a release only happens once Envoy
+	// itself — its DNS cache, transport socket, and health view — can
+	// reach the woken engine. The agent's default probe URL
+	// (wakeagent.DefaultRouteProbeURL) is pinned to this port by a test.
+	gatewayWakeAgentRouteProbePort int32 = 9905
+
 	// Resource floor for the wake-agent sidecar. Small and flat: it holds
 	// per-engine timestamps and parked connections, nothing that scales
 	// with query volume. No CPU limit, so a burst of releases is not
@@ -1025,7 +1035,7 @@ func buildEnvoyConfigYAML(instance *computev1alpha1.FireboltInstance, wakeEnable
                   - name: envoy.filters.http.router
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-  clusters:
+%s  clusters:
     - name: dynamic_forward_proxy
       lb_policy: CLUSTER_PROVIDED
 %s      # Mirror the listener's per_connection_buffer_limit_bytes onto the
@@ -1229,6 +1239,7 @@ func buildEnvoyConfigYAML(instance *computev1alpha1.FireboltInstance, wakeEnable
 		buildWakeHoldLua(wakeEnabled),                       // Lua: wake-agent hold (empty when wake is off)
 		buildListenerDownstreamTLSTransportSocket(instance), // listener filter_chain: transport_socket (empty when gateway TLS is not ready)
 		instance.Spec.Gateway.MetricsPort,                   // stats_listener: port_value
+		buildRouteProbeListener(wakeEnabled),                // routing_probe listener (empty when wake is off)
 		buildDFPUpstreamTLSTransportSocket(instance),        // dynamic_forward_proxy cluster: transport_socket (empty when engine TLS is not ready)
 		gatewayPerConnectionBufferLimitBytes,                // dynamic_forward_proxy cluster: per_connection_buffer_limit_bytes
 		gatewayMaxConnectionsPerEngine,                      // circuit_breakers: max_connections
@@ -1736,7 +1747,9 @@ func buildWakeHoldLua(enabled bool) string {
                             -- returns immediately; for an auto-stopped one it
                             -- parks this request while the operator scales the
                             -- engine back up, then releases it once the
-                            -- engine's EndpointSlice shows a ready endpoint.
+                            -- engine's endpoints are ready AND the agent's
+                            -- probe through this Envoy answers 200 from the
+                            -- engine, still bounded by the hold timeout.
                             --
                             -- Why the agent and not Envoy alone: the engine
                             -- Service is headless, so a stopped engine's name
@@ -1814,6 +1827,67 @@ func buildWakeAgentCluster(enabled bool) string {
                       address: 127.0.0.1
                       port_value: %d
 `, gatewayWakeAgentHoldPort)
+}
+
+// buildRouteProbeListener renders the loopback listener the wake agent
+// probes before releasing a held request, or nothing when wake is disabled.
+//
+// The listener forwards GET /health/ready to the same dynamic_forward_proxy
+// cluster that carries queries, at whatever authority the probe's Host
+// header names — for the agent, the woken engine's Service hostname, i.e.
+// the exact :authority the Lua filter rewrites queries to. A 200 therefore
+// means Envoy's own DNS cache, upstream transport socket, and health-check
+// view can deliver a request to that engine right now; endpoint readiness
+// alone establishes none of those, and a request released before they catch
+// up dies as a local 503 that no retry policy can see. Loopback-bound for
+// the same reason the hold port is: reachable from inside the pod and from
+// nothing else.
+func buildRouteProbeListener(enabled bool) string {
+	if !enabled {
+		return ""
+	}
+	return fmt.Sprintf(`    - name: routing_probe
+      traffic_direction: OUTBOUND
+      address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: %d
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: routing_probe
+                route_config:
+                  name: routing_probe
+                  virtual_hosts:
+                    - name: routing_probe
+                      domains: ["*"]
+                      routes:
+                        - match:
+                            path: /health/ready
+                            headers:
+                              - name: ":method"
+                                string_match:
+                                  exact: GET
+                          route:
+                            cluster: dynamic_forward_proxy
+                            # Probes are polled, so one attempt stays short:
+                            # a probe that cannot answer inside a second
+                            # fails fast and the next tick asks again.
+                            timeout: 1s
+                http_filters:
+                  - name: envoy.filters.http.dynamic_forward_proxy
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.dynamic_forward_proxy.v3.FilterConfig
+                      sub_cluster_config:
+                        # Shorter than the query listener's 5s for the same
+                        # reason as the route timeout above.
+                        cluster_init_timeout: 1s
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+`, gatewayWakeAgentRouteProbePort)
 }
 
 // wakeAgentConfig carries what effectiveGatewayPodTemplate needs in order to
@@ -2166,6 +2240,10 @@ func buildWakeAgentContainer(cfg wakeAgentConfig, envoy *corev1.Container) (*cor
 		fmt.Sprintf("--demand-port=%d", gatewayWakeAgentDemandPort),
 		fmt.Sprintf("--envoy-admin-url=http://127.0.0.1:%d", gatewayAdminPort),
 		fmt.Sprintf("--per-hold-bytes=%d", gatewayPerConnectionBufferLimitBytes),
+		// Explicit rather than left to the agent's default, so the probe
+		// target and the routing_probe listener the operator renders into
+		// envoy.yaml stay in lockstep by construction.
+		fmt.Sprintf("--route-probe-url=http://127.0.0.1:%d/health/ready", gatewayWakeAgentRouteProbePort),
 	}
 
 	env := []corev1.EnvVar{{

--- a/internal/controller/instance_gateway_wake_test.go
+++ b/internal/controller/instance_gateway_wake_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 
 	computev1alpha1 "github.com/firebolt-db/firebolt-kubernetes-operator/api/v1alpha1"
 	"github.com/firebolt-db/firebolt-kubernetes-operator/internal/wakeagent"
@@ -102,6 +103,9 @@ func TestGatewayPodRendersWakeAgent(t *testing.T) {
 	}
 	if !strings.Contains(joined, fmt.Sprintf("--envoy-admin-url=http://127.0.0.1:%d", gatewayAdminPort)) {
 		t.Errorf("Args = %v, want the Envoy admin URL for the live memory reading", agent.Args)
+	}
+	if !strings.Contains(joined, fmt.Sprintf("--route-probe-url=http://127.0.0.1:%d/health/ready", gatewayWakeAgentRouteProbePort)) {
+		t.Errorf("Args = %v, want the probe URL pointing at the routing_probe listener", agent.Args)
 	}
 }
 
@@ -473,6 +477,108 @@ func TestWakeHoldTimeoutOutlastsAgent(t *testing.T) {
 	}
 }
 
+// The routability half of the release condition: a loopback listener that
+// forwards the agent's probe to the dynamic_forward_proxy cluster, so the
+// probe exercises the same DNS cache, transport socket, and health view the
+// released query will. Present exactly when the wake hold is.
+func TestEnvoyConfigRoutingProbeListener(t *testing.T) {
+	t.Parallel()
+	inst := &computev1alpha1.FireboltInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "fb", Namespace: "default"},
+		Spec: computev1alpha1.FireboltInstanceSpec{
+			Gateway: computev1alpha1.GatewaySpec{MetricsPort: 9090},
+		},
+	}
+	cfg := buildEnvoyConfigYAML(inst, true)
+
+	if !strings.Contains(cfg, "- name: routing_probe") {
+		t.Error("wake-enabled config has no routing_probe listener")
+	}
+	if !strings.Contains(cfg, fmt.Sprintf("port_value: %d", gatewayWakeAgentRouteProbePort)) {
+		t.Errorf("routing_probe listener does not bind port %d", gatewayWakeAgentRouteProbePort)
+	}
+	var out map[string]any
+	if err := yaml.Unmarshal([]byte(cfg), &out); err != nil {
+		t.Fatalf("wake-enabled envoy config is not valid YAML: %v\n---\n%s", err, cfg)
+	}
+	// Walk the parsed listener rather than string-matching the whole config:
+	// the admin interface is also loopback-bound, so only a per-listener
+	// assertion proves THIS listener cannot land on 0.0.0.0. With
+	// domains ["*"] over the dynamic-forward-proxy cluster, a pod-IP bind
+	// would be a Host-keyed open proxy.
+	probe := findListenerByName(t, out, "routing_probe")
+	address := dig[map[string]any](t, probe, "address", "socket_address")
+	if got := address["address"]; got != "127.0.0.1" {
+		t.Errorf("routing_probe binds %v, want 127.0.0.1", got)
+	}
+	if got := address["port_value"]; fmt.Sprintf("%v", got) != fmt.Sprintf("%d", gatewayWakeAgentRouteProbePort) {
+		t.Errorf("routing_probe port = %v, want %d", got, gatewayWakeAgentRouteProbePort)
+	}
+	routes := dig[[]any](t, probe, "filter_chains", "0", "filters", "0", "typed_config", "route_config", "virtual_hosts", "0", "routes")
+	if len(routes) != 1 {
+		t.Fatalf("routing_probe has %d routes, want exactly the probe route", len(routes))
+	}
+	route, _ := routes[0].(map[string]any)
+	if got := dig[map[string]any](t, route, "match")["path"]; got != "/health/ready" {
+		t.Errorf("routing_probe route path = %v, want /health/ready", got)
+	}
+	if got := dig[map[string]any](t, route, "route")["cluster"]; got != "dynamic_forward_proxy" {
+		t.Errorf("routing_probe route cluster = %v, want dynamic_forward_proxy; "+
+			"probing any other cluster would not observe the sub-cluster queries use", got)
+	}
+
+	disabled := buildEnvoyConfigYAML(inst, false)
+	for _, fragment := range []string{"routing_probe", fmt.Sprintf("port_value: %d", gatewayWakeAgentRouteProbePort)} {
+		if strings.Contains(disabled, fragment) {
+			t.Errorf("wake-disabled config still contains %q", fragment)
+		}
+	}
+}
+
+// The agent's default probe URL and the operator-rendered listener are two
+// halves of one loopback contract; pin them together.
+func TestWakeAgentRouteProbeURLMatchesListener(t *testing.T) {
+	t.Parallel()
+	want := fmt.Sprintf("http://127.0.0.1:%d/health/ready", gatewayWakeAgentRouteProbePort)
+	if wakeagent.DefaultRouteProbeURL != want {
+		t.Errorf("wakeagent.DefaultRouteProbeURL = %q, want %q; "+
+			"the agent would probe a port the routing_probe listener does not serve",
+			wakeagent.DefaultRouteProbeURL, want)
+	}
+}
+
+// The agent duplicates the engine query port rather than importing it, for
+// the same dependency reason as the service suffix below; pin the two
+// together so a port change cannot leave the probe authority behind.
+func TestWakeAgentEngineQueryPortMatches(t *testing.T) {
+	t.Parallel()
+	if wakeagent.EngineHTTPQueryPort != EngineHTTPQueryPort {
+		t.Errorf("wakeagent.EngineHTTPQueryPort = %d, controller.EngineHTTPQueryPort = %d; "+
+			"the probe would key a different DFP sub-cluster than queries use",
+			wakeagent.EngineHTTPQueryPort, EngineHTTPQueryPort)
+	}
+}
+
+// The probe only observes the right sub-cluster if its Host is byte-for-byte
+// the :authority the Lua filter rewrites queries to. Pin the agent's
+// authority construction against the rendered rewrite.
+func TestWakeAgentAuthorityMatchesLuaRewrite(t *testing.T) {
+	t.Parallel()
+	inst := &computev1alpha1.FireboltInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "fb", Namespace: "ns-1"},
+		Spec: computev1alpha1.FireboltInstanceSpec{
+			Gateway: computev1alpha1.GatewaySpec{MetricsPort: 9090},
+		},
+	}
+	cfg := buildEnvoyConfigYAML(inst, true)
+
+	suffix := strings.TrimPrefix(wakeagent.EngineAuthority("e", "ns-1"), "e")
+	want := `headers:replace(":authority", engine .. "` + suffix + `")`
+	if !strings.Contains(cfg, want) {
+		t.Errorf("rendered config does not rewrite :authority to the agent's probe authority; want %q", want)
+	}
+}
+
 // The agent duplicates the service suffix rather than importing it, to keep
 // controller-runtime out of the sidecar's dependency graph. Pin the two
 // together so the duplication cannot silently drift.
@@ -519,4 +625,49 @@ func TestEnvoyConfigSetsStreamIdleTimeout(t *testing.T) {
 	if got := buildEnvoyConfigYAML(inst, true); !strings.Contains(got, want) {
 		t.Errorf("rendered config missing %q", want)
 	}
+}
+
+// findListenerByName walks static_resources.listeners of a parsed envoy
+// config and fails the test when the named listener is absent.
+func findListenerByName(t *testing.T, cfg map[string]any, name string) map[string]any {
+	t.Helper()
+	listeners := dig[[]any](t, cfg, "static_resources", "listeners")
+	for _, item := range listeners {
+		l, _ := item.(map[string]any)
+		if l["name"] == name {
+			return l
+		}
+	}
+	t.Fatalf("listener %q not found", name)
+	return nil
+}
+
+// dig walks nested maps and slices by key (numeric strings index slices) and
+// fails the test on the first missing step, naming the path walked so far.
+func dig[T any](t *testing.T, node any, path ...string) T {
+	t.Helper()
+	current := node
+	for i, step := range path {
+		switch typed := current.(type) {
+		case map[string]any:
+			next, ok := typed[step]
+			if !ok {
+				t.Fatalf("missing %q at %v", step, path[:i+1])
+			}
+			current = next
+		case []any:
+			index := 0
+			if _, err := fmt.Sscanf(step, "%d", &index); err != nil || index >= len(typed) {
+				t.Fatalf("bad index %q at %v", step, path[:i+1])
+			}
+			current = typed[index]
+		default:
+			t.Fatalf("cannot descend into %T at %v", current, path[:i+1])
+		}
+	}
+	out, ok := current.(T)
+	if !ok {
+		t.Fatalf("value at %v is %T", path, current)
+	}
+	return out
 }

--- a/internal/wakeagent/agent.go
+++ b/internal/wakeagent/agent.go
@@ -31,12 +31,17 @@ limitations under the License.
 //     parks the request.
 //  3. The operator polls /demand, sees fresh demand against an engine it
 //     knows is at zero replicas, and scales it.
-//  4. The agent's EndpointSlice watch observes endpoints appear and
-//     releases the parked request; Envoy routes it.
+//  4. The agent's EndpointSlice watch observes endpoints appear, the agent
+//     confirms through Envoy's loopback routing-probe listener that Envoy
+//     itself can reach the engine, and it releases the parked request;
+//     Envoy routes it.
 //
 // Step 4 is exact rather than approximate: the engine Service is headless
 // with PublishNotReadyAddresses false, so the endpoints the agent watches
 // are precisely the A records kube-dns will serve to Envoy's resolver.
+// Exact records still do not make a routable Envoy, though — its
+// dynamic-forward-proxy sub-cluster refreshes DNS and health state on its
+// own schedule — which is the gap the routing probe closes.
 package wakeagent
 
 import (
@@ -136,6 +141,14 @@ type Config struct {
 	FallbackCap     int
 	HoldTimeout     time.Duration
 	DemandRetention time.Duration
+
+	// RouteProbeURL is the loopback URL of Envoy's routing-probe listener,
+	// probed with the engine's authority as Host before a hold woken by
+	// endpoint readiness is released. Empty disables the probe, so a hold
+	// releases on endpoint readiness alone; there is deliberately no
+	// default here, because defaulting an explicitly emptied value would
+	// remove that escape hatch.
+	RouteProbeURL string
 }
 
 func (c *Config) applyDefaults() {
@@ -162,6 +175,7 @@ type Agent struct {
 	demand    *demandTracker
 	readiness *readinessTracker
 	capacity  *capacityLimiter
+	prober    *routeProber
 }
 
 // New builds an Agent with its collaborators wired but nothing started.
@@ -177,6 +191,7 @@ func New(cfg Config) *Agent {
 			cfg.FallbackCap,
 			cfg.EnvoyAdminURL,
 		),
+		prober: newRouteProber(cfg.RouteProbeURL),
 	}
 }
 
@@ -359,26 +374,59 @@ func (a *Agent) handleHold(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "engine became ready then went away", http.StatusServiceUnavailable)
 			return
 		}
+		// Ready endpoints are necessary but not sufficient: Envoy's own
+		// view of the engine (DNS cache, health checks) can lag them, and
+		// a release into that lag fails as a local 503. Hold on until
+		// Envoy itself answers for the engine, still under the same
+		// deadline the hold started with.
+		switch a.awaitRoutable(r.Context(), engine, timer.C) {
+		case routeWaitDeadline:
+			a.answerHoldDeadline(w, engine)
+			return
+		case routeWaitClientGone:
+			// Same as the client hanging up below: nothing to write.
+			return
+		case routeWaitRoutable:
+		}
+		// Deliberately no readiness re-check after a routable verdict: the
+		// probe's 200 traveled through Envoy moments ago and is the fresher
+		// fact. Endpoints vanishing after that 200 are indistinguishable from
+		// vanishing right after the release below; that failure belongs to
+		// the released query's dispatch. Re-checking here would 503 holds
+		// Envoy can demonstrably serve.
 		w.Header().Set(DecisionHeader, DecisionReleased)
 		w.WriteHeader(http.StatusOK)
 	case <-timer.C:
-		// A wake that completes exactly at the deadline can lose the race
-		// between the channel close and the timer: both arms are readable
-		// and select picks either. The engine is routable, so answer 200
-		// rather than telling the client a lie it will retry through.
-		if a.readiness.IsReady(engine) {
-			w.Header().Set(DecisionHeader, DecisionReleased)
-			w.WriteHeader(http.StatusOK)
-			return
-		}
-		w.Header().Set(DecisionHeader, DecisionTimeout)
-		w.Header().Set("Retry-After", "10")
-		http.Error(w, "engine did not become ready", http.StatusServiceUnavailable)
+		a.answerHoldDeadline(w, engine)
 	case <-r.Context().Done():
 		// Client hung up. Nothing to write; the demand stamp already
 		// recorded that they asked, which is why the timestamp rather
 		// than a pending-count is what the operator reads.
 	}
+}
+
+// answerHoldDeadline writes the response for a hold whose deadline expired,
+// releasing when the engine has ready endpoints and erroring when it does
+// not.
+//
+// Two paths land here and both want exactly this decision. A wake that
+// completes at the deadline can lose the select race between the channel
+// close and the timer — both arms are readable and select picks either — and
+// the engine is reachable then, so answering 200 beats telling the client a
+// lie it will retry through. And a hold whose routability probe never saw a
+// 200 within the deadline releases into the ready endpoints anyway: the
+// probe delays a release, it never converts one into an error, so a probe
+// that cannot succeed (a misconfigured listener, an engine Envoy can never
+// reach) degrades to exactly the behavior the gateway has without it.
+func (a *Agent) answerHoldDeadline(w http.ResponseWriter, engine string) {
+	if a.readiness.IsReady(engine) {
+		w.Header().Set(DecisionHeader, DecisionReleased)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	w.Header().Set(DecisionHeader, DecisionTimeout)
+	w.Header().Set("Retry-After", "10")
+	http.Error(w, "engine did not become ready", http.StatusServiceUnavailable)
 }
 
 // isValidEngineName mirrors the Lua filter's is_valid_engine: a single

--- a/internal/wakeagent/routing.go
+++ b/internal/wakeagent/routing.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2026 Firebolt Analytics.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wakeagent
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// DefaultRouteProbeURL is where the gateway's Envoy serves its loopback
+// routing-probe listener: a GET here is forwarded to the dynamic-forward-proxy
+// cluster at whatever authority the request's Host header names, so a 200 is
+// the engine answering /health/ready through the exact path a released query
+// will take. The operator renders that listener into the gateway Envoy config
+// whenever the wake agent is enabled; the port is asserted against the
+// operator's constant by a test in the controller package.
+const DefaultRouteProbeURL = "http://127.0.0.1:9905/health/ready"
+
+// EngineHTTPQueryPort mirrors the controller package's constant of the same
+// name: the engine's http-query listener port, and therefore the port in the
+// :authority the gateway's Lua filter rewrites every engine request to.
+// Duplicated rather than imported because the agent must not pull the
+// controller package (and its controller-runtime dependency graph) into the
+// sidecar's code path; the two are asserted equal by a test in the controller
+// package.
+const EngineHTTPQueryPort = 3473
+
+const (
+	// routeProbeInterval is how often a woken hold re-asks Envoy whether the
+	// engine is routable. Short, because every tick of it is added latency
+	// on a query that already waited out a cold start.
+	routeProbeInterval = 100 * time.Millisecond
+
+	// routeProbeTimeout bounds a single probe attempt. It covers the probe
+	// listener's own route timeout and sub-cluster init timeout (1s each),
+	// so a hung attempt cannot pin a hold much past its deadline.
+	routeProbeTimeout = time.Second
+)
+
+// EngineAuthority is the :authority the gateway routes an engine's queries
+// to — the same string the Lua filter rewrites into every request, which is
+// what keys Envoy's dynamic-forward-proxy sub-cluster for that engine. The
+// routing probe must present exactly this authority or it would warm (and
+// observe) a different sub-cluster than the one the released query uses.
+// A test in the controller package pins it against the Lua rewrite.
+func EngineAuthority(engine, namespace string) string {
+	return fmt.Sprintf("%s%s.%s.svc.cluster.local:%d", engine, ServiceSuffix, namespace, EngineHTTPQueryPort)
+}
+
+// routeProber asks the pod's own Envoy whether it can currently route to an
+// authority.
+//
+// Concurrent probes for the same authority are coalesced into one in-flight
+// request. Holds poll independently, so without coalescing a wake herd of N
+// parked queries would multiply into N probe streams against an engine that
+// just cold-started — each one a fresh TCP+TLS connection, because the
+// dynamic-forward-proxy cluster runs one request per connection.
+type routeProber struct {
+	// url is the probe listener's address, fixed at construction. Empty
+	// means probing is disabled and every answer is "routable".
+	url string
+
+	mu     sync.Mutex
+	flight map[string]*probeFlight
+}
+
+// probeFlight is one in-flight probe request; ok is valid once done closes.
+type probeFlight struct {
+	done chan struct{}
+	ok   bool
+}
+
+func newRouteProber(url string) *routeProber {
+	return &routeProber{url: url, flight: make(map[string]*probeFlight)}
+}
+
+// enabled reports whether a probe target is configured at all.
+func (p *routeProber) enabled() bool {
+	return p.url != ""
+}
+
+// probe reports whether Envoy answered 200 for the authority, joining an
+// already in-flight probe for it instead of adding another. A joiner whose
+// context ends first stops waiting and reports false; the flight itself
+// carries on for the callers still parked on it.
+func (p *routeProber) probe(ctx context.Context, authority string) bool {
+	p.mu.Lock()
+	if f, exists := p.flight[authority]; exists {
+		p.mu.Unlock()
+		select {
+		case <-f.done:
+			return f.ok
+		case <-ctx.Done():
+			return false
+		}
+	}
+	f := &probeFlight{done: make(chan struct{})}
+	p.flight[authority] = f
+	p.mu.Unlock()
+
+	f.ok = p.probeOnce(ctx, authority)
+
+	p.mu.Lock()
+	delete(p.flight, authority)
+	p.mu.Unlock()
+	close(f.done)
+	return f.ok
+}
+
+// routeProbeClient never consults proxy environment variables: the probe
+// target is a loopback listener, and a proxy without a loopback exclusion
+// would fail every probe and silently turn each hold into a deadline wait.
+var routeProbeClient = &http.Client{Transport: &http.Transport{Proxy: nil}}
+
+// probeOnce performs one probe: GET the probe listener with the engine's
+// authority as Host and accept only a 200 — which can only be the engine
+// itself answering /health/ready, since Envoy synthesizes non-200s for every
+// local failure (unresolved name, no healthy host, failed handshake). A
+// non-200 is deliberately ambiguous the other way: the engine's own 503
+// (draining, not yet healthy) also holds, so 200/non-200 is a conservative
+// "releasable now" signal, not a pure statement about Envoy's cache.
+// Resolving DNS in this process instead would prove nothing about Envoy's
+// own DNS cache, transport configuration, or health view.
+func (p *routeProber) probeOnce(ctx context.Context, authority string) bool {
+	ctx, cancel := context.WithTimeout(ctx, routeProbeTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.url, http.NoBody)
+	if err != nil {
+		return false
+	}
+	req.Host = authority
+	resp, err := routeProbeClient.Do(req)
+	if err != nil {
+		return false
+	}
+	// The verdict is the status code alone; the body is drained (bounded)
+	// only so the connection can be reused, and errors doing so change
+	// nothing.
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	return resp.StatusCode == http.StatusOK
+}
+
+// routeWait is awaitRoutable's outcome.
+type routeWait int
+
+const (
+	// routeWaitRoutable: Envoy answered 200 for the engine's authority (or
+	// probing is disabled), so releasing the hold now routes.
+	routeWaitRoutable routeWait = iota
+	// routeWaitDeadline: the hold deadline fired first. The caller answers
+	// exactly as it does when probing is disabled.
+	routeWaitDeadline
+	// routeWaitClientGone: the client hung up while waiting.
+	routeWaitClientGone
+)
+
+// awaitRoutable blocks until Envoy itself reports the engine reachable, the
+// hold deadline fires, or the client gives up.
+//
+// Endpoint readiness says the pods are there; it says nothing about whether
+// THIS Envoy can route to them yet. The dynamic-forward-proxy sub-cluster
+// for the engine's authority resolves DNS and runs active health checks on
+// its own schedule, so at the readiness edge Envoy may still be a DNS
+// refresh or a first health-check pass away from having a healthy host — and
+// a request released into that window dies as a local 503 that no retry
+// policy can see. Probing through Envoy's loopback routing-probe listener
+// exercises the same sub-cluster the released request will use, so a 200
+// here is the engine answering through the exact path the query takes.
+//
+// The probe gates only releases the agent already decided to make, and only
+// inside the hold window: on deadline the caller answers exactly as it would
+// have without the probe, and an empty RouteProbeURL disables the gate
+// entirely (the escape hatch when no probe listener is serving).
+func (a *Agent) awaitRoutable(ctx context.Context, engine string, deadline <-chan time.Time) routeWait {
+	if !a.prober.enabled() {
+		return routeWaitRoutable
+	}
+	authority := EngineAuthority(engine, a.cfg.Namespace)
+	ticker := time.NewTicker(routeProbeInterval)
+	defer ticker.Stop()
+	for {
+		if a.prober.probe(ctx, authority) {
+			return routeWaitRoutable
+		}
+		select {
+		case <-ctx.Done():
+			return routeWaitClientGone
+		case <-deadline:
+			return routeWaitDeadline
+		case <-ticker.C:
+		}
+	}
+}

--- a/internal/wakeagent/routing_test.go
+++ b/internal/wakeagent/routing_test.go
@@ -1,0 +1,358 @@
+/*
+Copyright 2026 Firebolt Analytics.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wakeagent
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestEngineAuthority(t *testing.T) {
+	t.Parallel()
+	got := EngineAuthority("analytics", "ns-1")
+	want := "analytics-service.ns-1.svc.cluster.local:3473"
+	if got != want {
+		t.Errorf("EngineAuthority() = %q, want %q", got, want)
+	}
+}
+
+// probeAgent is testAgent with a routing probe pointed at url.
+func probeAgent(t *testing.T, holdTimeout time.Duration, url string) *Agent {
+	t.Helper()
+	a := New(Config{
+		Namespace:     "test-ns",
+		HoldTimeout:   holdTimeout,
+		FallbackCap:   8,
+		RouteProbeURL: url,
+	})
+	a.readiness.MarkSynced()
+	return a
+}
+
+// startHold runs handleHold for the engine in the background and returns the
+// channel its recorder arrives on once the handler finishes.
+func startHold(t *testing.T, a *Agent, engine string) <-chan *httptest.ResponseRecorder {
+	t.Helper()
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		a.handleHold(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet,
+			"/hold?engine="+engine, http.NoBody))
+		done <- rec
+	}()
+	return done
+}
+
+// Ready endpoints alone must not release a hold: Envoy's own view of the
+// engine can lag them, and a request released into that lag dies as a local
+// 503 no retry policy can see. The hold stays parked while Envoy answers
+// 503 through the probe, and releases promptly once it answers 200.
+func TestHandleHoldWaitsForEnvoyRoutability(t *testing.T) {
+	t.Parallel()
+	var routable atomic.Bool
+	probe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if routable.Load() {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer probe.Close()
+
+	a := probeAgent(t, 30*time.Second, probe.URL+"/health/ready")
+	done := startHold(t, a, "stopped")
+	waitFor(t, func() bool { return a.demand.PendingTotal() == 1 })
+	a.readiness.setReady("stopped", true)
+
+	// Several probe ticks pass with Envoy still answering 503; the hold
+	// must not release on the readiness edge alone.
+	select {
+	case rec := <-done:
+		t.Fatalf("hold released with status %d while Envoy answered 503", rec.Code)
+	case <-time.After(400 * time.Millisecond):
+	}
+
+	routable.Store(true)
+	select {
+	case rec := <-done:
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 once Envoy answers 200", rec.Code)
+		}
+		if got := rec.Header().Get(DecisionHeader); got != DecisionReleased {
+			t.Errorf("%s = %q, want %q", DecisionHeader, got, DecisionReleased)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("hold not released after the probe turned 200")
+	}
+}
+
+// The probe must present the engine's authority as Host — the exact string
+// the Lua filter rewrites queries to — or Envoy would warm and observe a
+// different dynamic-forward-proxy sub-cluster than the released query uses.
+func TestRouteProbeCarriesEngineAuthority(t *testing.T) {
+	t.Parallel()
+	type seen struct{ host, path string }
+	got := make(chan seen, 1)
+	probe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case got <- seen{host: r.Host, path: r.URL.Path}:
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer probe.Close()
+
+	a := probeAgent(t, 5*time.Second, probe.URL+"/health/ready")
+	done := startHold(t, a, "analytics")
+	waitFor(t, func() bool { return a.demand.PendingTotal() == 1 })
+	a.readiness.setReady("analytics", true)
+
+	select {
+	case rec := <-done:
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("hold not released by a probe that answers 200")
+	}
+
+	s := <-got
+	if want := EngineAuthority("analytics", "test-ns"); s.host != want {
+		t.Errorf("probe Host = %q, want %q", s.host, want)
+	}
+	if s.path != "/health/ready" {
+		t.Errorf("probe path = %q, want /health/ready", s.path)
+	}
+}
+
+// An empty RouteProbeURL is the escape hatch: no probe at all, release on
+// endpoint readiness alone. The nil deadline channel would block forever,
+// so returning at all proves the probe path was skipped rather than raced.
+func TestAwaitRoutableSkipsWhenProbeDisabled(t *testing.T) {
+	t.Parallel()
+	a := testAgent(t, time.Minute) // no RouteProbeURL configured
+	if got := a.awaitRoutable(context.Background(), "engine", nil); got != routeWaitRoutable {
+		t.Errorf("awaitRoutable() = %v with probing disabled, want %v", got, routeWaitRoutable)
+	}
+}
+
+// With probing disabled the hold path behaves exactly as it does without
+// the probe feature: parked on readiness, released on the readiness edge.
+func TestHandleHoldReleasesOnReadinessAloneWithoutProbeURL(t *testing.T) {
+	t.Parallel()
+	a := testAgent(t, 5*time.Second)
+	done := startHold(t, a, "plain")
+	waitFor(t, func() bool { return a.demand.PendingTotal() == 1 })
+	a.readiness.setReady("plain", true)
+
+	select {
+	case rec := <-done:
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+		if got := rec.Header().Get(DecisionHeader); got != DecisionReleased {
+			t.Errorf("%s = %q, want %q", DecisionHeader, got, DecisionReleased)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("hold not released on the readiness edge with probing disabled")
+	}
+}
+
+// A probe that never succeeds must not extend the hold: the deadline still
+// fires, and since the engine's endpoints are ready the hold releases into
+// them — the probe delays a release, it never converts one into an error,
+// so an unroutable probe target degrades to the probe-disabled behavior.
+func TestHandleHoldDeadlineReleasesReadyEngineWhenNeverRoutable(t *testing.T) {
+	t.Parallel()
+	var probes atomic.Int64
+	probe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		probes.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer probe.Close()
+
+	const holdTimeout = 400 * time.Millisecond
+	a := probeAgent(t, holdTimeout, probe.URL+"/health/ready")
+	start := time.Now()
+	done := startHold(t, a, "stuck")
+	waitFor(t, func() bool { return a.demand.PendingTotal() == 1 })
+	a.readiness.setReady("stuck", true)
+
+	select {
+	case rec := <-done:
+		if elapsed := time.Since(start); elapsed < holdTimeout {
+			t.Errorf("hold answered after %v, before the %v deadline", elapsed, holdTimeout)
+		}
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 for a ready engine at the deadline", rec.Code)
+		}
+		if got := rec.Header().Get(DecisionHeader); got != DecisionReleased {
+			t.Errorf("%s = %q, want %q", DecisionHeader, got, DecisionReleased)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("hold not answered at the deadline despite a failing probe")
+	}
+	if probes.Load() == 0 {
+		t.Error("probe target was never asked; the routability gate did not run")
+	}
+}
+
+// An engine that flaps away while its release is still being probed gets the
+// same terminal answer as one that never arrived: the deadline fires and the
+// endpoints are gone, so the client sees the timeout 503.
+func TestHandleHoldDeadlineErrorsWhenEngineGoneMidProbe(t *testing.T) {
+	t.Parallel()
+	var probes atomic.Int64
+	probe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		probes.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer probe.Close()
+
+	a := probeAgent(t, 500*time.Millisecond, probe.URL+"/health/ready")
+	done := startHold(t, a, "flappy")
+	waitFor(t, func() bool { return a.demand.PendingTotal() == 1 })
+	a.readiness.setReady("flappy", true)
+	waitFor(t, func() bool { return probes.Load() > 0 })
+	a.readiness.setReady("flappy", false)
+
+	select {
+	case rec := <-done:
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want 503 when the engine left mid-probe", rec.Code)
+		}
+		if got := rec.Header().Get(DecisionHeader); got != DecisionTimeout {
+			t.Errorf("%s = %q, want %q", DecisionHeader, got, DecisionTimeout)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("hold not answered at the deadline")
+	}
+}
+
+// Holds poll independently, so a wake herd would multiply into as many probe
+// streams as parked requests — each one a fresh connection to an engine that
+// just cold-started. Concurrent probes for one authority must coalesce into
+// a single in-flight request.
+func TestConcurrentHoldsShareOneProbeStream(t *testing.T) {
+	t.Parallel()
+	var (
+		mu                sync.Mutex
+		inFlight, maxSeen int
+		routable          atomic.Bool
+		enter             = func() {
+			mu.Lock()
+			inFlight++
+			if inFlight > maxSeen {
+				maxSeen = inFlight
+			}
+			mu.Unlock()
+		}
+		leave = func() {
+			mu.Lock()
+			inFlight--
+			mu.Unlock()
+		}
+	)
+	probe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		enter()
+		defer leave()
+		// Widen each probe so independent pollers would overlap.
+		time.Sleep(20 * time.Millisecond)
+		if routable.Load() {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer probe.Close()
+
+	const holds = 8
+	a := probeAgent(t, 10*time.Second, probe.URL+"/health/ready")
+	var recs []<-chan *httptest.ResponseRecorder
+	for i := 0; i < holds; i++ {
+		recs = append(recs, startHold(t, a, "shared"))
+	}
+	waitFor(t, func() bool { return a.demand.PendingTotal() == holds })
+	a.readiness.setReady("shared", true)
+
+	// Let a few failing probe rounds pass with all holds awake, then open.
+	time.Sleep(300 * time.Millisecond)
+	routable.Store(true)
+
+	for i, done := range recs {
+		select {
+		case rec := <-done:
+			if rec.Code != http.StatusOK {
+				t.Errorf("hold %d: status = %d, want 200", i, rec.Code)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("hold %d never released", i)
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if maxSeen != 1 {
+		t.Errorf("max concurrent probe requests = %d, want 1 (coalesced)", maxSeen)
+	}
+}
+
+// A routable verdict is final: endpoints flapping to not-ready between the
+// probe's 200 and the hold response must not turn the release into a 503.
+// The 200 traveled through Envoy after the flap began, so it is the fresher
+// fact; the released query, not the hold, owns any later failure. This pins
+// the deliberate absence of a readiness re-check on the success path.
+func TestHandleHoldReleasesOnProbeSuccessDespiteEndpointFlap(t *testing.T) {
+	t.Parallel()
+	probeEntered := make(chan struct{})
+	probeRelease := make(chan struct{})
+	var entered sync.Once
+	probe := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		entered.Do(func() { close(probeEntered) })
+		<-probeRelease
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer probe.Close()
+
+	a := probeAgent(t, 30*time.Second, probe.URL+"/health/ready")
+	done := startHold(t, a, "flappy")
+	waitFor(t, func() bool { return a.demand.PendingTotal() == 1 })
+	a.readiness.setReady("flappy", true)
+
+	// The hold woke on readiness and is now inside the probe; flap the
+	// endpoints away before the probe answers.
+	<-probeEntered
+	a.readiness.setReady("flappy", false)
+	close(probeRelease)
+
+	select {
+	case rec := <-done:
+		if rec.Code != http.StatusOK {
+			t.Fatalf("hold answered %d after a routable verdict, want 200", rec.Code)
+		}
+		if got := rec.Header().Get(DecisionHeader); got != DecisionReleased {
+			t.Fatalf("decision = %q, want %q", got, DecisionReleased)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("hold did not answer after the probe returned 200")
+	}
+}


### PR DESCRIPTION
**Background**

FB-3986: a wake hold released on endpoint readiness alone can still fail. Envoy's dynamic-forward-proxy sub-cluster refreshes DNS and health state on its own schedule, so the released query can die as a local 503 that no retry policy sees.

**Summary**

- When wake is enabled, render a loopback `routing_probe` listener (127.0.0.1:9905) forwarding GET `/health/ready` to the dynamic-forward-proxy cluster, so a probe exercises the exact routing state a released query will use.
- Before releasing a hold woken by endpoint readiness, the agent polls that listener with the engine's authority as Host and releases on the first 200. Probes for one engine coalesce into a single in-flight request. The hold timeout is unchanged, and at the deadline the response is exactly what it is today.
- `--route-probe-url` configures the target; an explicitly empty value disables probing and restores readiness-only release.

**Test Plan**

- Unit tests cover: no release while the probe answers 503 and prompt release on 200, the Host header carrying the engine authority, the empty-URL escape hatch, both deadline paths, probe coalescing under concurrent holds, and the authority format pinned against the rendered Lua rewrite. Race mode passes.
- Config render tests pin the listener present only when wake is enabled and the sidecar flag in lockstep with the listener.
- The model-scope check passes; the rendered configs validate against the pinned Envoy binary, and a manual smoke against a stub engine covered healthy, unhealthy, recovery, and unresolvable authorities.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the gateway wake hold release path and Envoy config for all wake-enabled instances; behavior is bounded by the existing hold timeout and can be disabled via an empty route-probe URL.
> 
> **Overview**
> Fixes **FB-3986**: held gateway queries were released when Kubernetes endpoints became ready, but Envoy could still fail the follow-up route (dynamic-forward-proxy DNS/health lag), producing a local **503** that retry policy never sees.
> 
> When wake is enabled, the operator now renders a loopback **`routing_probe`** listener (`127.0.0.1:9905`) that forwards `GET /health/ready` through the same **`dynamic_forward_proxy`** cluster as real queries. The wake agent gains **`--route-probe-url`** and, after endpoints are ready, polls that URL with the engine’s **`:authority` as `Host`** until Envoy returns **200** (or the existing hold timeout). Concurrent probes for one engine **coalesce**; an **empty** probe URL restores readiness-only release. At the deadline, a ready engine still **releases** even if the probe never succeeds, so a broken probe degrades to prior behavior.
> 
> Docs describe the extra Envoy confirmation step; controller tests pin listener wiring, loopback bind, and alignment between the sidecar flag, default probe URL, query port, and Lua `:authority` rewrite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 232f24da0305fb0cf199a2c936f8ce22840c66d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->