### PR TITLE
fix(gateway): hold admission open for endpoint propagation before the preStop drain (FB-4108)

### DIFF
--- a/docs/instance/gateway/gateway-query-routing.mdx
+++ b/docs/instance/gateway/gateway-query-routing.mdx
@@ -53,4 +53,8 @@ During an Engine cutover or scale-down:
 
 The zero-downtime contract applies to traffic through the Gateway and to request bodies within the 2 MiB retry limit. Traffic that bypasses the Gateway is unsupported and receives none of these guarantees.
 
+## Graceful Gateway shutdown
+
+When a Gateway pod is replaced or scaled down, it fails its readiness check first and keeps accepting connections for a few seconds while the Service stops routing to it. It then stops accepting new connections, lets in-flight requests finish, and exits once no client connection remains or the 15-second termination window expires. A client connection that is idle at that point is closed by the pod's termination rather than by the drain.
+
 See [Engine rollouts](../../engine/engine-rollouts) for drain controls and [Gateway sizing](./gateway-sizing) for memory and concurrency planning.

--- a/internal/controller/gateway_shutdown.go
+++ b/internal/controller/gateway_shutdown.go
@@ -21,14 +21,24 @@ import (
 	"strings"
 )
 
-// gatewayPreStopScript closes public query admission before observing drained
-// connections. Returning lets kubelet send SIGTERM; a drained Envoy does not
-// exit on its own. Admin failures retain the process until the Pod deadline.
-// The image already supplies bash, cat and grep, so no extra client is needed.
+// gatewayPreStopScript fails the health check, holds admission open for
+// propagationSeconds while the Service stops routing to this Pod, then drains
+// the query listener and returns once no downstream connection is left.
+// Returning lets kubelet send SIGTERM; a drained Envoy does not exit on its
+// own. Admin failures retain the process until the Pod deadline. The image
+// already supplies bash, cat, grep and sleep, so no extra client is needed.
+//
+// The propagation floor is load-bearing: the EndpointSlice
+// controller and kube-proxy need on the order of a second to stop sending new
+// connections to a terminating Pod, and the drain below stops the INBOUND
+// listener as soon as it completes. Draining first, as an earlier version of
+// this hook did, refused or black-holed every connection that arrived in that
+// window. A Pod with no open connections would otherwise exit within
+// milliseconds of preStop starting.
 //
 // The script keys on gatewayQueryListenerName / gatewayQueryStatPrefix so it
 // cannot drift from the rendered envoy.yaml; the render test pins both.
-func gatewayPreStopScript(adminPort int32) string {
+func gatewayPreStopScript(adminPort int32, propagationSeconds int) string {
 	statGauge := fmt.Sprintf("http.%s.downstream_cx_active", gatewayQueryStatPrefix)
 	statGaugeRe := strings.ReplaceAll(statGauge, ".", "[.]")
 	return fmt.Sprintf(`set -u
@@ -44,6 +54,9 @@ admin() {
   printf '%%s\n' "$response"
 }
 until admin POST /healthcheck/fail >/dev/null; do sleep 0.1; done
+# Readiness is now failing. Keep accepting until the Service has stopped
+# routing here; only then close admission. See the propagation note above.
+sleep %[5]d
 # graceful: in-flight requests finish and their connections close right after
 # (drain-time-s is 0). The drain's completion also stops the INBOUND-marked
 # listeners, so the query socket refuses new connections while the stats
@@ -67,5 +80,5 @@ while true; do
   fi
   sleep 0.1
 done
-`, adminPort, statGaugeRe, statGauge, gatewayQueryListenerName)
+`, adminPort, statGaugeRe, statGauge, gatewayQueryListenerName, propagationSeconds)
 }

--- a/internal/controller/gateway_shutdown_test.go
+++ b/internal/controller/gateway_shutdown_test.go
@@ -28,6 +28,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -162,7 +163,7 @@ func runGatewayShutdownAdminSequence(t *testing.T, steps []gatewayShutdownAdminR
 		}
 	}))
 	port := int32(server.Listener.Addr().(*net.TCPAddr).Port)
-	cmd := exec.CommandContext(ctx, bash, "-c", gatewayPreStopScript(port))
+	cmd := exec.CommandContext(ctx, bash, "-c", gatewayPreStopScript(port, 0))
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	// Cancel the process group so a failed assertion cannot leave cat or sleep
 	// children holding the admin connection or the output pipes open.
@@ -244,7 +245,7 @@ func TestGatewayPreStopRetainsProcessWhenAdminNeverHealthy(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "bash", "-c", gatewayPreStopScript(port))
+	cmd := exec.CommandContext(ctx, "bash", "-c", gatewayPreStopScript(port, 0))
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = func() error {
 		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
@@ -262,5 +263,64 @@ func TestGatewayPreStopRetainsProcessWhenAdminNeverHealthy(t *testing.T) {
 	}
 	if err == nil {
 		t.Fatal("hook reported success after being killed at the deadline")
+	}
+}
+
+// The hold between failing readiness and draining is load-bearing: the
+// Service must stop routing to this Pod before admission closes,
+// or connections still arriving are refused. Pins that the drain request
+// cannot reach the admin API before the propagation floor has elapsed, and
+// that the hook still exits once the gauge reads zero.
+func TestGatewayPreStopHoldsAdmissionForPropagationFloor(t *testing.T) {
+	t.Parallel()
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("gateway pre-stop protocol test requires bash")
+	}
+	const floorSeconds = 1
+
+	var mu sync.Mutex
+	var failedAt, drainedAt time.Time
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		switch r.URL.Path {
+		case "/healthcheck/fail":
+			failedAt = time.Now()
+			_, _ = fmt.Fprint(w, "OK\n")
+		case "/drain_listeners":
+			drainedAt = time.Now()
+			_, _ = fmt.Fprint(w, "OK\n")
+		case "/stats":
+			_, _ = fmt.Fprintf(w, "http.%s.downstream_cx_active: 0\n", gatewayQueryStatPrefix)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	port := int32(server.Listener.Addr().(*net.TCPAddr).Port)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bash, "-c", gatewayPreStopScript(port, floorSeconds))
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("hook did not exit cleanly once the gauge read zero: %v\n%s", err, out)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if failedAt.IsZero() || drainedAt.IsZero() {
+		t.Fatalf("hook skipped a step: healthcheck/fail at %v, drain at %v", failedAt, drainedAt)
+	}
+	if held := drainedAt.Sub(failedAt); held < floorSeconds*time.Second {
+		t.Fatalf("drain requested %v after readiness failed; admission must stay open for at least %ds so the Service stops routing here first", held, floorSeconds)
 	}
 }

--- a/internal/controller/instance_gateway.go
+++ b/internal/controller/instance_gateway.go
@@ -110,6 +110,16 @@ const (
 	// wake-agent's preStop sleep both derive from it.
 	gatewayTerminationGraceSeconds int64 = 15
 
+	// gatewayPreStopPropagationSeconds is how long the envoy preStop keeps
+	// accepting connections after failing its health check, before it drains
+	// the query listener. It covers the EndpointSlice and kube-proxy lag
+	// between a Pod entering termination and the Service ceasing to route to
+	// it; connections arriving in that lag would otherwise be refused.
+	// A few seconds is ample for that lag and leaves most of the termination
+	// grace for the drain itself. Must stay well below
+	// gatewayTerminationGraceSeconds.
+	gatewayPreStopPropagationSeconds = 5
+
 	// gatewayWakeAgentDrainSeconds keeps the agent alive while Envoy's
 	// preStop drains connections so held requests are not reset on rollout.
 	// Envoy's drain may run up to the Pod termination grace period, so the
@@ -2028,7 +2038,7 @@ func effectiveGatewayPodTemplate(
 		Lifecycle: &corev1.Lifecycle{
 			PreStop: &corev1.LifecycleHandler{
 				Exec: &corev1.ExecAction{
-					Command: []string{"bash", "-c", gatewayPreStopScript(gatewayAdminPort)},
+					Command: []string{"bash", "-c", gatewayPreStopScript(gatewayAdminPort, gatewayPreStopPropagationSeconds)},
 				},
 			},
 		},

--- a/internal/controller/instance_gateway_test.go
+++ b/internal/controller/instance_gateway_test.go
@@ -1591,8 +1591,16 @@ func TestGatewayEnvoyPreStopDrain(t *testing.T) {
 			t.Errorf("preStop command %q does not contain %q", script, want)
 		}
 	}
-	if strings.Contains(script, "sleep 8") {
-		t.Errorf("preStop command %q uses a fixed sleep instead of observing the drain", script)
+	// Ordering is the contract: fail readiness, hold admission open
+	// for the propagation floor, then drain. Draining before the floor refuses
+	// connections the Service is still sending here.
+	floor := fmt.Sprintf("\nsleep %d\n", gatewayPreStopPropagationSeconds)
+	failAt, floorAt, drainAt := strings.Index(script, "/healthcheck/fail"), strings.Index(script, floor), strings.Index(script, "drain_listeners?inboundonly&graceful")
+	if floorAt < 0 || failAt >= floorAt || floorAt >= drainAt {
+		t.Errorf("preStop command %q must fail health, then sleep %d s, then drain (indexes fail=%d floor=%d drain=%d)", script, gatewayPreStopPropagationSeconds, failAt, floorAt, drainAt)
+	}
+	if int64(gatewayPreStopPropagationSeconds)*2 > gatewayTerminationGraceSeconds {
+		t.Errorf("propagation floor %d s leaves under half of the %d s termination grace for the drain", gatewayPreStopPropagationSeconds, gatewayTerminationGraceSeconds)
 	}
 	if strings.Contains(script, "&skip_exit") {
 		t.Error("preStop drain must not pass skip_exit: it suppresses the INBOUND listener stop")


### PR DESCRIPTION
**Background**

#247 replaced the gateway's fixed preStop sleep with an admin-API drain. The drain stops the query listener as soon as it completes, so a pod with no open connections closes its port within milliseconds of entering termination. Kubernetes still routes new connections to a terminating pod for about a second, and those connections were refused or timed out. The E2E spec "Gateway scaling should cause zero query failures" caught it on unrelated PRs (#253 and a dependabot bump) with connect-phase curl errors right after the scale-down step.

**Summary**

- The hook now fails the health check, keeps accepting for a fixed 5 s propagation floor, then drains and exits once no downstream connection is left. The floor leaves ten of the fifteen-second termination grace for the drain.
- The render test pins the order (fail, hold, drain) and that the floor stays under half the grace.
- New protocol test runs the real script against a fake admin API and asserts the drain request cannot arrive before the floor has elapsed.
- Short "Graceful Gateway shutdown" section added to the query-routing docs.

**Test Plan**

- Unit: the four preStop tests plus the gateway render tests pass; ordering and floor headroom are pinned.
- E2E: the gateway scaling spec is the regression test and runs on this PR on both image variants.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gateway pod shutdown timing on every rollout/scale-down; mis-tuned propagation vs grace could shorten drains, but behavior is heavily tested and scoped to preStop ordering.
> 
> **Overview**
> Fixes **gateway scale-down connect failures** by changing the Envoy **preStop** sequence: fail readiness, **hold query admission open for 5 seconds** (`gatewayPreStopPropagationSeconds`) so EndpointSlice/kube-proxy can stop routing here, **then** drain inbound listeners and exit when active downstream connections hit zero.
> 
> Previously draining immediately closed the query socket while Kubernetes could still send new connections for ~1s, causing refused connections and E2E “zero query failures” regressions.
> 
> Tests pin **fail → sleep → drain** ordering, propagation floor vs the 15s termination grace, and a protocol test that drain cannot run before the floor. Docs add a **Graceful Gateway shutdown** section describing the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d4ab2ee3feabd5a4d35afd9217787bcce6e6ed6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->