### PR TITLE
chore(deps): bump default engine/metadata image tags (#251)

### DIFF
--- a/config/images/defaults.latest.env
+++ b/config/images/defaults.latest.env
@@ -21,9 +21,9 @@
 #     test/e2e/e2e_suite_test.go's SynchronizedBeforeSuite.
 
 ENGINE_IMAGE=oci.firebolt.io/firebolt-db/engine
-ENGINE_TAG=release-5.0.0-pre.0.20260907054900.7676b5def2cd
+ENGINE_TAG=release-5.0.0-pre.0.20260910185502.9d66214c7f26
 METADATA_IMAGE=ghcr.io/firebolt-db/metadata
-METADATA_TAG=release-5.0.0-pre.0.20260907054900.7676b5def2cd
+METADATA_TAG=release-5.0.0-pre.0.20260910185502.9d66214c7f26
 # Multi-arch manifest-list digest (not a single-platform blob). Refresh with:
 #   docker buildx imagetools inspect postgres:16.15-alpine --format '{{.Manifest.Digest}}'
 POSTGRES_IMAGE=postgres:16.15-alpine@sha256:cf78e76683b9ca8c5733cbbdce6c9262b45b6767934dd0a95e671f9a0fc20685


### PR DESCRIPTION
**Background**

The `latest` E2E variant pins the default engine/metadata images to an older release build that predates the engine's SIGTERM connection-drain behavior. The zero-downtime retirement tests require that behavior to pass under the tightened gateway retry policy.

**Summary**

Bump `ENGINE_TAG` and `METADATA_TAG` in `config/images/defaults.latest.env` to the current release build. Both multi-arch manifests are published on GHCR. Engine and metadata move in lockstep on the same build, per the file's convention.

**Test Plan**

CI runs the E2E suite against the pinned images; the `latest` leg exercises the retirement/scaling specs that depend on the drain behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only lockstep tag bump; risk is mainly if the new engine/metadata build breaks the operator contract, which CI E2E is intended to catch.
> 
> **Overview**
> Updates the **latest** image variant pins in `config/images/defaults.latest.env`, moving `ENGINE_TAG` and `METADATA_TAG` together to `release-5.0.0-pre.0.20260910185502.9d66214c7f26` (from the prior `20260907054900` build). No other images or env keys change.
> 
> This refreshes the default engine/metadata images used by the operator image, Helm chart, and `make test-e2e` when `IMAGE_VARIANT` is unset, so CI and local E2E run against a newer release build—aligned with specs that need current engine behavior (e.g. SIGTERM connection drain during retirement).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6878e4f0f59d254f745cde466361112763ba8e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->