### PR TITLE
fix(ci): re-apply the chart appVersion sync on fresh main instead of rebasing it (FB-4073)

### DIFF
--- a/.github/workflows/release-main.yaml
+++ b/.github/workflows/release-main.yaml
@@ -407,54 +407,73 @@ jobs:
         run: |
           APP_VERSION="$(tr -d '[:space:]' < version.txt)"
           APP_VERSION_TAG="v${APP_VERSION}"
-
-          yq -i ".appVersion = \"${APP_VERSION_TAG}\"" helm/firebolt-operator/Chart.yaml
-
-          make helm-docs
+          PUSH_URL="https://x-access-token:${GH_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add helm/firebolt-operator/Chart.yaml \
-                  helm/firebolt-operator/README.md
 
-          if git diff --staged --quiet; then
-            echo "Chart appVersion already ${APP_VERSION_TAG}; nothing to commit."
-            COMMITTED=false
-          else
-            git commit -m "chore(deps): set chart appVersion to ${APP_VERSION_TAG}"
-            PUSH_URL="https://x-access-token:${GH_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-            COMMITTED=true
+          # Rewrite appVersion and the generated README on the current checkout
+          # and stage them. Returns non-zero when the tree already had this
+          # appVersion, i.e. there is nothing to commit.
+          apply_sync() {
+            yq -i ".appVersion = \"${APP_VERSION_TAG}\"" helm/firebolt-operator/Chart.yaml
+            make helm-docs
+            git add helm/firebolt-operator/Chart.yaml \
+                    helm/firebolt-operator/README.md
+            ! git diff --staged --quiet
+          }
 
-            for attempt in 1 2 3; do
-              if git push "$PUSH_URL" HEAD:main; then
-                break
-              fi
-
-              if [ "$attempt" -eq 3 ]; then
-                echo "Failed to push chart appVersion commit after ${attempt} attempts." 1>&2
-                exit 1
-              fi
-
+          # The edit is "set one key". When the push is rejected because main
+          # moved, regenerate the edit on main's new tip instead of rebasing the
+          # commit: a chart release landing in the same window touches the
+          # neighbouring `version:` line of Chart.yaml, and a textual rebase
+          # conflicts on that hunk (this is how the 0.17.0 sync was lost, see
+          # FB-4073). Re-applying can never conflict, and if the new tip already
+          # carries this appVersion the diff is empty and we stop cleanly.
+          OUTCOME=""
+          for attempt in 1 2 3; do
+            if [ "$attempt" -gt 1 ]; then
               git fetch "$PUSH_URL" main
-              if ! git rebase FETCH_HEAD; then
-                git rebase --abort || true
-                echo "Failed to rebase chart appVersion commit onto latest main." 1>&2
-                exit 1
-              fi
-            done
-          fi
+              git checkout -q --detach FETCH_HEAD
+            fi
+
+            if ! apply_sync; then
+              OUTCOME="already"
+              break
+            fi
+            git commit -q -m "chore(deps): set chart appVersion to ${APP_VERSION_TAG}"
+
+            if git push "$PUSH_URL" HEAD:main; then
+              OUTCOME="committed"
+              break
+            fi
+            echo "Push rejected on attempt ${attempt}: main moved; re-applying on its tip." 1>&2
+          done
 
           {
             echo "### Chart appVersion sync :link:"
             echo ""
-            if [ "$COMMITTED" = "true" ]; then
-              echo "Committed \`chore(deps): set chart appVersion to ${APP_VERSION_TAG}\` to \`main\`."
-              echo "release-please will open the \`firebolt-operator\` chart release PR that bumps its \`version\`;"
-              echo "merging it publishes the chart (\`release-helm-standalone\`)."
-            else
-              echo "Chart \`appVersion\` was already \`${APP_VERSION_TAG}\`; no chart release needed."
-            fi
+            case "$OUTCOME" in
+              committed)
+                echo "Committed \`chore(deps): set chart appVersion to ${APP_VERSION_TAG}\` to \`main\`."
+                echo "release-please will open the \`firebolt-operator\` chart release PR that bumps its \`version\`;"
+                echo "merging it publishes the chart (\`release-helm-standalone\`)."
+                ;;
+              already)
+                echo "Chart \`appVersion\` was already \`${APP_VERSION_TAG}\`; no chart release needed."
+                ;;
+              *)
+                echo ":x: **Failed to push the chart appVersion commit after 3 attempts.**"
+                echo "The published chart still ships the previous operator. Re-run this job, or set"
+                echo "\`appVersion: ${APP_VERSION_TAG}\` in \`helm/firebolt-operator/Chart.yaml\` by hand."
+                ;;
+            esac
           } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -z "$OUTCOME" ]; then
+            echo "Failed to push chart appVersion commit after 3 attempts." 1>&2
+            exit 1
+          fi
 
   release-helm-standalone:
     needs:


### PR DESCRIPTION
**Background**

FB-4073: after an operator release, `sync-chart-appversion` commits the new `appVersion` to main so release-please can cut the chart. On the 0.17.0 release the chart 0.14.0 release PR merged in the same minute, the push was rejected, and the job's `git rebase` conflicted on `Chart.yaml` because both commits touch adjacent lines (`version:` and `appVersion:`). The job exited 1 and the chart shipped operator v0.16.0 for two days.

**Summary**

- On a rejected push the job now fetches main, checks out its tip, and regenerates the edit there (same `yq` + `helm-docs` as the first attempt) instead of rebasing the commit. A one-key edit re-applied on fresh main cannot conflict.
- If the new tip already carries the target `appVersion`, the diff is empty and the job reports "already synced" and exits 0.
- A sync that still fails after three attempts is written to the step summary with the manual fallback, not just to the job log.
- No change to what the job edits or to release-please ownership of chart `version`.

**Test Plan**

- actionlint passes.
- The shell block was dry-run against a scratch bare repo with `yq`/`make` stubbed, covering three cases: a concurrent commit bumping `version:` (previously the conflicting case; now retried and both fields land), a concurrent commit already setting the same `appVersion` (exits 0 as "already"), and no concurrent change (commits first try).
- Real verification is the next operator release: the job should succeed and open the chart release PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation that commits to `main` after operator releases; wrong behavior could leave the Helm chart pointing at a stale operator image, but scope is limited to retry/conflict handling.
> 
> **Overview**
> Fixes a race where `sync-chart-appversion` could fail when a chart release PR merges at the same time as the post-operator-release `appVersion` commit. The job used to **rebase** its commit onto updated `main`, which often conflicted on adjacent `version:` and `appVersion:` lines in `helm/firebolt-operator/Chart.yaml` (FB-4073).
> 
> The workflow now wraps the `yq` + `helm-docs` edit in **`apply_sync()`** and, on push rejection, **fetches `main`, checks out its tip, and re-applies** the same one-key change instead of rebasing. If the tip already has the target `appVersion`, it exits successfully as already synced. Step summary messaging uses an **`OUTCOME`** (`committed` / `already` / failure with manual fix instructions), and the job still fails after three failed pushes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27710e185e59a01a50e9cc6de9790e9a97567f9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->